### PR TITLE
fix(templates): bundle page CSS up front to kill boosted-nav FOUC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ __pycache__/
 /.claude/scheduled_tasks.lock
 /.claude/worktrees/
 /.phpdoc/
+/public/css/pages.css

--- a/app.php
+++ b/app.php
@@ -68,6 +68,30 @@ if (PHP_SAPI === 'cli' && !in_array($__cliSub, ['stop', 'status', 'logs', '--hel
     unset($__cliSub, $__docsIndex, $__buildScript, $__log, $__proc, $__pipes);
 }
 
+// Build the page-CSS bundle: concatenate public/css/pages/*.css into one
+// public/css/pages.css served statically and loaded up front in _head.php.
+// Loading page styles eagerly (vs. lazily per page) is what stops hx-boost
+// navigation from flashing unstyled content. Regenerated on every boot so
+// it can't drift from the per-page sources; trivial cost (~47 KB). The
+// /css/ path is owned by OpenSwoole's static handler, so this must be a
+// real file — a PHP route never gets a chance to serve it.
+if (PHP_SAPI === 'cli' && !in_array($argv[1] ?? 'start', ['stop', 'status', 'logs', '--help', '-h'], true)) {
+    $__cssPagesDir = __DIR__ . '/public/css/pages';
+    if (is_dir($__cssPagesDir)) {
+        $__bundle = '';
+        $__cssFiles = glob($__cssPagesDir . '/*.css') ?: [];
+        sort($__cssFiles);
+        foreach ($__cssFiles as $__cssFile) {
+            $__cssBody = file_get_contents($__cssFile);
+            if ($__cssBody !== false) {
+                $__bundle .= '/* ── ' . basename($__cssFile) . " ── */\n" . $__cssBody . "\n";
+            }
+        }
+        @file_put_contents(__DIR__ . '/public/css/pages.css', $__bundle);
+    }
+    unset($__cssPagesDir, $__bundle, $__cssFiles, $__cssFile, $__cssBody);
+}
+
 // Lifecycle is coroutine-mode by default (the recommended default for new
 // apps). Overridable via env so the same demo can be exercised under the
 // Mixed-mode and legacy-CGI lifecycles too — used by the coverage harness to

--- a/template/_head.php
+++ b/template/_head.php
@@ -57,6 +57,10 @@ $ogImageUrl = $ogImageExists ? ($__scheme . '://' . $__host . $ogImage) : null;
   <meta name="twitter:image" content="<?= htmlspecialchars($ogImageUrl, ENT_QUOTES) ?>">
   <?php endif; ?>
   <link rel="stylesheet" href="/css/zealphp.css?v=<?= $v ?>">
+  <!-- All page-scoped styles in one always-loaded bundle (route/assets.php).
+       Loaded up front, not lazily per page, so hx-boost navigation never
+       flashes unstyled content waiting on a per-page stylesheet to fetch. -->
+  <link rel="stylesheet" href="/css/pages.css?v=<?= $v ?>">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <!-- Instrument Sans — display / heading font; Fira Code — code font -->
@@ -77,18 +81,15 @@ $ogImageUrl = $ogImageExists ? ($__scheme . '://' . $__host . $ogImage) : null;
   <script src="/js/learn-tictactoe.js?v=<?= $v ?>" defer></script>
   <script src="/js/timers.js?v=<?= $v ?>" defer></script>
 <?php
-  // Page-scoped CSS/JS modules — the home of styles/scripts extracted
-  // out of the page templates (no inline <style>/<script> in templates,
-  // per the project's separation-of-concerns rule). A page keyed
-  // "$page" (e.g. "performance", "docs/guide", "learn/htmx") gets its
-  // module auto-loaded when the file exists. Slashes flatten to dashes
-  // so "docs/guide" → docs-guide.{css,js}. Existence-gated so a page
-  // without a module emits nothing.
+  // Page-scoped JS modules — scripts extracted out of the page templates
+  // (no inline <script> in templates, per the separation-of-concerns
+  // rule). A page keyed "$page" (e.g. "home", "learn/htmx") gets its
+  // module auto-loaded when the file exists; slashes flatten to dashes
+  // so "learn/htmx" → learn-htmx.js. Existence-gated. (Page CSS is NOT
+  // lazy-loaded here — it ships in the always-loaded /css/pages.css
+  // bundle above, so boosted navigation never flashes unstyled.)
   $__pageKey  = preg_replace('/[^a-z0-9_-]+/i', '-', (string) ($page ?? ''));
   $__pubRoot  = dirname(__DIR__) . '/public';
-  if ($__pageKey !== '' && is_file($__pubRoot . '/css/pages/' . $__pageKey . '.css')): ?>
-  <link rel="stylesheet" href="/css/pages/<?= $__pageKey ?>.css?v=<?= $v ?>">
-<?php endif;
   if ($__pageKey !== '' && is_file($__pubRoot . '/js/pages/' . $__pageKey . '.js')): ?>
   <script src="/js/pages/<?= $__pageKey ?>.js?v=<?= $v ?>" defer></script>
 <?php endif; ?>


### PR DESCRIPTION
**Reported:** navigating to a page for the *first* time flashes unstyled content; revisiting doesn't.

**Cause:** flash-of-unstyled-content from the page-scoped CSS (#51) + head-support (#52) combo. hx-boost swaps `<body>` immediately; head-support then *adds* the new page's `<link>`, which the browser fetches async — so `.perf-*`/`.home-*` markup renders unstyled until the CSS lands (first visit, uncached). Cached on revisit → no flash. Exactly the reported symptom.

**Fix:** stop lazy-loading page CSS per navigation. Concatenate all `public/css/pages/*.css` into one `public/css/pages.css` loaded up front in `_head.php`. Every page's styles are present from the first full load and stay loaded across boosted nav → no async stylesheet fetch after a swap → no flash, ever.

- `app.php`: boot step concatenates `pages/*.css` → `pages.css` (regenerated each start, ~47 KB, gitignored). `/css/` is OpenSwoole's static-handler turf, so it must be a real file — a PHP route never gets to serve it.
- `_head.php`: load `/css/pages.css` always; drop the `$page`-gated per-page `<link>` (page JS stays lazy — no visual flash from JS).
- `.gitignore`: ignore the generated bundle.

Selectors are page-prefixed, zero cross-file collisions (verified) → safe to concatenate. Per-page sources stay for organization.

**Verified (Chrome DevTools):** bundle present on first paint; home → /performance triggers **zero** css `<link>` add/remove in `<head>` (previously ADD performance.css / REMOVE home.css — the async fetch that flashed); styles apply immediately.