### PR TITLE
fix: nonexistent .php URLs return 404 instead of 403 (Apache parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Nonexistent `.php` URLs now return 404, not 403** ([#25](https://github.com/sibidharan/zealphp/issues/25)). With `ignore_php_ext` on (default), the `*.php` catch-all returned a blanket `403 Forbidden` for every `.php` URL — telling clients "no permission" when the truth was "doesn't exist." It now checks the file on disk (under the document root): an existing `.php` blocked from direct access → **403**, a `.php` URL with no backing file → **404** (Apache parity).
+
 ### Added
 
 - **`ScopedMiddleware` (Apache `<Location>` / `<LocationMatch>` / `<FilesMatch>` parity)** — wrap any middleware so it applies only to matching request paths: `ScopedMiddleware::location($inner, '/admin')` (literal URL-path prefix) or `ScopedMiddleware::match($inner, '#^/api/#')` (PCRE). Out of scope the inner middleware is skipped and the request passes straight through; in scope it runs normally (free to short-circuit). The middleware-composition equivalent of Apache's scoped directive containers — e.g. `BasicAuthMiddleware` only under `/admin`.

--- a/src/App.php
+++ b/src/App.php
@@ -3829,7 +3829,17 @@ HELP;
             $this->patternRoute('/.*\.php', ['methods' => ['GET', 'POST']], function($response) {
                 $app = App::instance();
                 assert($app !== null);
-                return $app->renderError(403);
+                // Apache parity (#25): a `.php` file that exists on disk but is
+                // blocked from direct access is 403 Forbidden; a `.php` URL with
+                // no backing file is 404 Not Found — "doesn't exist" must not
+                // masquerade as "no permission".
+                $g = \ZealPHP\RequestContext::instance();
+                $reqPath = parse_url((string)($g->server['REQUEST_URI'] ?? ''), PHP_URL_PATH);
+                $reqPath = is_string($reqPath) ? rawurldecode($reqPath) : '';
+                $docRoot = App::resolveDocumentRoot();
+                $abs = realpath($docRoot . '/' . ltrim($reqPath, '/'));
+                $exists = $abs !== false && is_file($abs) && str_starts_with($abs, $docRoot . '/');
+                return $app->renderError($exists ? 403 : 404);
             });
         }
 

--- a/tests/Integration/PublicRoutingTest.php
+++ b/tests/Integration/PublicRoutingTest.php
@@ -114,4 +114,21 @@ class PublicRoutingTest extends TestCase
         $this->assertArrayHasKey('content-range', $r['headers']);
         $this->assertSame(10, strlen($r['body']));
     }
+
+    // ── Apache parity (#25): .php URL status ───────────────────────────
+
+    public function testNonexistentPhpReturns404(): void
+    {
+        // A `.php` URL with no backing file is "not found", not "forbidden".
+        $r = $this->get('/nonexistent-page.php');
+        $this->assertStatus(404, $r);
+    }
+
+    public function testExistingPhpFileReturns403(): void
+    {
+        // public/home.php exists but direct `.php` access is blocked
+        // (ignore_php_ext serves it as /home) — Apache returns 403 here.
+        $r = $this->get('/home.php');
+        $this->assertStatus(403, $r);
+    }
 }


### PR DESCRIPTION
Fixes #25.

## Problem
With `ignore_php_ext` on (default), the `*.php` catch-all returned a blanket **403** for every `.php` URL — so `/nonexistent-page.php` said "forbidden" when Apache says "not found."

## Fix
The catch-all now resolves the request path under the document root:
- existing `.php` file blocked from direct access → **403 Forbidden**
- `.php` URL with no backing file → **404 Not Found**

`realpath()` + a doc-root prefix check guard against traversal (and the pre-routing traversal guard still runs first).

## Tests
- `testNonexistentPhpReturns404` — `/nonexistent-page.php` → 404
- `testExistingPhpFileReturns403` — `/home.php` (exists) → 403

Verified live: `/nonexistent-page.php`→404, `/home.php`→403. Full suite green (unit + 178 integration), PHPStan L10 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)