### PR TITLE
Pin Docker base image by digest + Dependabot docker ecosystem (Scorecard Pinned-Dependencies)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 # Dependabot — auto-PRs for outdated dependencies.
 #
-# Watching two ecosystems:
+# Watching three ecosystems:
 #   - composer: production + dev dependencies in composer.json/lock
 #   - github-actions: pinned action versions in .github/workflows/*.yml
+#   - docker: the digest-pinned base image in Dockerfile (keeps the pin patched)
 #
 # Weekly schedule (Monday) keeps the noise rate sane while still catching
 # CVE-class updates within a week of disclosure. Security advisories are
@@ -52,3 +53,17 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: chore(docker)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM php:8.3-cli-bookworm
+# Pinned by digest for supply-chain reproducibility (OpenSSF Scorecard
+# Pinned-Dependencies). Dependabot's docker ecosystem bumps this digest weekly
+# so security patches keep flowing — see .github/dependabot.yml.
+FROM php:8.3-cli-bookworm@sha256:ed0bdc6dad3aea67fe296d9eea65a11b89677c1cbcf304601a630f4d318be308
 
 ARG OPENSWOOLE_VERSION=
 ARG UOPZ_VERSION=


### PR DESCRIPTION
Final in-repo Pinned-Dependencies lever after the actions-pin pass (Scorecard 7.4).

- Dockerfile `FROM php:8.3-cli-bookworm` → pinned `@sha256:ed0bdc6…` (current digest).
- Added `docker` ecosystem to `.github/dependabot.yml` so the digest is bumped weekly — the pin stays patched, not frozen. (composer + github-actions already covered.)

The only remaining Scorecard gaps are policy/people, not code: **Branch-Protection** (would block direct-to-master release pushes — your call), Code-Review/Contributors (solo maintainer), CII-Best-Practices (questionnaire), Fuzzing (OSS-Fuzz/ClusterFuzzLite). No `src/` changes.