### PR TITLE
chore(ci): refresh mutation MSI badge to 93%

### DIFF
--- a/.github/badges/mutation.json
+++ b/.github/badges/mutation.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "mutation MSI",
-  "message": "92%",
+  "message": "93%",
   "color": "brightgreen",
   "style": "flat-square"
 }


### PR DESCRIPTION
Supersedes bot auto-PR #43. The `mutation.yml` workflow regenerated the badge (92%→93% vs current master) but pushes with `GITHUB_TOKEN`, which doesn't trigger the required CI workflows — so #43 is permanently BLOCKED (0 check-runs). Re-applying the same value as a normal commit lets CI run + merge without an admin bypass. Value matches the Infection run on the #55 master push (07:42). Will close #43.