### PR TITLE
feat(docs): curated API index landing + breadcrumbs on API pages

### DIFF
--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -1130,6 +1130,48 @@ pre:hover > .code-copy { opacity: 1; }
   color: inherit;
 }
 
+/* Curated API index — grouped class grid (template/pages/docs/api-index.php) */
+.api-index { margin-top: 1.5rem; }
+.api-index-group { margin-bottom: 2rem; }
+.api-index-group-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0 0 .75rem;
+  padding-bottom: .4rem;
+  border-bottom: 1px solid var(--border);
+  letter-spacing: -.01em;
+}
+.api-index-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: .4rem;
+}
+.api-index-link {
+  display: block;
+  padding: .5rem .7rem;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  text-decoration: none;
+  background: var(--bg);
+  transition: border-color .15s, background .15s;
+}
+.api-index-link:hover {
+  border-color: rgba(245,158,11,.45);
+  background: rgba(245,158,11,.05);
+  text-decoration: none;
+}
+.api-index-link code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-size: .82rem;
+  color: var(--accent-dark);
+}
+.api-index-link:hover code { color: var(--accent-dark); }
+
 /* ====================================================================
  * API SEARCH — htmx-powered inline suggestions at the top of every
  * /docs/api/ page. The <input> debounces input events and GETs

--- a/route/docs.php
+++ b/route/docs.php
@@ -80,6 +80,19 @@ $app->patternRoute('#^/docs/api(/.*)?$#', function ($response) {
         return null;
     }
 
+    // Curated API landing — replace phpDocumentor's flat Table-of-Contents
+    // at the root with a class index grouped by namespace (built from the
+    // generated class pages). Far more navigable than the phpdoc default.
+    if ($rel === '/index.html') {
+        App::render('/_master', [
+            'title'     => 'API Reference · ZealPHP Docs',
+            'page'      => 'docs/api-index',
+            'active'    => 'docs',
+            'apiGroups' => \ZealPHP\Docs\ApiIndex::groups($apiRoot . '/classes'),
+        ]);
+        return null;
+    }
+
     $target = $apiRoot . $rel;
     $realTarget = realpath($target);
     if ($realTarget === false
@@ -246,6 +259,7 @@ $app->patternRoute('#^/docs/api(/.*)?$#', function ($response) {
             'apiSidebar'   => $sidebarHtml,
             'apiCssHref'   => $apiCssHref,
             'apiTitle'     => $apiTitle,
+            'apiCrumb'     => \ZealPHP\Docs\ApiIndex::breadcrumb($rel),
         ]);
         return null;
     }

--- a/src/Docs/ApiIndex.php
+++ b/src/Docs/ApiIndex.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Docs;
+
+/**
+ * Builds a curated landing for /docs/api/ from the phpDocumentor output.
+ *
+ * phpDocumentor's own index is a flat "Table of Contents" dump (Packages
+ * → Namespaces → a long list of loose functions) that buries the classes
+ * a reader actually wants. This class scans the generated
+ * `public/docs/api/classes/*.html` files and groups them by namespace
+ * (Core, HTTP, Middleware, Session, …) so the landing surfaces every
+ * class directly. It's regenerated from the files on each request, so it
+ * never drifts as classes are added or removed.
+ *
+ * Also provides the breadcrumb trail shown atop each wrapped API page —
+ * the phpDocumentor header (which carried its own breadcrumb) is stripped
+ * during wrapping, so we synthesise one from the file path.
+ */
+final class ApiIndex
+{
+    /**
+     * Preferred group order + display titles. Groups not listed here
+     * (future namespaces) are appended alphabetically after these.
+     *
+     * @var array<string, string>
+     */
+    private const GROUP_TITLES = [
+        'Core'        => 'Core',
+        'HTTP'        => 'HTTP',
+        'Middleware'  => 'Middleware',
+        'Session'     => 'Session',
+        'Legacy'      => 'Legacy / CGI',
+        'Cache'       => 'Cache',
+        'Log'         => 'Logging',
+        'Input'       => 'Input',
+        'Diagnostics' => 'Diagnostics',
+        'Docs'        => 'Docs',
+        'Learn'       => 'Learn (demo app)',
+    ];
+
+    /**
+     * Group the generated class pages by namespace.
+     *
+     * @return array<string, list<array{label: string, href: string}>>
+     *         Display-title → list of {short class label, page href},
+     *         in the preferred group order.
+     */
+    public static function groups(string $classesDir): array
+    {
+        $files = glob(rtrim($classesDir, '/') . '/*.html') ?: [];
+        sort($files);
+
+        /** @var array<string, list<array{label: string, href: string}>> $byGroup */
+        $byGroup = [];
+        foreach ($files as $file) {
+            $base  = basename($file, '.html');         // ZealPHP-Middleware-CorsMiddleware
+            $parts = explode('-', $base);
+            if ($parts[0] !== 'ZealPHP' || count($parts) < 2) {
+                continue;
+            }
+            $rest = array_slice($parts, 1);            // [Middleware, CorsMiddleware]
+            if (count($rest) === 1) {
+                $group = 'Core';                        // top-level: App, Store, ZealAPI…
+                $label = $rest[0];
+            } else {
+                $group = $rest[0];                      // Middleware / HTTP / Session…
+                $label = implode('\\', array_slice($rest, 1)); // CorsMiddleware, Factory\RequestFactory
+            }
+            $byGroup[$group][] = ['label' => $label, 'href' => '/docs/api/classes/' . $base . '.html'];
+        }
+
+        // Emit in preferred order, then any leftover groups alphabetically.
+        $ordered = [];
+        foreach (self::GROUP_TITLES as $key => $title) {
+            if (isset($byGroup[$key])) {
+                $ordered[$title] = $byGroup[$key];
+                unset($byGroup[$key]);
+            }
+        }
+        ksort($byGroup);
+        foreach ($byGroup as $key => $items) {
+            $ordered[$key] = $items;
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * Breadcrumb trail for an API page, derived from its path relative to
+     * /docs/api (e.g. "/classes/ZealPHP-Middleware-CorsMiddleware.html").
+     * The last segment has a null href (current page).
+     *
+     * @return list<array{label: string, href: ?string}>
+     */
+    public static function breadcrumb(string $rel): array
+    {
+        $trail = [
+            ['label' => 'Docs', 'href' => '/docs/'],
+            ['label' => 'API Reference', 'href' => '/docs/api/'],
+        ];
+
+        // A class page: surface namespace segments + the class short name.
+        if (preg_match('#^/classes/(ZealPHP-[^/]+)\.html$#', $rel, $m) === 1) {
+            $rest = array_slice(explode('-', $m[1]), 1); // drop "ZealPHP"
+            $class = array_pop($rest);
+            foreach ($rest as $ns) {                      // namespace segments (no link)
+                $trail[] = ['label' => $ns, 'href' => null];
+            }
+            $trail[] = ['label' => (string) $class, 'href' => null];
+            return $trail;
+        }
+
+        // Other page types (namespaces/packages/reports/indices/functions).
+        if (preg_match('#^/([a-z-]+)/#', $rel, $m) === 1) {
+            $trail[] = ['label' => ucfirst(str_replace('-', ' ', $m[1])), 'href' => null];
+        }
+
+        return $trail;
+    }
+}

--- a/template/pages/docs/api-index.php
+++ b/template/pages/docs/api-index.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * /docs/api/ landing — curated, grouped index of the API reference.
+ *
+ * Replaces phpDocumentor's flat "Table of Contents" (which buried the
+ * classes behind a Packages/Namespaces/loose-functions dump) with the
+ * classes grouped by namespace. $apiGroups is built by
+ * ZealPHP\Docs\ApiIndex::groups() in route/docs.php.
+ *
+ * @var array<string, list<array{label: string, href: string}>> $apiGroups
+ */
+use ZealPHP\App;
+
+$apiGroups = $apiGroups ?? [];
+$classCount = array_sum(array_map('count', $apiGroups));
+?>
+<div class="learn-layout">
+  <?php App::render('/pages/docs/_sidebar', ['topic' => '__api__']); ?>
+
+  <article class="lesson-content docs-landing">
+    <?php App::render('/pages/docs/_search'); ?>
+
+    <nav class="docs-breadcrumbs" aria-label="Breadcrumbs">
+      <a href="/docs/">Docs</a>
+      <span class="sep">›</span>
+      <span class="current">API Reference</span>
+    </nav>
+
+    <header class="lesson-header">
+      <h1 class="lesson-title">API Reference</h1>
+      <p class="lesson-subtitle">
+        Auto-generated from <code>src/</code> docblocks — every public class,
+        method, and property across <strong><?= (int) $classCount ?> classes</strong>.
+        Grouped by namespace below; full method signatures are on each class page.
+      </p>
+    </header>
+
+    <div class="api-index">
+      <?php foreach ($apiGroups as $group => $classes): ?>
+        <section class="api-index-group">
+          <h2 class="api-index-group-title"><?= htmlspecialchars($group, ENT_QUOTES) ?></h2>
+          <ul class="api-index-list">
+            <?php foreach ($classes as $cls): ?>
+              <li>
+                <a class="api-index-link" href="<?= htmlspecialchars($cls['href'], ENT_QUOTES) ?>" hx-boost="false">
+                  <code><?= htmlspecialchars($cls['label'], ENT_QUOTES) ?></code>
+                </a>
+              </li>
+            <?php endforeach; ?>
+          </ul>
+        </section>
+      <?php endforeach; ?>
+    </div>
+  </article>
+</div>

--- a/template/pages/docs/api-wrapped.php
+++ b/template/pages/docs/api-wrapped.php
@@ -32,6 +32,19 @@ $v = defined('ZEALPHP_ASSET_VERSION') ? ZEALPHP_ASSET_VERSION : '';
   <article class="lesson-content docs-api">
     <?php App::render('/pages/docs/_search'); ?>
 
+    <?php $apiCrumb = $apiCrumb ?? []; if (!empty($apiCrumb)): ?>
+      <nav class="docs-breadcrumbs" aria-label="Breadcrumbs">
+        <?php foreach ($apiCrumb as $i => $seg): ?>
+          <?php if ($i > 0): ?><span class="sep">›</span><?php endif; ?>
+          <?php if (!empty($seg['href'])): ?>
+            <a href="<?= htmlspecialchars($seg['href'], ENT_QUOTES) ?>" hx-boost="false"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></a>
+          <?php else: ?>
+            <span class="current"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></span>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      </nav>
+    <?php endif; ?>
+
     <?php if (!empty($apiSidebar)): ?>
       <details class="docs-api-index">
         <summary>API Index — Namespaces, Packages, Reports, Indices</summary>

--- a/tests/Unit/Docs/ApiIndexTest.php
+++ b/tests/Unit/Docs/ApiIndexTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\Docs;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\Docs\ApiIndex;
+
+/**
+ * Pins the curated API-index grouping + breadcrumb derivation.
+ */
+final class ApiIndexTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/apiindex-' . uniqid();
+        mkdir($this->dir, 0777, true);
+        foreach ([
+            'ZealPHP-App',
+            'ZealPHP-Store',
+            'ZealPHP-Middleware-CorsMiddleware',
+            'ZealPHP-Middleware-ETagMiddleware',
+            'ZealPHP-HTTP-Request',
+            'ZealPHP-HTTP-Factory-RequestFactory',
+            'ZealPHP-Learn-Auth',
+            'NotZealPHP-Thing',          // ignored (wrong prefix)
+        ] as $name) {
+            file_put_contents($this->dir . '/' . $name . '.html', '<html></html>');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->dir . '/*') ?: []);
+        rmdir($this->dir);
+    }
+
+    // ── groups() ────────────────────────────────────────────────────────
+
+    public function testTopLevelClassesGoToCore(): void
+    {
+        $groups = ApiIndex::groups($this->dir);
+        $labels = array_column($groups['Core'], 'label');
+        $this->assertContains('App', $labels);
+        $this->assertContains('Store', $labels);
+    }
+
+    public function testNamespacedClassesGroupByFirstSegment(): void
+    {
+        $groups = ApiIndex::groups($this->dir);
+        $this->assertSame(
+            ['CorsMiddleware', 'ETagMiddleware'],
+            array_column($groups['Middleware'], 'label')
+        );
+    }
+
+    public function testDeepNamespaceKeepsRemainderAsLabel(): void
+    {
+        $groups = ApiIndex::groups($this->dir);
+        $labels = array_column($groups['HTTP'], 'label');
+        $this->assertContains('Request', $labels);
+        $this->assertContains('Factory\\RequestFactory', $labels);
+    }
+
+    public function testHrefPointsAtClassPage(): void
+    {
+        $groups = ApiIndex::groups($this->dir);
+        $cors = null;
+        foreach ($groups['Middleware'] as $entry) {
+            if ($entry['label'] === 'CorsMiddleware') {
+                $cors = $entry;
+            }
+        }
+        $this->assertSame('/docs/api/classes/ZealPHP-Middleware-CorsMiddleware.html', $cors['href'] ?? null);
+    }
+
+    public function testNonZealphpFilesIgnored(): void
+    {
+        $groups = ApiIndex::groups($this->dir);
+        $all = [];
+        foreach ($groups as $items) {
+            $all = array_merge($all, array_column($items, 'label'));
+        }
+        $this->assertNotContains('Thing', $all);
+    }
+
+    public function testCoreOrderedBeforeOtherGroups(): void
+    {
+        $keys = array_keys(ApiIndex::groups($this->dir));
+        $this->assertSame('Core', $keys[0]);
+        $this->assertContains('Learn (demo app)', $keys);     // display title mapped
+        $this->assertLessThan(
+            array_search('Learn (demo app)', $keys, true),
+            array_search('Middleware', $keys, true)
+        );
+    }
+
+    // ── breadcrumb() ────────────────────────────────────────────────────
+
+    public function testBreadcrumbForClassPageIncludesNamespaceAndClass(): void
+    {
+        $crumb = ApiIndex::breadcrumb('/classes/ZealPHP-Middleware-CorsMiddleware.html');
+        $labels = array_column($crumb, 'label');
+        $this->assertSame(['Docs', 'API Reference', 'Middleware', 'CorsMiddleware'], $labels);
+        // last segment is the current page (no link)
+        $this->assertNull($crumb[array_key_last($crumb)]['href']);
+    }
+
+    public function testBreadcrumbForTopLevelClassHasNoNamespaceSegment(): void
+    {
+        $labels = array_column(ApiIndex::breadcrumb('/classes/ZealPHP-App.html'), 'label');
+        $this->assertSame(['Docs', 'API Reference', 'App'], $labels);
+    }
+
+    public function testBreadcrumbForOtherPageType(): void
+    {
+        $labels = array_column(ApiIndex::breadcrumb('/namespaces/zealphp.html'), 'label');
+        $this->assertSame(['Docs', 'API Reference', 'Namespaces'], $labels);
+    }
+}


### PR DESCRIPTION
**1. Curated /docs/api/ landing.** phpDocumentor's default index is a flat TOC (Packages → Namespaces → loose `apache_*` functions) that buried the classes — you had to click through the ZealPHP namespace to reach `App`, `Store`, middleware, etc. Replaced with a namespace-grouped class index (Core, HTTP, Middleware, Session, Legacy/CGI, …), each class a code chip linking straight to its page. `src/Docs/ApiIndex::groups()` scans the generated class files and buckets by namespace (regenerated per request, never drifts).

**2. Breadcrumbs on wrapped API pages.** phpdoc's header (with its breadcrumb) is stripped during wrapping; `ApiIndex::breadcrumb()` synthesises 'Docs › API Reference › Middleware › CorsMiddleware' from the path, matching the guides' `.docs-breadcrumbs` style. Index shows 'Docs › API Reference'.

9 unit tests for grouping + breadcrumb. PHPStan L10 clean (v2), verified live (grouped 77-class index + breadcrumb trail).