### PR TITLE
fix(session): write pipe-delimited format for cross-server parity

### DIFF
--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -657,23 +657,12 @@ function zeal_session_encode(): string
 
 function zeal_session_decode(string $data): bool
 {
-    // Defensive: unserialize() returns false on malformed input, which would
-    // TypeError on assignment to the typed array property. Match PHP native
-    // session_decode signature — returns bool, true only on successful decode.
     if ($data === '') {
         return false;
     }
-    $decoded = @unserialize($data, ['allowed_classes' => ['stdClass']]);
-    if (!is_array($decoded)) {
+    $sessionData = php_session_decode_to_array($data);
+    if ($sessionData === []) {
         return false;
-    }
-    // Narrow array<mixed,mixed> to array<string,mixed> for typed property assignment.
-    /** @var array<string, mixed> $sessionData */
-    $sessionData = [];
-    foreach ($decoded as $k => $v) {
-        if (is_string($k)) {
-            $sessionData[$k] = $v;
-        }
     }
     RequestContext::instance()->session = $sessionData;
     if (\ZealPHP\App::$superglobals) {

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -31,6 +31,22 @@ use ZealPHP\RequestContext;
  *
  * @return array<string, mixed>
  */
+/**
+ * Encode an array into PHP's native 'php' session serialize format
+ * (key|serialized_value for each key). This matches the format produced by
+ * session.serialize_handler = php (the default in mod_php / phpredis).
+ *
+ * @param array<string, mixed> $data
+ */
+function php_session_encode_from_array(array $data): string
+{
+    $encoded = '';
+    foreach ($data as $key => $value) {
+        $encoded .= $key . '|' . serialize($value);
+    }
+    return $encoded;
+}
+
 function php_session_decode_to_array(string $data): array
 {
     $decoded = @unserialize($data, ['allowed_classes' => ['stdClass']]);
@@ -350,9 +366,9 @@ function zeal_session_write_close(): bool
                     $data = $current;
                 }
             }
-            $wHandler->write((string) $session_id, serialize($data));
+            $wHandler->write((string) $session_id, php_session_encode_from_array($data));
         } else {
-            file_put_contents($session_file, serialize($data));
+            file_put_contents($session_file, php_session_encode_from_array($data));
         }
 
         // Mark inactive — in both modes. Unset the typed slot in coroutine
@@ -452,7 +468,7 @@ function zeal_session_regenerate_id($delete_old_session = false): bool
         /** @phpstan-ignore-next-line isset.property — runtime tests uninitialized typed slot */
         $data = $superglobals ? ($GLOBALS['_SESSION'] ?? []) : (isset($g->session) ? $g->session : []);
         $data = is_array($data) ? $data : [];
-        $handler->write((string) $new_session_id, serialize($data));
+        $handler->write((string) $new_session_id, php_session_encode_from_array($data));
         if ($delete_old_session && is_string($old_session_id) && $old_session_id !== '') {
             $handler->destroy((string) $old_session_id);
         }
@@ -626,12 +642,10 @@ function zeal_session_abort(): bool
 
 function zeal_session_encode(): string
 {
-    // In superglobals mode, $_SESSION is the canonical store (Symfony / legacy
-    // code writes here). In coroutine mode, the typed $g->session is.
     $data = \ZealPHP\App::$superglobals
         ? ($GLOBALS['_SESSION'] ?? [])
         : RequestContext::instance()->session;
-    return serialize($data);
+    return php_session_encode_from_array(is_array($data) ? $data : []);
 }
 
 function zeal_session_decode(string $data): bool

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -647,11 +647,12 @@ function zeal_session_abort(): bool
 
 function zeal_session_encode(): string
 {
-    /** @var array<string, mixed> $data */
     $data = \ZealPHP\App::$superglobals
         ? ($GLOBALS['_SESSION'] ?? [])
         : RequestContext::instance()->session;
-    return php_session_encode_from_array(is_array($data) ? $data : []);
+    /** @var array<string, mixed> $narrowed */
+    $narrowed = is_array($data) ? $data : [];
+    return php_session_encode_from_array($narrowed);
 }
 
 function zeal_session_decode(string $data): bool

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -471,8 +471,8 @@ function zeal_session_regenerate_id($delete_old_session = false): bool
         $superglobals = \ZealPHP\App::$superglobals;
         /** @phpstan-ignore-next-line isset.property — runtime tests uninitialized typed slot */
         $data = $superglobals ? ($GLOBALS['_SESSION'] ?? []) : (isset($g->session) ? $g->session : []);
-        /** @var array<string, mixed> $data */
         $data = is_array($data) ? $data : [];
+        /** @var array<string, mixed> $data */
         $handler->write((string) $new_session_id, php_session_encode_from_array($data));
         if ($delete_old_session && is_string($old_session_id) && $old_session_id !== '') {
             $handler->destroy((string) $old_session_id);

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -29,7 +29,6 @@ use ZealPHP\RequestContext;
  * gadget. `DateTime` for example has `__wakeup` and is therefore
  * deliberately excluded.
  *
- * @return array<string, mixed>
  */
 /**
  * Encode an array into PHP's native 'php' session serialize format
@@ -47,6 +46,9 @@ function php_session_encode_from_array(array $data): string
     return $encoded;
 }
 
+/**
+ * @return array<string, mixed>
+ */
 function php_session_decode_to_array(string $data): array
 {
     $decoded = @unserialize($data, ['allowed_classes' => ['stdClass']]);
@@ -366,8 +368,10 @@ function zeal_session_write_close(): bool
                     $data = $current;
                 }
             }
+            /** @var array<string, mixed> $data */
             $wHandler->write((string) $session_id, php_session_encode_from_array($data));
         } else {
+            /** @var array<string, mixed> $data */
             file_put_contents($session_file, php_session_encode_from_array($data));
         }
 
@@ -467,6 +471,7 @@ function zeal_session_regenerate_id($delete_old_session = false): bool
         $superglobals = \ZealPHP\App::$superglobals;
         /** @phpstan-ignore-next-line isset.property — runtime tests uninitialized typed slot */
         $data = $superglobals ? ($GLOBALS['_SESSION'] ?? []) : (isset($g->session) ? $g->session : []);
+        /** @var array<string, mixed> $data */
         $data = is_array($data) ? $data : [];
         $handler->write((string) $new_session_id, php_session_encode_from_array($data));
         if ($delete_old_session && is_string($old_session_id) && $old_session_id !== '') {
@@ -642,6 +647,7 @@ function zeal_session_abort(): bool
 
 function zeal_session_encode(): string
 {
+    /** @var array<string, mixed> $data */
     $data = \ZealPHP\App::$superglobals
         ? ($GLOBALS['_SESSION'] ?? [])
         : RequestContext::instance()->session;

--- a/tests/Unit/SessionRegenerateIdHandlerTest.php
+++ b/tests/Unit/SessionRegenerateIdHandlerTest.php
@@ -9,6 +9,7 @@ use ZealPHP\RequestContext;
 use ZealPHP\Tests\TestCase;
 
 use function ZealPHP\Session\zeal_session_regenerate_id;
+use function ZealPHP\Session\php_session_decode_to_array;
 
 /**
  * Regression test for issue #19 — session ID regeneration must be aware of a
@@ -131,7 +132,7 @@ class SessionRegenerateIdHandlerTest extends TestCase
         // @phpstan-ignore-next-line — fake handler exposes ->store
         $this->assertArrayHasKey($newId, $handler->store, 'new ID must be written to the handler');
         // @phpstan-ignore-next-line — fake handler exposes ->store
-        $migrated = unserialize($handler->store[$newId], ['allowed_classes' => false]);
+        $migrated = php_session_decode_to_array($handler->store[$newId]);
         $this->assertSame($this->authData, $migrated, 'auth fields must survive regeneration');
 
         // delete_old_session = true → old ID destroyed in the handler.
@@ -165,7 +166,7 @@ class SessionRegenerateIdHandlerTest extends TestCase
         $this->assertNotSame($this->oldId, $newId);
 
         // @phpstan-ignore-next-line — fake handler exposes ->store
-        $migrated = unserialize($handler->store[$newId], ['allowed_classes' => false]);
+        $migrated = php_session_decode_to_array($handler->store[$newId]);
         $this->assertSame($this->authData, $migrated);
 
         // delete_old_session = false → old ID NOT destroyed.

--- a/tests/Unit/SessionUtilsCoverageTest.php
+++ b/tests/Unit/SessionUtilsCoverageTest.php
@@ -10,6 +10,7 @@ use ZealPHP\Tests\TestCase;
 use function ZealPHP\Session\zeal_session_start;
 use function ZealPHP\Session\zeal_session_status;
 use function ZealPHP\Session\zeal_session_encode;
+use function ZealPHP\Session\php_session_decode_to_array;
 use function ZealPHP\Session\zeal_session_unset;
 use function ZealPHP\Session\zeal_session_abort;
 use function ZealPHP\Session\zeal_session_id;
@@ -199,7 +200,7 @@ class SessionUtilsCoverageTest extends TestCase
         $prop = new \ReflectionProperty(RequestContext::class, 'session');
         $prop->setValue($g, ['co' => 'data']);
         $encoded = zeal_session_encode();
-        $this->assertSame(['co' => 'data'], unserialize($encoded));
+        $this->assertSame(['co' => 'data'], php_session_decode_to_array($encoded));
     }
 
     public function testUnsetEmptiesSuperglobalSession(): void

--- a/tests/Unit/SessionUtilsTest.php
+++ b/tests/Unit/SessionUtilsTest.php
@@ -9,6 +9,7 @@ use ZealPHP\Tests\TestCase;
 
 use function ZealPHP\Session\zeal_session_encode;
 use function ZealPHP\Session\zeal_session_decode;
+use function ZealPHP\Session\php_session_decode_to_array;
 use function ZealPHP\Session\zeal_session_status;
 use function ZealPHP\Session\zeal_session_name;
 use function ZealPHP\Session\zeal_session_id;
@@ -99,7 +100,7 @@ class SessionUtilsTest extends TestCase
     {
         $GLOBALS['_SESSION'] = ['user_id' => 42, 'name' => 'alice'];
         $encoded = zeal_session_encode();
-        $this->assertSame(['user_id' => 42, 'name' => 'alice'], unserialize($encoded));
+        $this->assertSame(['user_id' => 42, 'name' => 'alice'], php_session_decode_to_array($encoded));
     }
 
     public function testDecodePopulatesBothStores(): void

--- a/tests/Unit/SessionUtilsTest.php
+++ b/tests/Unit/SessionUtilsTest.php
@@ -9,7 +9,6 @@ use ZealPHP\Tests\TestCase;
 
 use function ZealPHP\Session\zeal_session_encode;
 use function ZealPHP\Session\zeal_session_decode;
-use function ZealPHP\Session\php_session_decode_to_array;
 use function ZealPHP\Session\zeal_session_status;
 use function ZealPHP\Session\zeal_session_name;
 use function ZealPHP\Session\zeal_session_id;


### PR DESCRIPTION
## Summary
- ZealPHP was writing session data using `serialize($data)` which produces `php_serialize` format (`a:N:{...}`)
- Apache's default `session.serialize_handler` is `php`, which uses pipe-delimited format (`key|serialized_value`)
- This mismatch broke cross-server session sharing: sessions written by ZealPHP couldn't be read by Apache and vice versa
- Added `php_session_encode_from_array()` function and replaced `serialize()` at all 4 write points

## Test plan
- [ ] Login on ZealPHP, verify session in Redis uses pipe-delimited format
- [ ] Login on Apache, access ZealPHP with same cookie — session works
- [ ] Login on ZealPHP, access Apache with same cookie — session works
- [ ] Verify `whoami` API returns identical user on both servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)