### PR TITLE
feat: coroutine mode support — $g injection, HaltException, Redis sessions

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1581,8 +1581,11 @@ class App
     {
         ob_start();
         try {
+            $args['g'] = RequestContext::instance();
             extract($args, EXTR_SKIP);
             $result = include $absPath;
+        } catch (HaltException $e) {
+            // Clean halt (redirect, exit) — capture buffered output and return
         } catch (\Throwable $e) {
             @ob_end_clean();
             throw $e;

--- a/src/App.php
+++ b/src/App.php
@@ -1580,6 +1580,7 @@ class App
     private static function executeFile(string $absPath, array $args): mixed
     {
         ob_start();
+        $result = null;
         try {
             $args['g'] = RequestContext::instance();
             extract($args, EXTR_SKIP);

--- a/src/HaltException.php
+++ b/src/HaltException.php
@@ -1,0 +1,13 @@
+<?php
+namespace ZealPHP;
+
+/**
+ * Thrown to cleanly halt page execution without killing the worker process.
+ *
+ * In traditional PHP (Apache mod_php), exit/die terminates the request process.
+ * Under ZealPHP/OpenSwoole, exit/die would kill the entire worker. Code that
+ * previously used exit (e.g. after a redirect header) should throw HaltException
+ * instead. App::executeFile() catches it and treats it as a normal return —
+ * any output buffered before the halt is still captured and sent.
+ */
+class HaltException extends \Exception {}

--- a/src/Session/Handler/RedisSessionHandler.php
+++ b/src/Session/Handler/RedisSessionHandler.php
@@ -35,7 +35,7 @@ class RedisSessionHandler implements \SessionHandlerInterface
     public function read($sessionId): string
     {
         $data = $this->redis->get($this->prefix . $sessionId);
-        return $data === false ? '' : $data;
+        return is_string($data) ? $data : '';
     }
 
     public function write($sessionId, $sessionData): bool

--- a/src/Session/Handler/RedisSessionHandler.php
+++ b/src/Session/Handler/RedisSessionHandler.php
@@ -1,0 +1,61 @@
+<?php
+namespace ZealPHP\Session\Handler;
+
+/**
+ * Redis-backed session handler for ZealPHP.
+ *
+ * Reads/writes session data using the same key format as PHP's phpredis
+ * session handler (PHPREDIS_SESSION:{session_id}), so sessions created
+ * by Apache/mod_php are readable by ZealPHP and vice versa.
+ */
+class RedisSessionHandler implements \SessionHandlerInterface
+{
+    private \Redis $redis;
+    private string $prefix;
+    private int $ttl;
+
+    public function __construct(string $host = '127.0.0.1', int $port = 6379, string $prefix = 'PHPREDIS_SESSION:', int $ttl = 1440)
+    {
+        $this->prefix = $prefix;
+        $this->ttl = $ttl;
+        $this->redis = new \Redis();
+        $this->redis->connect($host, $port);
+    }
+
+    public function open($savePath, $sessionName): bool
+    {
+        return $this->redis->isConnected();
+    }
+
+    public function close(): bool
+    {
+        return true;
+    }
+
+    public function read($sessionId): string
+    {
+        $data = $this->redis->get($this->prefix . $sessionId);
+        return $data === false ? '' : $data;
+    }
+
+    public function write($sessionId, $sessionData): bool
+    {
+        return $this->redis->setex($this->prefix . $sessionId, $this->ttl, $sessionData);
+    }
+
+    public function destroy($sessionId): bool
+    {
+        $this->redis->del($this->prefix . $sessionId);
+        return true;
+    }
+
+    public function gc($maxlifetime): int|false
+    {
+        return 0;
+    }
+
+    public function getRedis(): \Redis
+    {
+        return $this->redis;
+    }
+}

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -13,7 +13,14 @@ function php_session_decode_to_array(string $data): array
 {
     $decoded = @unserialize($data, ['allowed_classes' => true]);
     if (is_array($decoded)) {
-        return $decoded;
+        /** @var array<string, mixed> $narrowed */
+        $narrowed = [];
+        foreach ($decoded as $k => $v) {
+            if (is_string($k)) {
+                $narrowed[$k] = $v;
+            }
+        }
+        return $narrowed;
     }
     $result = [];
     $offset = 0;
@@ -98,7 +105,7 @@ function zeal_session_start(): bool
 
     if ($handler instanceof \SessionHandlerInterface) {
         /** @var string $sessionName */
-        $sessionName = $g->session_params['name'] ?? 'PHPSESSID';
+        $sessionName = $g->session_params['name'];
         $handler->open($save_path, (string) $sessionName);
         $contents = $handler->read((string) $session_id);
         if (is_string($contents) && $contents !== '') {

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -4,6 +4,41 @@ namespace ZealPHP\Session;
 use ZealPHP\RequestContext;
 
 /**
+ * Decode PHP 'php' session serialize format (key|serialized_value;key|...).
+ * Falls back to unserialize() for php_serialize handler format.
+ */
+function php_session_decode_to_array(string $data): array
+{
+    $decoded = @unserialize($data, ['allowed_classes' => true]);
+    if (is_array($decoded)) {
+        return $decoded;
+    }
+    $result = [];
+    $offset = 0;
+    $len = strlen($data);
+    while ($offset < $len) {
+        $pipe = strpos($data, '|', $offset);
+        if ($pipe === false) break;
+        $key = substr($data, $offset, $pipe - $offset);
+        $offset = $pipe + 1;
+        $value = @unserialize(substr($data, $offset), ['allowed_classes' => true]);
+        if ($value === false && substr($data, $offset, 4) !== 'b:0;') {
+            $next = strpos($data, ';', $offset);
+            if ($next !== false) {
+                $offset = $next + 1;
+            } else {
+                break;
+            }
+        } else {
+            $serialized = serialize($value);
+            $offset += strlen($serialized);
+            $result[$key] = $value;
+        }
+    }
+    return $result;
+}
+
+/**
  * Start a new session or resume existing one
  */
 function zeal_session_start(): bool
@@ -41,36 +76,36 @@ function zeal_session_start(): bool
     static $verified_paths = [];
     $rawSavePath = $g->session_params['save_path'];
     $save_path = is_string($rawSavePath) ? $rawSavePath : '';
-    if (!isset($verified_paths[$save_path])) {
-        if (!is_dir($save_path)) {
-            mkdir($save_path, 0700, true);
+
+    $handler = $g->session_params['handler'] ?? null;
+
+    if (!($handler instanceof \SessionHandlerInterface)) {
+        if (!isset($verified_paths[$save_path])) {
+            if (!is_dir($save_path)) {
+                mkdir($save_path, 0700, true);
+            }
+            $verified_paths[$save_path] = true;
         }
-        $verified_paths[$save_path] = true;
     }
 
     // Get session ID from cookie or generate a new one
     $session_id = zeal_session_id();
 
-    // Read session data from file. Defensive against three failure modes that
-    // would otherwise crash the worker (TypeError: cannot assign false to
-    // typed array property):
-    //   1. Empty file — unserialize('') returns false
-    //   2. Corrupted / truncated file (interrupted write) — unserialize returns false
-    //   3. TOCTOU race: file_exists returned true but file_get_contents fails
-    // All three reduce to "treat as no session data" rather than crashing.
     /** @var array<string, mixed> $session_data */
     $session_data = [];
-    $session_file = $save_path . '/sess_' . $session_id;
-    if (file_exists($session_file)) {
-        $contents = @file_get_contents($session_file);
+
+    if ($handler instanceof \SessionHandlerInterface) {
+        $handler->open($save_path, $g->session_params['name'] ?? 'PHPSESSID');
+        $contents = $handler->read($session_id);
         if (is_string($contents) && $contents !== '') {
-            $decoded = @unserialize($contents, ['allowed_classes' => false]);
-            if (is_array($decoded)) {
-                foreach ($decoded as $k => $v) {
-                    if (is_string($k)) {
-                        $session_data[$k] = $v;
-                    }
-                }
+            $session_data = php_session_decode_to_array($contents);
+        }
+    } else {
+        $session_file = $save_path . '/sess_' . $session_id;
+        if (file_exists($session_file)) {
+            $contents = @file_get_contents($session_file);
+            if (is_string($contents) && $contents !== '') {
+                $session_data = php_session_decode_to_array($contents);
             }
         }
     }
@@ -310,10 +345,18 @@ function zeal_session_get_cookie_params(): array
  * @param bool   $secure
  * @param bool   $httponly
  */
-function zeal_session_set_cookie_params($lifetime, $path = '/', $domain = '', $secure = false, $httponly = false): void
+function zeal_session_set_cookie_params($lifetime_or_options, $path = '/', $domain = '', $secure = false, $httponly = false): void
 {
     $g = RequestContext::instance();
-    $g->session_params['cookie_params'] = compact('lifetime', 'path', 'domain', 'secure', 'httponly');
+    if (is_array($lifetime_or_options)) {
+        $g->session_params['cookie_params'] = array_merge([
+            'lifetime' => 0, 'path' => '/', 'domain' => '',
+            'secure' => false, 'httponly' => false, 'samesite' => 'Lax',
+        ], $lifetime_or_options);
+    } else {
+        $g->session_params['cookie_params'] = compact('path', 'domain', 'secure', 'httponly');
+        $g->session_params['cookie_params']['lifetime'] = $lifetime_or_options;
+    }
 }
 
 /**

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -7,11 +7,19 @@ use ZealPHP\RequestContext;
  * Decode PHP 'php' session serialize format (key|serialized_value;key|...).
  * Falls back to unserialize() for php_serialize handler format.
  *
+ * SECURITY: both unserialize() calls pass allowed_classes => false to keep
+ * the object-injection hardening that commit c43da63 introduced. Sessions
+ * are user-controlled storage (tampered cookie, compromised Redis); allowing
+ * arbitrary class instantiation here would let an attacker trigger
+ * __wakeup() / __destruct() gadgets in any class in the autoload graph.
+ * If a future caller genuinely needs to round-trip objects through sessions,
+ * that's a separate feature with an explicit class whitelist, not a global flip.
+ *
  * @return array<string, mixed>
  */
 function php_session_decode_to_array(string $data): array
 {
-    $decoded = @unserialize($data, ['allowed_classes' => true]);
+    $decoded = @unserialize($data, ['allowed_classes' => false]);
     if (is_array($decoded)) {
         /** @var array<string, mixed> $narrowed */
         $narrowed = [];
@@ -30,7 +38,7 @@ function php_session_decode_to_array(string $data): array
         if ($pipe === false) break;
         $key = substr($data, $offset, $pipe - $offset);
         $offset = $pipe + 1;
-        $value = @unserialize(substr($data, $offset), ['allowed_classes' => true]);
+        $value = @unserialize(substr($data, $offset), ['allowed_classes' => false]);
         if ($value === false && substr($data, $offset, 4) !== 'b:0;') {
             $next = strpos($data, ';', $offset);
             if ($next !== false) {

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -6,6 +6,8 @@ use ZealPHP\RequestContext;
 /**
  * Decode PHP 'php' session serialize format (key|serialized_value;key|...).
  * Falls back to unserialize() for php_serialize handler format.
+ *
+ * @return array<string, mixed>
  */
 function php_session_decode_to_array(string $data): array
 {
@@ -95,8 +97,10 @@ function zeal_session_start(): bool
     $session_data = [];
 
     if ($handler instanceof \SessionHandlerInterface) {
-        $handler->open($save_path, $g->session_params['name'] ?? 'PHPSESSID');
-        $contents = $handler->read($session_id);
+        /** @var string $sessionName */
+        $sessionName = $g->session_params['name'] ?? 'PHPSESSID';
+        $handler->open($save_path, (string) $sessionName);
+        $contents = $handler->read((string) $session_id);
         if (is_string($contents) && $contents !== '') {
             $session_data = php_session_decode_to_array($contents);
         }
@@ -115,6 +119,7 @@ function zeal_session_start(): bool
     // $_SESSION would never round-trip through $g->session. Mirror to both:
     // $_SESSION is what user/Symfony code reads/writes, $g->session is what
     // coroutine-mode code reads/writes via the typed property.
+    /** @var array<string, mixed> $session_data */
     $g->session = $session_data;
     if (\ZealPHP\App::$superglobals) {
         $GLOBALS['_SESSION'] = $session_data;
@@ -337,9 +342,10 @@ function zeal_session_get_cookie_params(): array
 }
 
 /**
- * Set session cookie parameters
+ * Set session cookie parameters. Accepts either positional args (PHP < 8.0)
+ * or an options array (PHP 8.0+).
  *
- * @param int    $lifetime
+ * @param int|array<string, mixed> $lifetime_or_options
  * @param string $path
  * @param string $domain
  * @param bool   $secure

--- a/src/ZealAPI.php
+++ b/src/ZealAPI.php
@@ -235,10 +235,14 @@ class ZealAPI extends REST
         }
     }
 
-    // public function isAuthenticated()
-    // {
-    //     return Session::$authStatus == Constants::STATUS_LOGGEDIN ;
-    // }
+    /**
+     * Override in your application's API base class to provide auth checking.
+     * Default returns false (no session integration).
+     */
+    public function isAuthenticated(): bool
+    {
+        return false;
+    }
 
     /**
      * Checks if all supplied parameters exists
@@ -258,20 +262,33 @@ class ZealAPI extends REST
         return $exists;
     }
 
-    // public function isAuthenticatedFor(User $user)
-    // {
-    //     return Session::getUser()->getEmail() == $user->getEmail();
-    // }
+    /**
+     * Override in your application's API base class.
+     */
+    public function isAdmin(): bool
+    {
+        return false;
+    }
 
-    // public function isAdmin()
-    // {
-    //     return Session::isAdmin();
-    // }
+    /**
+     * Override in your application's API base class.
+     */
+    public function getUsername(): ?string
+    {
+        return null;
+    }
 
-    // public function getUsername()
-    // {
-    //     return Session::getUser()->getUsername();
-    // }
+    /**
+     * POST + authenticated guard. Returns false and sends 403 if check fails.
+     */
+    public function requirePostAuth(): bool
+    {
+        if ($this->get_request_method() !== "POST" || !$this->isAuthenticated()) {
+            $this->response($this->json(["error" => "Unauthorized"]), 403);
+            return false;
+        }
+        return true;
+    }
 
     /**
      * @param \Throwable $e

--- a/tests/Unit/HaltExceptionTest.php
+++ b/tests/Unit/HaltExceptionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\Tests\TestCase;
+use ZealPHP\HaltException;
+
+/**
+ * Unit tests for ZealPHP\HaltException — the exit() / die() replacement that
+ * lets a page halt cleanly without killing the OpenSwoole worker.
+ *
+ * The class is intentionally tiny — verify the contract surface only:
+ *   - it's an Exception subclass (so catch (\Throwable) and catch (\Exception)
+ *     blocks in user code still catch it as expected)
+ *   - construction with and without a message works
+ *   - it can be thrown and caught as itself, as \Exception, and as \Throwable
+ *
+ * The cross-cutting behaviour (App::executeFile() catching it and returning
+ * the captured output buffer) is the responsibility of FileExecutionContractTest
+ * — this class only owns the type-shape contract.
+ */
+class HaltExceptionTest extends TestCase
+{
+    public function testIsAnException(): void
+    {
+        $this->assertInstanceOf(\Exception::class, new HaltException());
+        $this->assertInstanceOf(\Throwable::class, new HaltException());
+    }
+
+    public function testDefaultConstructorHasEmptyMessage(): void
+    {
+        $e = new HaltException();
+        $this->assertSame('', $e->getMessage());
+        $this->assertSame(0, $e->getCode());
+    }
+
+    public function testConstructorMessageAndCodeAreStored(): void
+    {
+        $e = new HaltException('redirect handoff', 302);
+        $this->assertSame('redirect handoff', $e->getMessage());
+        $this->assertSame(302, $e->getCode());
+    }
+
+    public function testCatchAsHaltException(): void
+    {
+        try {
+            throw new HaltException('stop here');
+        } catch (HaltException $caught) {
+            $this->assertSame('stop here', $caught->getMessage());
+            return;
+        }
+        $this->fail('HaltException was not caught as itself');
+    }
+
+    public function testCatchAsGenericException(): void
+    {
+        try {
+            throw new HaltException('stop here');
+        } catch (\Exception $caught) {
+            $this->assertInstanceOf(HaltException::class, $caught);
+            return;
+        }
+        $this->fail('HaltException was not caught as \Exception');
+    }
+
+    public function testCatchAsThrowable(): void
+    {
+        try {
+            throw new HaltException();
+        } catch (\Throwable $caught) {
+            $this->assertInstanceOf(HaltException::class, $caught);
+            return;
+        }
+        $this->fail('HaltException was not caught as \Throwable');
+    }
+
+    public function testWrappingPreviousException(): void
+    {
+        $prev = new \RuntimeException('upstream');
+        $e    = new HaltException('halted by upstream', 0, $prev);
+        $this->assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Unit/PhpSessionDecodeTest.php
+++ b/tests/Unit/PhpSessionDecodeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\Tests\TestCase;
+
+use function ZealPHP\Session\php_session_decode_to_array;
+
+/**
+ * Unit tests for ZealPHP\Session\php_session_decode_to_array().
+ *
+ * The function decodes two session-handler wire formats:
+ *   - `php_serialize` handler  → top-level serialize() of an array (a:N:{...})
+ *   - `php` handler (default)  → custom `key|<serialized_value>;key|...` format
+ *
+ * SECURITY contract: both unserialize() calls must pass
+ * `['allowed_classes' => false]` — sessions are user-controlled storage, and
+ * allowing arbitrary class instantiation would re-introduce the PHP
+ * object-injection vector that commit c43da63 closed.
+ */
+class PhpSessionDecodeTest extends TestCase
+{
+    // ──────────────────────────────────────────────────────────────
+    // php_serialize handler format — top-level serialize() of an array
+    // ──────────────────────────────────────────────────────────────
+
+    public function testPhpSerializeFormatBasicArray(): void
+    {
+        $original = ['user_id' => 42, 'name' => 'alice'];
+        $decoded  = php_session_decode_to_array(serialize($original));
+        $this->assertSame($original, $decoded);
+    }
+
+    public function testPhpSerializeFormatNestedArray(): void
+    {
+        $original = ['user' => ['id' => 42, 'roles' => ['admin', 'editor']]];
+        $decoded  = php_session_decode_to_array(serialize($original));
+        $this->assertSame($original, $decoded);
+    }
+
+    public function testPhpSerializeFormatMixedScalars(): void
+    {
+        $original = ['int' => 1, 'float' => 1.5, 'bool' => true, 'null' => null, 'string' => 'hi'];
+        $decoded  = php_session_decode_to_array(serialize($original));
+        $this->assertSame($original, $decoded);
+    }
+
+    public function testNonStringKeysDropped(): void
+    {
+        // serialize() of array with int keys round-trips; the function narrows
+        // to <string,mixed> by skipping non-string keys.
+        $payload = serialize([0 => 'first', 1 => 'second', 'named' => 'third']);
+        $decoded = php_session_decode_to_array($payload);
+        $this->assertSame(['named' => 'third'], $decoded);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // php handler format — key|<serialized_value>;key|<serialized_value>;
+    // ──────────────────────────────────────────────────────────────
+
+    public function testPhpHandlerFormatBasicScalars(): void
+    {
+        // Manually constructed in PHP's native session-encode format
+        $payload = 'user_id|i:42;name|s:5:"alice";';
+        $decoded = php_session_decode_to_array($payload);
+        $this->assertSame(['user_id' => 42, 'name' => 'alice'], $decoded);
+    }
+
+    public function testPhpHandlerFormatBooleanFalseEdgeCase(): void
+    {
+        // unserialize('b:0;') returns false — the decoder has a special case
+        // for this to not confuse it with "unserialize failed".
+        $payload = 'flag|b:0;active|b:1;';
+        $decoded = php_session_decode_to_array($payload);
+        $this->assertSame(['flag' => false, 'active' => true], $decoded);
+    }
+
+    public function testPhpHandlerFormatNestedArray(): void
+    {
+        $value   = ['id' => 7, 'roles' => ['admin']];
+        $payload = 'user|' . serialize($value) . ';';
+        $decoded = php_session_decode_to_array($payload);
+        $this->assertSame(['user' => $value], $decoded);
+    }
+
+    public function testEmptyInputReturnsEmptyArray(): void
+    {
+        $this->assertSame([], php_session_decode_to_array(''));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // SECURITY — allowed_classes must be FALSE in both branches
+    // ──────────────────────────────────────────────────────────────
+
+    public function testObjectInPhpSerializeBranchIsRejected(): void
+    {
+        // A serialized object would normally instantiate when unserialized.
+        // With allowed_classes => false, PHP returns __PHP_Incomplete_Class —
+        // is_array() check then fails and the function falls through to the
+        // pipe-format parser, which finds no `|` and returns [].
+        $payload = serialize(new \stdClass());
+        $decoded = php_session_decode_to_array($payload);
+        // Either an empty array (fall-through to pipe parser which finds no |)
+        // OR a single-key array whose value is __PHP_Incomplete_Class. Neither
+        // is the original \stdClass — the security property is "no arbitrary
+        // class instantiation".
+        if ($decoded !== []) {
+            foreach ($decoded as $v) {
+                $this->assertNotInstanceOf(\stdClass::class, $v);
+                if (is_object($v)) {
+                    $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $v);
+                }
+            }
+        }
+        $this->assertTrue(true);
+    }
+
+    public function testObjectInPhpHandlerBranchIsRejected(): void
+    {
+        // Pipe-format with a serialized object as the value.
+        $payload = 'obj|' . serialize(new \stdClass()) . ';';
+        $decoded = php_session_decode_to_array($payload);
+        // The value, if present, must NOT be a live \stdClass instance.
+        if (isset($decoded['obj'])) {
+            $this->assertNotInstanceOf(\stdClass::class, $decoded['obj']);
+            if (is_object($decoded['obj'])) {
+                $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $decoded['obj']);
+            }
+        }
+        $this->assertTrue(true);
+    }
+
+    public function testMalformedDataDoesNotCrash(): void
+    {
+        // Garbage bytes — should not throw, just return [] or skip past the
+        // bad entries.
+        $payloads = [
+            'this is not a valid session string',
+            'key|garbage;key2|i:1;',
+            "\x00\x01\x02bin garbage",
+        ];
+        foreach ($payloads as $p) {
+            $decoded = php_session_decode_to_array($p);
+            $this->assertIsArray($decoded, "malformed payload caused non-array return: " . bin2hex(substr($p, 0, 8)));
+        }
+    }
+}

--- a/tests/Unit/RedisSessionHandlerTest.php
+++ b/tests/Unit/RedisSessionHandlerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\Tests\TestCase;
+use ZealPHP\Session\Handler\RedisSessionHandler;
+
+/**
+ * Unit tests for ZealPHP\Session\Handler\RedisSessionHandler.
+ *
+ * The class implements PHP's \SessionHandlerInterface against a Redis backend
+ * using the `PHPREDIS_SESSION:{id}` key format (phpredis-compatible). Tests
+ * split into two sets:
+ *
+ *  1. Class-shape contract tests — verify the type satisfies the
+ *     SessionHandlerInterface API even without ext-redis loaded. These
+ *     guard against accidental signature drift.
+ *
+ *  2. Connected behaviour tests — skipped automatically when ext-redis is
+ *     absent OR when no Redis is reachable at 127.0.0.1:6379. These cover
+ *     read/write/destroy round-trips against a live instance.
+ *
+ * Production deployments should run the connected set as part of an
+ * integration job that boots Redis as a docker service.
+ */
+class RedisSessionHandlerTest extends TestCase
+{
+    // ──────────────────────────────────────────────────────────────
+    // Class-shape contract — no ext-redis required
+    // ──────────────────────────────────────────────────────────────
+
+    public function testClassExists(): void
+    {
+        $this->assertTrue(class_exists(RedisSessionHandler::class));
+    }
+
+    public function testImplementsSessionHandlerInterface(): void
+    {
+        $this->assertTrue(
+            is_subclass_of(RedisSessionHandler::class, \SessionHandlerInterface::class)
+        );
+    }
+
+    public function testExposesAllSessionHandlerInterfaceMethods(): void
+    {
+        $required = ['open', 'close', 'read', 'write', 'destroy', 'gc'];
+        foreach ($required as $method) {
+            $this->assertTrue(
+                method_exists(RedisSessionHandler::class, $method),
+                "RedisSessionHandler is missing required method: $method"
+            );
+        }
+    }
+
+    public function testHasGetRedisAccessor(): void
+    {
+        $this->assertTrue(
+            method_exists(RedisSessionHandler::class, 'getRedis'),
+            'getRedis() accessor is part of the documented surface'
+        );
+    }
+
+    public function testConstructorSignatureAcceptsDefaults(): void
+    {
+        // Verify the constructor's parameter list — pure reflection, no
+        // instantiation needed (which would trigger Redis connect()).
+        $ref = new \ReflectionMethod(RedisSessionHandler::class, '__construct');
+        $params = $ref->getParameters();
+        $this->assertCount(4, $params, 'constructor should take host, port, prefix, ttl');
+        $names = array_map(static fn(\ReflectionParameter $p): string => $p->getName(), $params);
+        $this->assertSame(['host', 'port', 'prefix', 'ttl'], $names);
+        foreach ($params as $p) {
+            $this->assertTrue($p->isDefaultValueAvailable(), "{$p->getName()} should have a default");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Connected behaviour — skipped unless Redis is reachable
+    // ──────────────────────────────────────────────────────────────
+
+    private function skipIfNoRedis(): RedisSessionHandler
+    {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('ext-redis not loaded — connected tests skipped.');
+        }
+        try {
+            $h = new RedisSessionHandler('127.0.0.1', 6379, 'PHPREDIS_SESSION_TEST:', 60);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('Redis not reachable at 127.0.0.1:6379 — connected tests skipped: ' . $e->getMessage());
+        }
+        return $h;
+    }
+
+    public function testOpenReturnsTrueOnConnected(): void
+    {
+        $h = $this->skipIfNoRedis();
+        $this->assertTrue($h->open('', 'PHPSESSID'));
+        $h->close();
+    }
+
+    public function testReadOnMissingKeyReturnsEmptyString(): void
+    {
+        $h = $this->skipIfNoRedis();
+        $h->open('', 'PHPSESSID');
+        $sid = 'test_' . bin2hex(random_bytes(8));
+        $this->assertSame('', $h->read($sid));
+        $h->close();
+    }
+
+    public function testWriteThenReadRoundTrip(): void
+    {
+        $h = $this->skipIfNoRedis();
+        $h->open('', 'PHPSESSID');
+        $sid     = 'test_' . bin2hex(random_bytes(8));
+        $payload = 'user_id|i:42;name|s:5:"alice";';
+        $this->assertTrue($h->write($sid, $payload));
+        $this->assertSame($payload, $h->read($sid));
+        $h->destroy($sid);
+        $h->close();
+    }
+
+    public function testDestroyRemovesKey(): void
+    {
+        $h = $this->skipIfNoRedis();
+        $h->open('', 'PHPSESSID');
+        $sid = 'test_' . bin2hex(random_bytes(8));
+        $h->write($sid, 'tmp|i:1;');
+        $this->assertSame('tmp|i:1;', $h->read($sid));
+        $this->assertTrue($h->destroy($sid));
+        $this->assertSame('', $h->read($sid));
+        $h->close();
+    }
+
+    public function testKeyPrefixIsApplied(): void
+    {
+        $h = $this->skipIfNoRedis();
+        $h->open('', 'PHPSESSID');
+        $sid = 'test_' . bin2hex(random_bytes(8));
+        $h->write($sid, 'x|i:1;');
+        // Verify the underlying key includes the prefix — the whole point
+        // of the configurable prefix is phpredis compatibility.
+        $raw = $h->getRedis()->get('PHPREDIS_SESSION_TEST:' . $sid);
+        $this->assertSame('x|i:1;', $raw);
+        $h->destroy($sid);
+        $h->close();
+    }
+
+    public function testGcReturnsZero(): void
+    {
+        $h = $this->skipIfNoRedis();
+        $h->open('', 'PHPSESSID');
+        // Redis handles expiry via TTL — gc() is documented as a no-op.
+        $this->assertSame(0, $h->gc(0));
+        $h->close();
+    }
+}


### PR DESCRIPTION
## Summary
- **`$g` auto-injection** in `executeFile()` — all templates get `$g = RequestContext::instance()` in scope via `extract()`, enabling `$g->get`, `$g->server` etc. without boilerplate
- **`HaltException`** — clean halt for redirect/exit flows without killing the worker process (caught by `executeFile`, buffered output preserved)
- **`RedisSessionHandler`** — reads/writes sessions using `PHPREDIS_SESSION:{id}` key format, compatible with PHP's phpredis extension so Apache and ZealPHP share sessions
- **`php_session_decode_to_array()`** — decodes PHP's default `php` session serialize format (`key|serialized_value;`)
- **`zeal_session_set_cookie_params()`** — accepts PHP 8.0+ array argument form
- **`ZealAPI`** auth methods — `isAuthenticated()`, `isAdmin()`, `getUsername()`, `requirePostAuth()` as overridable stubs

## Context
These changes were developed during the labs-dashboard-web coroutine migration (210 files, 791 superglobal replacements, full in-process execution). All changes are backward compatible — existing superglobals(true) + CGI mode is unaffected.

## Test plan
- [ ] Existing ZealPHP test suite passes
- [ ] Template rendering works with `$g` in scope
- [ ] HaltException is caught cleanly (redirect headers preserved, no worker crash)
- [ ] RedisSessionHandler reads sessions written by phpredis and vice versa
- [ ] Array-form `session_set_cookie_params(['lifetime' => 0, ...])` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)