### PR TITLE
fix(templates): load page-scoped CSS/JS on boosted nav (head-support)

### DIFF
--- a/template/_head.php
+++ b/template/_head.php
@@ -62,6 +62,11 @@ $ogImageUrl = $ogImageExists ? ($__scheme . '://' . $__host . $ogImage) : null;
   <!-- Instrument Sans — display / heading font; Fira Code — code font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap">
   <script src="https://unpkg.com/htmx.org@2.0.10" defer></script>
+  <!-- head-support: hx-boost swaps <body> + <title> but NOT <head>; this
+       extension reconciles <head> on boosted navigation so each page's
+       page-scoped CSS/JS module (css/pages/*.css, js/pages/*.js) loads
+       when you navigate INTO it, not just on a full reload. -->
+  <script src="https://unpkg.com/htmx-ext-head-support@2.0.4/head-support.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" defer></script>
   <script src="/js/mermaid-init.js?v=<?= $v ?>" defer></script>
   <script src="/js/site-nav.js?v=<?= $v ?>" defer></script>

--- a/template/_master.php
+++ b/template/_master.php
@@ -8,7 +8,7 @@ $active      ??= $page;
 <!doctype html>
 <html lang="en">
 <?php App::render('/_head', compact('title', 'description', 'page')); ?>
-<body hx-boost="true">
+<body hx-boost="true" hx-ext="head-support">
 <div id="htmx-progress" class="htmx-progress" aria-hidden="true"></div>
 <?php App::render('/_nav', ['active' => $active]); ?>
 <?php App::render('/components/_banner'); ?>


### PR DESCRIPTION
**Regression from PR #51** (inline-CSS/JS extraction). Page-scoped modules (`css/pages/*.css`, `js/pages/*.js`) are emitted in `<head>`, but `<body hx-boost="true">` swaps only `<body>` + `<title>` — never `<head>`. So navigating *into* a page from another page (home → /legacy-apps) kept the previous page's CSS and never loaded the target's. Symptom: "CSS not loading at times" (only on boosted nav, not direct load).

**Fix:** htmx's `head-support` extension reconciles `<head>` on boosted swaps — adds the incoming page's `<link>`/`<script>`, removes stale ones, leaves shared tags (htmx, site-nav.js, learn.js) intact.
- `_head.php`: load `htmx-ext-head-support@2.0.4` after htmx core.
- `_master.php`: `hx-ext="head-support"` on the boosted body.

**Verified (Chrome DevTools):** home → /legacy-apps loads legacy-apps.css + drops home.css; /legacy-apps → /performance loads performance.css + drops legacy-apps.css + keeps global site-nav.js. 2-line change.