### PR TITLE
ci: pass admin-read token to Scorecard (Branch-Protection readability)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Admin-read PAT so the Branch-Protection check can read the rules
+          # (the default GITHUB_TOKEN cannot). See .github/dependabot.yml note.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: true
 
       - name: Upload SARIF artifact


### PR DESCRIPTION
Branch protection on master is enforced, but Scorecard's default token can't read the rules, capping Branch-Protection at 3. This passes `repo_token: ${{ secrets.SCORECARD_TOKEN }}` (admin-read PAT) so the check can read required-PR + status checks + admin enforcement. Scorecard runs on master-push, so the effect shows after merge.