### PR TITLE
fix(docs/api): strip stray bullets from phpdoc -clean lists

### DIFF
--- a/public/css/docs-api.css
+++ b/public/css/docs-api.css
@@ -117,6 +117,16 @@
   letter-spacing: .08em;
   font-weight: 700;
 }
+/* phpdoc's "-clean" list modifier (the API tree / table-of-contents
+ * lists) has no backing rule in the bundled template.css, so its items
+ * fall back to default disc bullets — including the empty wrapper <li>
+ * that only holds a nested <ul>, which shows a stray bullet next to
+ * nothing (e.g. on the HaltException page). Strip bullets on -clean
+ * lists; they're meant to be bulletless. */
+.docs-api .phpdocumentor-list.-clean,
+.docs-api .phpdocumentor-list.-clean li {
+  list-style: none;
+}
 .docs-api .phpdocumentor-list a {
   color: var(--text);
   padding: .3rem .6rem;


### PR DESCRIPTION
phpDocumentor emits its API-tree lists with the `-clean` modifier (meant to be bulletless), but the bundled `template.css` ships no `.-clean` rule, so they fall back to disc bullets — including the empty wrapper `<li>` that only holds a nested `<ul>`, showing a stray bullet next to nothing (reported on HaltException). Added `list-style: none` for `.phpdocumentor-list.-clean` in the overlay; scoped to `-clean` only so prose description lists keep their bullets. Verified live: empty wrapper li → none, content item ('Diagnostics') → disc.