### PR TITLE
fix(docs): drop redundant h2 top-border after page h1 (double-hr look)

### DIFF
--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -1011,10 +1011,13 @@ pre:hover > .code-copy { opacity: 1; }
   border-top: 1px solid var(--border);
   letter-spacing: -.01em;
 }
-/* An <hr> directly before an <h2> would stack the rule's line with the
- * h2's own border-top — a double divider. Drop the h2 border in that
- * case (markdown `---` immediately before a `## heading`). */
-.docs-markdown hr + h2 { border-top: 0; padding-top: 0; margin-top: 0; }
+/* Drop the h2's own top border (a redundant divider) when it directly
+ * follows another rule: an <hr> (markdown `---`) OR the page <h1>, whose
+ * border-bottom already draws a line. Without this, a guide that opens
+ * "# Title" then "## Section" — i.e. most of them — shows two stacked
+ * rules at the top that read as a double <hr>. */
+.docs-markdown hr + h2,
+.docs-markdown h1 + h2 { border-top: 0; padding-top: 0; margin-top: .6rem; }
 .docs-markdown h3 { font-size: 1.15rem; margin: 1.6rem 0 .4rem; }
 .docs-markdown h4 { font-size: 1rem; margin: 1.2rem 0 .3rem; color: var(--text-muted); }
 .docs-markdown p { margin: 0 0 1rem; }


### PR DESCRIPTION
Guides open `# Title` then `## Section` with nothing between, so the rendered `<h1>` (border-bottom title underline) sits directly above the first `<h2>` (border-top section divider) — the two stacked rules read as a double `<hr>` at the top. Reported on /docs/guide/websocket; present on most guides.

Extended the existing `hr + h2` dedup to also match `h1 + h2` (h2 drops its top border/padding when directly after the h1 or an hr). Section-separating h2s deeper in the page keep their divider.

Verified live: /docs/guide/websocket 'Overview' h2 → border-top 0; 'Lifecycle' h2 → keeps 1px.