### PR TITLE
feat(home): add icons to hero CTA buttons

### DIFF
--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -349,6 +349,9 @@ p  { max-width: 70ch; }
 .btn-outline { border: 1px solid rgba(245,158,11,.4); color: #fff; background: transparent; }
 .btn-outline:hover { background: rgba(245,158,11,.1); border-color: var(--accent); color: var(--accent); }
 .btn-sm { padding: .35rem .9rem; font-size: .8rem; }
+/* Leading icon inside a .btn — sized to the text, inherits button colour
+ * via stroke:currentColor. The .btn flex gap handles spacing. */
+.btn-icon { width: 1.05em; height: 1.05em; flex-shrink: 0; }
 .btn-ghost { background: transparent; color: var(--text-muted); }
 .btn-ghost:hover { background: var(--bg-alt); }
 

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,10 +18,18 @@ $siteUrl = site_url();
        one server, one process. Coroutine-native concurrency with PHP's developer experience.</p>
     <p class="home-hero-sub">Upgrade your existing PHP codebase to async — start without rewriting, migrate at your own pace.</p>
     <div class="cta">
-      <a href="/getting-started" class="btn btn-primary">Get Started →</a>
-      <a href="/docs/" class="btn btn-outline">Browse Docs →</a>
-      <a href="/why-zealphp" class="btn btn-outline">Why ZealPHP? →</a>
-      <a href="https://deepwiki.com/sibidharan/zealphp" class="btn btn-outline" target="_blank" rel="noopener">Ask DeepWiki ↗</a>
+      <a href="/getting-started" class="btn btn-primary">
+        <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
+        Get Started →</a>
+      <a href="/docs/" class="btn btn-outline">
+        <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>
+        Browse Docs →</a>
+      <a href="/why-zealphp" class="btn btn-outline">
+        <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>
+        Why ZealPHP? →</a>
+      <a href="https://deepwiki.com/sibidharan/zealphp" class="btn btn-outline" target="_blank" rel="noopener">
+        <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>
+        Ask DeepWiki ↗</a>
     </div>
     <p class="home-hero-why">
       <a href="/why-zealphp">Why?</a> covers the problem PHP-FPM can't solve, where ZealPHP fits vs Laravel Octane / FrankenPHP / RoadRunner, and when it's the wrong choice.


### PR DESCRIPTION
Adds a leading Lucide-style inline SVG icon to each of the four hero CTAs (rocket / book-open / help-circle / sparkles), keeping the trailing arrows. Icons inherit button text colour via `stroke:currentColor`, sized with a new `.btn-icon` rule; the existing `.btn` inline-flex + gap handles alignment (no layout change). Verified live: all 4 render with correct per-button colour.