### PR TITLE
fix(timers): reflect SSE connection state on Connect/Disconnect buttons

### DIFF
--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -349,6 +349,7 @@ p  { max-width: 70ch; }
 .btn-outline { border: 1px solid rgba(245,158,11,.4); color: #fff; background: transparent; }
 .btn-outline:hover { background: rgba(245,158,11,.1); border-color: var(--accent); color: var(--accent); }
 .btn-sm { padding: .35rem .9rem; font-size: .8rem; }
+.btn:disabled { opacity: .45; cursor: not-allowed; pointer-events: none; }
 /* Leading icon inside a .btn — sized to the text, inherits button colour
  * via stroke:currentColor. The .btn flex gap handles spacing. */
 .btn-icon { width: 1.05em; height: 1.05em; flex-shrink: 0; }

--- a/public/js/timers.js
+++ b/public/js/timers.js
@@ -18,11 +18,23 @@
     log.scrollTop = log.scrollHeight;
   }
 
+  // Reflect connection state on the buttons so the UI is unambiguous:
+  // Connect is disabled while a stream is live (no accidental second
+  // connection), Disconnect is disabled while idle (it was a dead-feeling
+  // no-op before — clicking it with nothing to close did nothing).
+  function setConnected(connected) {
+    document.querySelectorAll('[data-action="timers-sse-start"]')
+      .forEach(b => { b.disabled = connected; });
+    document.querySelectorAll('[data-action="timers-sse-stop"]')
+      .forEach(b => { b.disabled = !connected; });
+  }
+
   function stop() {
     if (eventSource) {
       eventSource.close();
       eventSource = null;
     }
+    setConnected(false);
   }
 
   function start() {
@@ -41,6 +53,7 @@
       appendLine('connection closed', 'done');
       stop();
     };
+    setConnected(true);
   }
 
   function init() {
@@ -51,6 +64,7 @@
       .forEach(btn => btn.addEventListener('click', start));
     document.querySelectorAll('[data-action="timers-sse-stop"]')
       .forEach(btn => btn.addEventListener('click', stop));
+    setConnected(false); // idle until the user connects
   }
 
   document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
Two reported /timers issues, both from the buttons never reflecting connection state:
- **Disconnect 'doesn't react'**: while idle it was a silent no-op (nothing to close) + near-invisible btn-ghost hover → felt dead.
- **'Two connections'**: no visual lock, so easy to click Connect again and stack a second stream.

Fix: drive buttons from state — Connect disabled while connected (no double-open), Disconnect disabled while idle (enabled only when there's a stream to close). `setConnected()` from start/stop/init + a `.btn:disabled` style. Verified live across idle → connected → disconnected.