### PR TITLE
fix(app): void return discards buffered output

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1821,8 +1821,8 @@ class App
         }
 
         // PHP's `include` returns int(1) when the file has no explicit `return`.
-        // Treat as "no explicit return" — surface the buffered echo (or null).
-        if ($result === 1) {
+        // `return;` (void) yields null. Both should surface buffered output.
+        if ($result === 1 || ($result === null && $output !== '')) {
             return $output !== '' ? $output : null;
         }
 

--- a/tests/Unit/FileExecutionFamilyTest.php
+++ b/tests/Unit/FileExecutionFamilyTest.php
@@ -48,6 +48,11 @@ class FileExecutionFamilyTest extends TestCase
         $this->assertSame(['ok' => true, 'n' => 7], App::render('return_array', [], self::DIR));
     }
 
+    public function testVoidReturnSurfacesBufferedOutput(): void
+    {
+        $this->assertSame('hello-void', App::render('void_return', [], self::DIR));
+    }
+
     public function testEchoThenReturnConcatenatesInWireOrder(): void
     {
         $this->assertSame('SHELL-BODY', App::render('echo_and_return', [], self::DIR));

--- a/tests/fixtures/render/void_return.php
+++ b/tests/fixtures/render/void_return.php
@@ -1,0 +1,1 @@
+<?php echo "hello-void"; return;


### PR DESCRIPTION
## Summary

Fixes #20.

- `executeFile()` only treated `$result === 1` (no return statement) as "surface buffered echo output"
- A bare `return;` (void return) yields `null` from PHP's `include`, which fell through to the explicit-return branch and returned `null` — silently discarding all echoed HTML
- Now `$result === null && $output !== ''` is also treated as the no-explicit-return case, surfacing the buffer

## Real-world impact

Any PHP file that uses `echo`/HTML output followed by `return;` (common pattern in template files) would render as 0 bytes on ZealPHP. Confirmed fix on labs-dashboard-web clan pages (0 bytes → 102,295 bytes).

## Test plan

- [x] Added `tests/fixtures/render/void_return.php` — `<?php echo "hello-void"; return;`
- [x] Added `testVoidReturnSurfacesBufferedOutput` to `FileExecutionFamilyTest`
- [x] Verified fix in production: clan page renders correctly on ZealPHP

🤖 Generated with [Claude Code](https://claude.com/claude-code)