### PR TITLE
fix(why-zealphp): competitive table header was light-on-light (invisible)

### DIFF
--- a/public/css/pages/why-zealphp.css
+++ b/public/css/pages/why-zealphp.css
@@ -103,7 +103,13 @@
   min-width: 700px;
 }
 
-.why-compare-th {
+/* Scoped under .why-compare-table so this beats the global `.ztable th`
+ * rule (both carry the .ztable class on the <table>): `.ztable th` is
+ * specificity (0,1,1) and was overriding this header's dark background
+ * back to the light --bg-alt, leaving light --code-text on a light
+ * surface (invisible). `.why-compare-table th.why-compare-th` is
+ * (0,2,1), so the dark code-style header wins. */
+.why-compare-table th.why-compare-th {
   background: var(--code-bg);
   color: var(--code-text);
   border-bottom: 2px solid rgba(255,255,255,.15);


### PR DESCRIPTION
The competitive-landscape table header rendered light `--code-text` on a light background — invisible. CSS specificity collision from the #51 extraction: the table has both classes (`ztable why-compare-table`), so the global `.ztable th` (0,1,1) overrode `.why-compare-th` (0,1,0), forcing the header bg back to light `--bg-alt` while the light text colour stuck → light-on-light. Fixed by scoping the rule as `.why-compare-table th.why-compare-th` (0,2,1) so the intended dark code-style header wins. Verified live: #e7e5e4 on #1a1412, readable.