### PR TITLE
docs: fence docblock code examples + API htmx nav + runtime-arch CGI/G

### DIFF
--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -26,7 +26,9 @@ ZealPHP merges your configuration with its defaults (`enable_static_handler: tru
 
 ## Superglobals and the `G` Container
 
-Traditional PHP scripts rely on `$_GET`, `$_POST`, `$_SERVER`, etc. ZealPHP emulates this behaviour while running inside an event loop by funneling state through `ZealPHP\G`:
+> **`G` is an alias; `ZealPHP\RequestContext` is the class.** `G` is the short, conventional name for the per-request **G**lobal state container. The class was originally named `G`, renamed to `RequestContext` in v0.2.6, with `class_alias(RequestContext::class, 'ZealPHP\G')` (at the bottom of `RequestContext.php`) keeping the short name working forever. `G::instance()` and the `$g` variable are the everyday accessors — type against `\ZealPHP\G` or `\ZealPHP\RequestContext`, they're literally the same class. In the [API reference](/docs/api/classes/ZealPHP-RequestContext.html) it's documented under its real name, **`RequestContext`**: a runtime `class_alias` has no source declaration of its own, so phpDocumentor can't give `G` a separate page.
+
+Traditional PHP scripts rely on `$_GET`, `$_POST`, `$_SERVER`, etc. ZealPHP emulates this behaviour while running inside an event loop by funneling state through `ZealPHP\RequestContext` (alias `G`):
 
 - When `App::$superglobals` is **true** (default), each request reconstructs the real PHP superglobals before executing route handlers. The `G` container proxies get/set operations so legacy code “just works.”
 - When `App::superglobals(false)` is called, ZealPHP stops mutating global arrays and instead uses coroutine-safe properties on the `G` instance. In this mode, OpenSwoole coroutine hooks are enabled and you can safely use `go()` from within the main request handler. Access request data through `$g = G::instance(); $g->get`, `$g->server`, etc.
@@ -59,6 +61,42 @@ ZealPHP favours a single-request-per-worker model to protect superglobals. When 
 
 - `App::cgiMode('proc' | 'fork' | 'fcgi')` selects the per-request isolation strategy for legacy `public/*.php` files. `'proc'` forks a fresh PHP interpreter per request via `proc_open` + `cgi_worker.php` (mod_php-style global isolation, ~30–50 ms cold start — what unmodified WordPress/Drupal needs). `'fork'` (v0.2.29) forks the warm worker via `OpenSwoole\Process` for ~5× faster startup at the cost of function-scope semantics. `'fcgi'` (v0.2.39+) forwards to an upstream php-fpm pool via `App::fcgiAddress()` — no child process at all. See [tasks-and-concurrency.md](./tasks-and-concurrency.md) for the trade-off table.
 - `coprocess()` / `coproc()` create dedicated processes with coroutine support for longer-running workloads that should not block the main worker. These helpers are only available when superglobals are enabled (`coproc` throws otherwise).
+
+### Custom CGI backends — host any language
+
+`App::cgiMode()` sets the strategy for **`.php`** files framework-wide. To serve **other languages** — Perl, Python, Ruby, shell, or anything that speaks CGI/1.1 or FastCGI — register a per-extension backend with `App::registerCgiBackend(string $extension, array $config)` before `$app->run()`. Unregistered extensions fall back to `App::$cgi_mode`.
+
+```php
+use ZealPHP\App;
+
+// Perl via proc (Apache `AddHandler cgi-script .pl` parity)
+App::registerCgiBackend('.pl', [
+    'mode'        => 'proc',
+    'interpreter' => '/usr/bin/perl',
+]);
+
+// Python via FastCGI — forward to a warm Python FCGI daemon
+App::registerCgiBackend('.py', [
+    'mode'        => 'fcgi',
+    'address'     => '127.0.0.1:9001',        // or unix:/run/python-fpm.sock
+    'fcgi_params' => ['APP_ENV' => 'prod'],   // merged into the CGI env
+]);
+
+// .cgi via shebang — the OS reads the #! line, no explicit interpreter
+App::registerCgiBackend('.cgi', ['mode' => 'proc']);
+```
+
+The three `mode` values:
+
+| `mode` | What it does | Languages |
+|--------|--------------|-----------|
+| `'proc'` | `proc_open` spawns the interpreter (or reads the `#!` shebang) per request — Apache CGI semantics | any (`interpreter` optional) |
+| `'fork'` | warm `OpenSwoole\Process` fork (~5× faster than proc) | **`.php` only** — `registerCgiBackend('.py', ['mode' => 'fork'])` throws `InvalidArgumentException` |
+| `'fcgi'` | forwards to a FastCGI daemon at `address` (php-fpm, a Python/Ruby FCGI server, …) — no per-request spawn | any FastCGI/1.0 server |
+
+`App::resolveCgiBackend('/path/file.py')` returns the resolved config for a given path. Full walkthrough — socket forms, `fcgi_params`, multiple upstream pools, 502/timeout behaviour — in the [FastCGI backends guide](fastcgi-backends.md). The framework-wide `'fcgi'` setter (`App::cgiMode('fcgi')` + `App::fcgiAddress()`) is the "front an existing php-fpm pool" shortcut for when **every** `public/*.php` should go to one upstream.
+
+> CGI backends require `superglobals(true) + processIsolation(true)` (the **Legacy CGI** mode in the matrix below). In coroutine mode, write native ZealPHP handlers instead.
 
 ## Task Workers
 

--- a/public/css/docs-api.css
+++ b/public/css/docs-api.css
@@ -371,6 +371,18 @@
   font-size: .85em;
   font-weight: 500;
 }
+/* …but block code inside a fenced <pre> is NOT an inline chip — the <pre>
+ * already provides the dark code surface. Strip the chip border/bg/padding
+ * so it doesn't draw a stray amber box inside the dark block. Specificity
+ * (0,3,2) beats the inline rule above (0,3,1). */
+.docs-api pre code:not(.phpdocumentor-signature):not(.phpdocumentor-code) {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+  color: inherit;
+}
 
 /* ---------- PARAMETERS + RETURN VALUES blocks ---------- */
 /* phpdoc emits these as <h5 class="phpdocumentor-argument-list__heading">

--- a/src/App.php
+++ b/src/App.php
@@ -875,8 +875,11 @@ class App
      * to read the current checker. Pass a callable to install one.
      *
      * Example:
-     *   `App::authChecker(fn() => !empty($_SESSION['user_id']));`
-     *   `App::authChecker(fn() => MyAuth::status() === MyAuth::LOGGED_IN);`
+     *
+     * ```php
+     * App::authChecker(fn() => !empty($_SESSION['user_id']));
+     * App::authChecker(fn() => MyAuth::status() === MyAuth::LOGGED_IN);
+     * ```
      *
      * @param callable|null $fn
      */
@@ -1755,9 +1758,12 @@ class App
      * The route pattern is converted to a named regex group for parameter matching.
      *
      * Example usage:
-     * `$app->route('/user/{id}', ['methods' => ['GET', 'POST']], function($id) {`
-     *     `// Handler code here`
-     * `});`
+     *
+     * ```php
+     * $app->route('/user/{id}', ['methods' => ['GET', 'POST']], function($id) {
+     *     // Handler code here
+     * });
+     * ```
      *
      * @param array<string, mixed>|callable $options
      * @param callable|null $handler
@@ -1837,10 +1843,13 @@ class App
      * and the actual route will be `/api/{path}` with {path} capturing all trailing segments.
      * 
      * Example:
+     *
+     * ```php
      * $app->nsPathRoute('api', ['methods' => ['GET']], function($path) {
      *     return "Full path under /api: $path";
      * });
-     * 
+     * ```
+     *
      * Accessing /api/devices/set_pref will set $path = "devices/set_pref".
      *
      * @param array<string, mixed>|callable $options
@@ -2288,11 +2297,14 @@ class App
      * buffered output once.
      *
      * Compose multiple template streams with `yield from`:
-     *   return (function() {
-     *       yield from App::renderStream('shell-open', ['title' => 'Users']);
-     *       yield from App::renderStream('users/list', ['users' => $users]);
-     *       yield from App::renderStream('shell-close');
-     *   })();
+     *
+     * ```php
+     * return (function() {
+     *     yield from App::renderStream('shell-open', ['title' => 'Users']);
+     *     yield from App::renderStream('users/list', ['users' => $users]);
+     *     yield from App::renderStream('shell-close');
+     * })();
+     * ```
      *
      * @see App::executeFile() (private core) and the sibling methods (render / renderToString / include).
      *

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -12,14 +12,17 @@ namespace ZealPHP;
  * back to file. TTL-based expiry with lazy cleanup + periodic GC timer.
  *
  * Usage:
- *   // Before $app->run():
- *   Cache::init();
  *
- *   // Anywhere (any worker):
- *   Cache::set('user:42', $profile, ttl: 300);
- *   $profile = Cache::get('user:42');
- *   Cache::has('user:42');
- *   Cache::del('user:42');
+ * ```php
+ * // Before $app->run():
+ * Cache::init();
+ *
+ * // Anywhere (any worker):
+ * Cache::set('user:42', $profile, ttl: 300);
+ * $profile = Cache::get('user:42');
+ * Cache::has('user:42');
+ * Cache::del('user:42');
+ * ```
  *
  * LIMITATIONS — when to use Redis/Valkey instead:
  *   - Multi-server: Cache is per-server. Redis shares state across machines.

--- a/src/Counter.php
+++ b/src/Counter.php
@@ -12,21 +12,24 @@ namespace ZealPHP;
  * is inherited by all forked workers.
  *
  * Usage:
- *   // Before `app->run()`:
- *   `$hits    = new Counter();`
- *   `$errors  = new Counter(0);`
- *   `$version = new Counter(1);`
  *
- *   // Anywhere (all workers share the same value):
- *   `$hits->increment();`          // +1, returns new value
- *   `$hits->increment(5);`         // +5
- *   `$hits->decrement();`          // -1
- *   `$hits->get();`                // current value
- *   `$hits->set(0);`               // force-set (not atomic vs concurrent reads)
- *   `$hits->reset();`              // alias for `set(0)`
+ * ```php
+ * // Before $app->run():
+ * $hits    = new Counter();
+ * $errors  = new Counter(0);
+ * $version = new Counter(1);
  *
- *   // Conditional update (compare-and-swap):
- *   `$hits->compareAndSet($expected, $new);` // returns bool
+ * // Anywhere (all workers share the same value):
+ * $hits->increment();          // +1, returns new value
+ * $hits->increment(5);         // +5
+ * $hits->decrement();          // -1
+ * $hits->get();                // current value
+ * $hits->set(0);               // force-set (not atomic vs concurrent reads)
+ * $hits->reset();              // alias for set(0)
+ *
+ * // Conditional update (compare-and-swap):
+ * $hits->compareAndSet($expected, $new); // returns bool
+ * ```
  */
 class Counter
 {

--- a/src/GithubStars.php
+++ b/src/GithubStars.php
@@ -13,11 +13,18 @@ namespace ZealPHP;
  * remote GitHub call.
  *
  * Usage:
- *   In `app.php` boot, before `$app->run()`:
- *     `\ZealPHP\GithubStars::register('sibidharan/zealphp');`
  *
- *   In templates / route handlers:
- *     `<span>★ <?= htmlspecialchars(\ZealPHP\GithubStars::format()) ?></span>`
+ * In `app.php` boot, before `$app->run()`:
+ *
+ * ```php
+ * \ZealPHP\GithubStars::register('sibidharan/zealphp');
+ * ```
+ *
+ * In templates / route handlers:
+ *
+ * ```php
+ * <span>★ <?= htmlspecialchars(\ZealPHP\GithubStars::format()) ?></span>
+ * ```
  */
 final class GithubStars
 {

--- a/src/Middleware/BasicAuthMiddleware.php
+++ b/src/Middleware/BasicAuthMiddleware.php
@@ -42,17 +42,19 @@ use ZealPHP\RequestContext;
  *
  * Usage in `app.php`:
  *
- *   // File-based
- *   $app->addMiddleware(new \ZealPHP\Middleware\BasicAuthMiddleware(
- *       htpasswdFile: '/etc/zealphp/.htpasswd',
- *       realm:        'Admin Area',
- *   ));
+ * ```php
+ * // File-based
+ * $app->addMiddleware(new \ZealPHP\Middleware\BasicAuthMiddleware(
+ *     htpasswdFile: '/etc/zealphp/.htpasswd',
+ *     realm:        'Admin Area',
+ * ));
  *
- *   // Callback-based (e.g. validate against your DB)
- *   $app->addMiddleware(new \ZealPHP\Middleware\BasicAuthMiddleware(
- *       verify: fn(string $u, string $p): bool => User::verify($u, $p),
- *       realm:  'API',
- *   ));
+ * // Callback-based (e.g. validate against your DB)
+ * $app->addMiddleware(new \ZealPHP\Middleware\BasicAuthMiddleware(
+ *     verify: fn(string $u, string $p): bool => User::verify($u, $p),
+ *     realm:  'API',
+ * ));
+ * ```
  */
 class BasicAuthMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/BlockPhpExtMiddleware.php
+++ b/src/Middleware/BlockPhpExtMiddleware.php
@@ -18,8 +18,11 @@ use Psr\Http\Server\RequestHandlerInterface;
  * exists.
  *
  * Apache equivalent — the classic `.htaccess` pattern:
- *   `RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s([^.]+)\.php [NC]`
- *   `RewriteRule ^ - [R=404,L]`
+ *
+ * ```
+ * RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s([^.]+)\.php [NC]
+ * RewriteRule ^ - [R=404,L]
+ * ```
  *
  * nginx equivalent:
  *   `location ~ \.php$ { return 404; }`

--- a/src/Middleware/BodyRewriteMiddleware.php
+++ b/src/Middleware/BodyRewriteMiddleware.php
@@ -32,10 +32,12 @@ use ZealPHP\RequestContext;
  *
  * Usage in `app.php`:
  *
- *   $app->addMiddleware(new \ZealPHP\Middleware\BodyRewriteMiddleware([
- *       ['pattern' => '#http://internal\.lan#', 'replacement' => 'https://example.com'],
- *       ['pattern' => '/Powered by Old/i',      'replacement' => 'Powered by ZealPHP'],
- *   ]));
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\BodyRewriteMiddleware([
+ *     ['pattern' => '#http://internal\.lan#', 'replacement' => 'https://example.com'],
+ *     ['pattern' => '/Powered by Old/i',      'replacement' => 'Powered by ZealPHP'],
+ * ]));
+ * ```
  */
 class BodyRewriteMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/CacheControlMiddleware.php
+++ b/src/Middleware/CacheControlMiddleware.php
@@ -17,15 +17,21 @@ use ZealPHP\RequestContext;
  * `.htaccess` pattern for "tell the browser to cache static assets for 30 days".
  *
  * Apache equivalent:
- *   `<FilesMatch "\.(css|js|jpe?g|png|gif|svg|ico|woff2?)$">`
- *       `Header set Cache-Control "max-age=2628000, public"`
- *   `</FilesMatch>`
+ *
+ * ```
+ * <FilesMatch "\.(css|js|jpe?g|png|gif|svg|ico|woff2?)$">
+ *     Header set Cache-Control "max-age=2628000, public"
+ * </FilesMatch>
+ * ```
  *
  * nginx equivalent:
- *   `location ~* \.(css|js|jpe?g|png|gif|svg|ico|woff2?)$ {`
- *       `expires 30d;`
- *       `add_header Cache-Control "public, max-age=2628000";`
- *   `}`
+ *
+ * ```
+ * location ~* \.(css|js|jpe?g|png|gif|svg|ico|woff2?)$ {
+ *     expires 30d;
+ *     add_header Cache-Control "public, max-age=2628000";
+ * }
+ * ```
  *
  * Constructor accepts a map of `extension => max-age-seconds`. Defaults
  * cover the common static-asset extensions at 30 days (`2_628_000`s).
@@ -40,14 +46,16 @@ use ZealPHP\RequestContext;
  *
  * Usage in `app.php`:
  *
- *   // defaults — 30d for css/js/images/fonts
- *   `$app->addMiddleware(new \ZealPHP\Middleware\CacheControlMiddleware());`
+ * ```php
+ * // defaults — 30d for css/js/images/fonts
+ * $app->addMiddleware(new \ZealPHP\Middleware\CacheControlMiddleware());
  *
- *   // custom: 1y for fingerprinted hashes, 5m for HTML
- *   `$app->addMiddleware(new \ZealPHP\Middleware\CacheControlMiddleware([`
- *       `'css' => 31536000, 'js' => 31536000, 'woff2' => 31536000,`
- *       `'html' => 300,`
- *   `]));`
+ * // custom: 1y for fingerprinted hashes, 5m for HTML
+ * $app->addMiddleware(new \ZealPHP\Middleware\CacheControlMiddleware([
+ *     'css' => 31536000, 'js' => 31536000, 'woff2' => 31536000,
+ *     'html' => 300,
+ * ]));
+ * ```
  */
 class CacheControlMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/CharsetMiddleware.php
+++ b/src/Middleware/CharsetMiddleware.php
@@ -18,12 +18,18 @@ use ZealPHP\RequestContext;
  * …) when the `Content-Type` doesn't already declare a charset.
  *
  * Apache equivalent:
- *   `AddDefaultCharset utf-8`
- *   `AddCharset utf-8 .html .css .js .json`
+ *
+ * ```
+ * AddDefaultCharset utf-8
+ * AddCharset utf-8 .html .css .js .json
+ * ```
  *
  * Usage in `app.php`:
- *   `$app->addMiddleware(new \ZealPHP\Middleware\CharsetMiddleware());`          // utf-8
- *   `$app->addMiddleware(new \ZealPHP\Middleware\CharsetMiddleware('iso-8859-1'));`
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\CharsetMiddleware());          // utf-8
+ * $app->addMiddleware(new \ZealPHP\Middleware\CharsetMiddleware('iso-8859-1'));
+ * ```
  */
 class CharsetMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ConcurrencyLimitMiddleware.php
+++ b/src/Middleware/ConcurrencyLimitMiddleware.php
@@ -46,33 +46,39 @@ use ZealPHP\Store;
  *
  * Usage — global mode (existing API, no change):
  *
- *   $inflight = new \ZealPHP\Counter();
- *   $app->addMiddleware(new \ZealPHP\Middleware\ConcurrencyLimitMiddleware(
- *       maxConcurrent: 100,
- *       counter:       $inflight,
- *   ));
+ * ```php
+ * $inflight = new \ZealPHP\Counter();
+ * $app->addMiddleware(new \ZealPHP\Middleware\ConcurrencyLimitMiddleware(
+ *     maxConcurrent: 100,
+ *     counter:       $inflight,
+ * ));
+ * ```
  *
  * Usage — per-key mode (nginx limit_conn parity):
  *
- *   Store::make('conn_limit', 4096, [
- *       'count' => [\OpenSwoole\Table::TYPE_INT, 4],
- *   ]);
+ * ```php
+ * Store::make('conn_limit', 4096, [
+ *     'count' => [\OpenSwoole\Table::TYPE_INT, 4],
+ * ]);
  *
- *   $app->addMiddleware(new \ZealPHP\Middleware\ConcurrencyLimitMiddleware(
- *       maxConcurrent: 20,
- *       counter:       null,          // no global counter
- *       tableName:     'conn_limit',  // per-key Store table
- *   ));
+ * $app->addMiddleware(new \ZealPHP\Middleware\ConcurrencyLimitMiddleware(
+ *     maxConcurrent: 20,
+ *     counter:       null,          // no global counter
+ *     tableName:     'conn_limit',  // per-key Store table
+ * ));
+ * ```
  *
  * Usage — per-key + global cap together:
  *
- *   $global = new \ZealPHP\Counter();
- *   $app->addMiddleware(new \ZealPHP\Middleware\ConcurrencyLimitMiddleware(
- *       maxConcurrent: 20,     // per-key cap
- *       counter:       $global, // also enforce global cap (separate Counter)
- *       tableName:     'conn_limit',
- *       globalMax:     500,    // global ceiling across all clients
- *   ));
+ * ```php
+ * $global = new \ZealPHP\Counter();
+ * $app->addMiddleware(new \ZealPHP\Middleware\ConcurrencyLimitMiddleware(
+ *     maxConcurrent: 20,     // per-key cap
+ *     counter:       $global, // also enforce global cap (separate Counter)
+ *     tableName:     'conn_limit',
+ *     globalMax:     500,    // global ceiling across all clients
+ * ));
+ * ```
  *
  * Options:
  *   `rejectStatus`  int           HTTP status on rejection (`400`–`599`, default `503`)

--- a/src/Middleware/ContentEncodingMiddleware.php
+++ b/src/Middleware/ContentEncodingMiddleware.php
@@ -32,11 +32,14 @@ use ZealPHP\RequestContext;
  *   `AddEncoding br       .br`
  *
  * Usage in `app.php`:
- *   $app->addMiddleware(new \ZealPHP\Middleware\ContentEncodingMiddleware([
- *       'gz'  => 'gzip',
- *       'br'  => 'br',
- *       'bz2' => 'bzip2',
- *   ]));
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\ContentEncodingMiddleware([
+ *     'gz'  => 'gzip',
+ *     'br'  => 'br',
+ *     'bz2' => 'bzip2',
+ * ]));
+ * ```
  */
 class ContentEncodingMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ContentLanguageMiddleware.php
+++ b/src/Middleware/ContentLanguageMiddleware.php
@@ -30,11 +30,14 @@ use ZealPHP\RequestContext;
  *   `AddLanguage de .de`
  *
  * Usage in `app.php`:
- *   $app->addMiddleware(new \ZealPHP\Middleware\ContentLanguageMiddleware([
- *       'en' => 'en',
- *       'fr' => 'fr',
- *       'de' => 'de',
- *   ]));
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\ContentLanguageMiddleware([
+ *     'en' => 'en',
+ *     'fr' => 'fr',
+ *     'de' => 'de',
+ * ]));
+ * ```
  */
 class ContentLanguageMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ExpiresMiddleware.php
+++ b/src/Middleware/ExpiresMiddleware.php
@@ -19,10 +19,13 @@ use ZealPHP\RequestContext;
  * common in migrated `.htaccess` files that the name parity matters.
  *
  * Apache equivalent:
- *   `ExpiresActive On`
- *   `ExpiresDefault                    "access plus 5 minutes"`
- *   `ExpiresByType image/jpeg          "access plus 1 month"`
- *   `ExpiresByType text/css            "access plus 1 year"`
+ *
+ * ```
+ * ExpiresActive On
+ * ExpiresDefault                    "access plus 5 minutes"
+ * ExpiresByType image/jpeg          "access plus 1 month"
+ * ExpiresByType text/css            "access plus 1 year"
+ * ```
  *
  * Constructor takes a `Content-Type` prefix => relative-date map. Values are
  * parsed by `strtotime()` so any of these forms work:
@@ -60,30 +63,32 @@ use ZealPHP\RequestContext;
  *
  * Usage in `app.php`:
  *
- *   // Access-time base, `Expires` header only (legacy compat):
- *   `$app->addMiddleware(new \ZealPHP\Middleware\ExpiresMiddleware(`
- *       `byType: [`
- *           `'image/'           => '+30 days',`
- *           `'text/css'         => '+1 year',`
- *           `'text/javascript'  => '+1 year',`
- *           `'font/'            => '+1 year',`
- *       `],`
- *       `default: '+5 minutes',`
- *   `));`
+ * ```php
+ * // Access-time base, Expires header only (legacy compat):
+ * $app->addMiddleware(new \ZealPHP\Middleware\ExpiresMiddleware(
+ *     byType: [
+ *         'image/'           => '+30 days',
+ *         'text/css'         => '+1 year',
+ *         'text/javascript'  => '+1 year',
+ *         'font/'            => '+1 year',
+ *     ],
+ *     default: '+5 minutes',
+ * ));
  *
- *   // Apache-parity: both `Expires` + `Cache-Control: max-age` from one rule:
- *   `$app->addMiddleware(new \ZealPHP\Middleware\ExpiresMiddleware(`
- *       `byType: ['image/' => '+30 days', 'text/css' => '+1 year'],`
- *       `default: '+5 minutes',`
- *       `emitCacheControl: true,`
- *   `));`
+ * // Apache-parity: both Expires + Cache-Control: max-age from one rule:
+ * $app->addMiddleware(new \ZealPHP\Middleware\ExpiresMiddleware(
+ *     byType: ['image/' => '+30 days', 'text/css' => '+1 year'],
+ *     default: '+5 minutes',
+ *     emitCacheControl: true,
+ * ));
  *
- *   // `M` (modification-time) base — expiry relative to `Last-Modified`:
- *   `$app->addMiddleware(new \ZealPHP\Middleware\ExpiresMiddleware(`
- *       `byType: ['text/html' => '+5 minutes'],`
- *       `base: 'M',`
- *       `emitCacheControl: true,`
- *   `));`
+ * // M (modification-time) base — expiry relative to Last-Modified:
+ * $app->addMiddleware(new \ZealPHP\Middleware\ExpiresMiddleware(
+ *     byType: ['text/html' => '+5 minutes'],
+ *     base: 'M',
+ *     emitCacheControl: true,
+ * ));
+ * ```
  *
  * Match is by `Content-Type` prefix (first match wins, longest-prefix-first
  * for determinism). `default` applies when no prefix matches; pass `null`

--- a/src/Middleware/HeaderMiddleware.php
+++ b/src/Middleware/HeaderMiddleware.php
@@ -18,14 +18,20 @@ use ZealPHP\RequestContext;
  * response without sprinkling `$response->header(...)` calls through handlers.
  *
  * Apache equivalent (`mod_headers`):
- *   `Header set X-Frame-Options "DENY"`
- *   `Header append Vary "Accept-Encoding"`
- *   `Header unset Server`
- *   `Header add Set-Cookie "..."`
+ *
+ * ```
+ * Header set X-Frame-Options "DENY"
+ * Header append Vary "Accept-Encoding"
+ * Header unset Server
+ * Header add Set-Cookie "..."
+ * ```
  *
  * nginx equivalent:
- *   `add_header X-Frame-Options "DENY" always;`
- *   `more_clear_headers Server;`   # `ngx_headers_more` module
+ *
+ * ```
+ * add_header X-Frame-Options "DENY" always;
+ * more_clear_headers Server;   # ngx_headers_more module
+ * ```
  *
  * ## Status-conditional application (nginx parity)
  *
@@ -64,29 +70,33 @@ use ZealPHP\RequestContext;
  *
  * Usage in `app.php` — current default (all-status, BC-safe):
  *
- *   `$app->addMiddleware(new \ZealPHP\Middleware\HeaderMiddleware([`
- *       `'set' => [`
- *           `'X-Frame-Options'            => 'DENY',`
- *           `'X-Content-Type-Options'     => 'nosniff',`
- *           `'Referrer-Policy'            => 'strict-origin-when-cross-origin',`
- *           `'Strict-Transport-Security'  => 'max-age=31536000; includeSubDomains',`
- *           `'Content-Security-Policy'    => "default-src 'self'",`
- *       `],`
- *       `'append' => ['Vary' => 'Accept-Encoding'],`
- *       `'unset'  => ['Server', 'X-Powered-By'],`
- *   `]));`
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\HeaderMiddleware([
+ *     'set' => [
+ *         'X-Frame-Options'            => 'DENY',
+ *         'X-Content-Type-Options'     => 'nosniff',
+ *         'Referrer-Policy'            => 'strict-origin-when-cross-origin',
+ *         'Strict-Transport-Security'  => 'max-age=31536000; includeSubDomains',
+ *         'Content-Security-Policy'    => "default-src 'self'",
+ *     ],
+ *     'append' => ['Vary' => 'Accept-Encoding'],
+ *     'unset'  => ['Server', 'X-Powered-By'],
+ * ]));
+ * ```
  *
  * Usage with nginx semantics (skip on error responses unless `always=true`):
  *
- *   `$app->addMiddleware(new \ZealPHP\Middleware\HeaderMiddleware([`
- *       `'set' => [`
- *           // Skipped on 4xx/5xx (nginx default behaviour).
- *           `'Cache-Control' => 'no-cache',`
- *           // Always applied even on error responses.
- *           `'X-Frame-Options' => ['value' => 'DENY', 'always' => true],`
- *       `],`
- *       `'unset' => ['Server'],`   // `unset` is always unconditional
- *   `], alwaysByDefault: false));`
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\HeaderMiddleware([
+ *     'set' => [
+ *         // Skipped on 4xx/5xx (nginx default behaviour).
+ *         'Cache-Control' => 'no-cache',
+ *         // Always applied even on error responses.
+ *         'X-Frame-Options' => ['value' => 'DENY', 'always' => true],
+ *     ],
+ *     'unset' => ['Server'],   // unset is always unconditional
+ * ], alwaysByDefault: false));
+ * ```
  */
 class HeaderMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/IpAccessMiddleware.php
+++ b/src/Middleware/IpAccessMiddleware.php
@@ -18,13 +18,19 @@ use ZealPHP\RequestContext;
  * — useful to express "allow everyone except deny list" or "deny by default".
  *
  * Apache 2.2 equivalent (legacy):
- *   `Order Deny,Allow`
- *   `Deny from all`
- *   `Allow from 10.0.0.0/8 127.0.0.1`
+ *
+ * ```
+ * Order Deny,Allow
+ * Deny from all
+ * Allow from 10.0.0.0/8 127.0.0.1
+ * ```
  *
  * Apache 2.4+ / nginx equivalent:
- *   `Require ip 10.0.0.0/8 127.0.0.1`     (Apache 2.4+)
- *   `allow 10.0.0.0/8; allow 127.0.0.1; deny all;`   (nginx)
+ *
+ * ```
+ * Require ip 10.0.0.0/8 127.0.0.1                  # Apache 2.4+
+ * allow 10.0.0.0/8; allow 127.0.0.1; deny all;     # nginx
+ * ```
  *
  * Resolution rules:
  *   1. If `deny` matches the IP → `403` (deny wins ties)
@@ -43,17 +49,19 @@ use ZealPHP\RequestContext;
  *
  * Usage in `app.php`:
  *
- *   // Allow only office network and CI
- *   `$app->addMiddleware(new \ZealPHP\Middleware\IpAccessMiddleware([`
- *       `'allow' => ['203.0.113.0/24', '198.51.100.42'],`
- *       `'deny'  => [],`
- *   `]));`
+ * ```php
+ * // Allow only office network and CI
+ * $app->addMiddleware(new \ZealPHP\Middleware\IpAccessMiddleware([
+ *     'allow' => ['203.0.113.0/24', '198.51.100.42'],
+ *     'deny'  => [],
+ * ]));
  *
- *   // Block a specific abuser, allow the rest
- *   `$app->addMiddleware(new \ZealPHP\Middleware\IpAccessMiddleware([`
- *       `'allow' => ['*'],`
- *       `'deny'  => ['1.2.3.4'],`
- *   `]));`
+ * // Block a specific abuser, allow the rest
+ * $app->addMiddleware(new \ZealPHP\Middleware\IpAccessMiddleware([
+ *     'allow' => ['*'],
+ *     'deny'  => ['1.2.3.4'],
+ * ]));
+ * ```
  */
 class IpAccessMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/MimeTypeMiddleware.php
+++ b/src/Middleware/MimeTypeMiddleware.php
@@ -31,20 +31,25 @@ use ZealPHP\RequestContext;
  * based `Content-Type` negotiation.
  *
  * Apache equivalent:
- *   `AddType application/wasm           .wasm`
- *   `AddType model/gltf-binary          .glb`
- *   `AddType model/vnd.usdz+zip         .usdz`
+ *
+ * ```
+ * AddType application/wasm           .wasm
+ * AddType model/gltf-binary          .glb
+ * AddType model/vnd.usdz+zip         .usdz
+ * ```
  *
  * Only fires when the upstream response has no `Content-Type` — explicit
  * `$response->header('Content-Type', ...)` calls in the handler always win.
  *
  * Usage in `app.php`:
  *
- *   `$app->addMiddleware(new \ZealPHP\Middleware\MimeTypeMiddleware([`
- *       `'wasm' => 'application/wasm',`
- *       `'glb'  => 'model/gltf-binary',`
- *       `'usdz' => 'model/vnd.usdz+zip',`
- *   `]));`
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\MimeTypeMiddleware([
+ *     'wasm' => 'application/wasm',
+ *     'glb'  => 'model/gltf-binary',
+ *     'usdz' => 'model/vnd.usdz+zip',
+ * ]));
+ * ```
  */
 class MimeTypeMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/RangeMiddleware.php
+++ b/src/Middleware/RangeMiddleware.php
@@ -37,9 +37,12 @@ use ZealPHP\RequestContext;
  *   `$app->addMiddleware(new \ZealPHP\Middleware\RangeMiddleware());`
  *
  * To raise or lower the per-request range cap:
- *   `$mw = new \ZealPHP\Middleware\RangeMiddleware();`
- *   `$mw->maxRanges = 50;`
- *   `$app->addMiddleware($mw);`
+ *
+ * ```php
+ * $mw = new \ZealPHP\Middleware\RangeMiddleware();
+ * $mw->maxRanges = 50;
+ * $app->addMiddleware($mw);
+ * ```
  */
 class RangeMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/RedirectMiddleware.php
+++ b/src/Middleware/RedirectMiddleware.php
@@ -25,10 +25,13 @@ use Psr\Http\Server\RequestHandlerInterface;
  * target doesn't carry its own), matching mod_alias.
  *
  * Usage in app.php:
- *   $app->addMiddleware(new \ZealPHP\Middleware\RedirectMiddleware([
- *       ['from' => '/old', 'to' => '/new', 'status' => 301],
- *       ['match' => '#^/blog/(\d+)$#', 'to' => '/posts/$1', 'status' => 302],
- *   ]));
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\RedirectMiddleware([
+ *     ['from' => '/old', 'to' => '/new', 'status' => 301],
+ *     ['match' => '#^/blog/(\d+)$#', 'to' => '/posts/$1', 'status' => 302],
+ * ]));
+ * ```
  */
 class RedirectMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/RefererMiddleware.php
+++ b/src/Middleware/RefererMiddleware.php
@@ -37,10 +37,13 @@ use Psr\Http\Server\RequestHandlerInterface;
  * and `allowBlocked` to tune the none/blocked token behaviour.
  *
  * Usage in app.php:
- *   $app->addMiddleware(new \ZealPHP\Middleware\RefererMiddleware(
- *       ['example.com', '*.example.com', '~\.google\.'],
- *       serverNames: ['myapp.example.com'],
- *   ));
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\RefererMiddleware(
+ *     ['example.com', '*.example.com', '~\.google\.'],
+ *     serverNames: ['myapp.example.com'],
+ * ));
+ * ```
  */
 class RefererMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/RequestHeaderMiddleware.php
+++ b/src/Middleware/RequestHeaderMiddleware.php
@@ -24,10 +24,13 @@ use ZealPHP\RequestContext;
  *   - `unset`          — remove the header
  *
  * Usage in app.php:
- *   $app->addMiddleware(new \ZealPHP\Middleware\RequestHeaderMiddleware([
- *       ['op' => 'set',    'name' => 'X-Forwarded-Proto', 'value' => 'https'],
- *       ['op' => 'unset',  'name' => 'X-Debug'],
- *   ]));
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\RequestHeaderMiddleware([
+ *     ['op' => 'set',    'name' => 'X-Forwarded-Proto', 'value' => 'https'],
+ *     ['op' => 'unset',  'name' => 'X-Debug'],
+ * ]));
+ * ```
  */
 class RequestHeaderMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ReturnMiddleware.php
+++ b/src/Middleware/ReturnMiddleware.php
@@ -24,8 +24,11 @@ use Psr\Http\Server\RequestHandlerInterface;
  * (`Location`); for any other status it is the response body.
  *
  * Usage in app.php:
- *   $app->addMiddleware(ScopedMiddleware::location(new ReturnMiddleware(403), '/blocked'));
- *   $app->addMiddleware(ScopedMiddleware::match(new ReturnMiddleware(301, '/new'), '#^/old$#'));
+ *
+ * ```php
+ * $app->addMiddleware(ScopedMiddleware::location(new ReturnMiddleware(403), '/blocked'));
+ * $app->addMiddleware(ScopedMiddleware::match(new ReturnMiddleware(301, '/new'), '#^/old$#'));
+ * ```
  */
 class ReturnMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ScopedMiddleware.php
+++ b/src/Middleware/ScopedMiddleware.php
@@ -27,8 +27,11 @@ use Psr\Http\Server\RequestHandlerInterface;
  * continue via the handler.
  *
  * Usage in app.php:
- *   $app->addMiddleware(ScopedMiddleware::location(new BasicAuthMiddleware(...), '/admin'));
- *   $app->addMiddleware(ScopedMiddleware::match(new BlockPhpExtMiddleware(), '#\.php$#'));
+ *
+ * ```php
+ * $app->addMiddleware(ScopedMiddleware::location(new BasicAuthMiddleware(...), '/admin'));
+ * $app->addMiddleware(ScopedMiddleware::match(new BlockPhpExtMiddleware(), '#\.php$#'));
+ * ```
  */
 final class ScopedMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/SetEnvIfMiddleware.php
+++ b/src/Middleware/SetEnvIfMiddleware.php
@@ -23,15 +23,21 @@ use ZealPHP\RequestContext;
  * `User-Agent` gives `BrowserMatch` behavior).
  *
  * Apache equivalent:
- *   SetEnvIf User-Agent "bot" IS_BOT=1
- *   SetEnvIf Request_URI "^/admin" ADMIN_AREA=1
- *   BrowserMatch "MSIE" old_browser=1
+ *
+ * ```
+ * SetEnvIf User-Agent "bot" IS_BOT=1
+ * SetEnvIf Request_URI "^/admin" ADMIN_AREA=1
+ * BrowserMatch "MSIE" old_browser=1
+ * ```
  *
  * Usage in app.php:
- *   $app->addMiddleware(new \ZealPHP\Middleware\SetEnvIfMiddleware([
- *       ['attr' => 'User-Agent',  'regex' => '#bot#i',     'set' => ['IS_BOT' => '1']],
- *       ['attr' => 'Request_URI', 'regex' => '#^/admin#',  'set' => ['ADMIN_AREA' => '1']],
- *   ]));
+ *
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\SetEnvIfMiddleware([
+ *     ['attr' => 'User-Agent',  'regex' => '#bot#i',     'set' => ['IS_BOT' => '1']],
+ *     ['attr' => 'Request_URI', 'regex' => '#^/admin#',  'set' => ['ADMIN_AREA' => '1']],
+ * ]));
+ * ```
  */
 class SetEnvIfMiddleware implements MiddlewareInterface
 {

--- a/src/Store.php
+++ b/src/Store.php
@@ -17,23 +17,26 @@ namespace ZealPHP;
  *   `\OpenSwoole\Table::TYPE_STRING` — up to N bytes (specify max length)
  *
  * Usage:
- *   // Before `app->run()`:
- *   `Store::make('sessions', 4096, [
- *       'uid'  => [\OpenSwoole\Table::TYPE_STRING, 64],
- *       'room' => [\OpenSwoole\Table::TYPE_STRING, 32],
- *       'hits' => [\OpenSwoole\Table::TYPE_INT,    4],
- *   ]);`
  *
- *   // Anywhere (all workers share the same data):
- *   `Store::set('sessions', $fd, ['uid' => 'alice', 'room' => 'general', 'hits' => 0]);`
- *   `Store::get('sessions', $fd);`        // `['uid' => 'alice', ...]`
- *   `Store::incr('sessions', $fd, 'hits');`
- *   `Store::del('sessions', $fd);`
- *   `Store::count('sessions');`
+ * ```php
+ * // Before $app->run():
+ * Store::make('sessions', 4096, [
+ *     'uid'  => [\OpenSwoole\Table::TYPE_STRING, 64],
+ *     'room' => [\OpenSwoole\Table::TYPE_STRING, 32],
+ *     'hits' => [\OpenSwoole\Table::TYPE_INT,    4],
+ * ]);
  *
- *   // Or use the `Table` object directly:
- *   `$t = Store::table('sessions');`
- *   `foreach ($t as $key => $row) { ... }`
+ * // Anywhere (all workers share the same data):
+ * Store::set('sessions', $fd, ['uid' => 'alice', 'room' => 'general', 'hits' => 0]);
+ * Store::get('sessions', $fd);        // ['uid' => 'alice', ...]
+ * Store::incr('sessions', $fd, 'hits');
+ * Store::del('sessions', $fd);
+ * Store::count('sessions');
+ *
+ * // Or use the Table object directly:
+ * $t = Store::table('sessions');
+ * foreach ($t as $key => $row) { ... }
+ * ```
  */
 class Store
 {

--- a/src/utils.php
+++ b/src/utils.php
@@ -344,18 +344,20 @@ function log_write(string $message, string $kind = 'debug'): void
  *
  * Example (3 parallel HTTP fetches from a sequential worker):
  *
- *     $json = coprocess(function () {
- *         $chan = new \OpenSwoole\Coroutine\Channel(3);
- *         foreach (['a','b','c'] as $svc) {
- *             go(function () use ($svc, $chan) {
- *                 $chan->push([$svc => file_get_contents("https://api/$svc")]);
- *             });
- *         }
- *         $out = [];
- *         for ($i = 0; $i < 3; $i++) { $out += $chan->pop(); }
- *         echo json_encode($out);            // returned to the caller as a string
- *     });
- *     $data = json_decode($json, true);
+ * ```php
+ * $json = coprocess(function () {
+ *     $chan = new \OpenSwoole\Coroutine\Channel(3);
+ *     foreach (['a','b','c'] as $svc) {
+ *         go(function () use ($svc, $chan) {
+ *             $chan->push([$svc => file_get_contents("https://api/$svc")]);
+ *         });
+ *     }
+ *     $out = [];
+ *     for ($i = 0; $i < 3; $i++) { $out += $chan->pop(); }
+ *     echo json_encode($out);            // returned to the caller as a string
+ * });
+ * $data = json_decode($json, true);
+ * ```
  *
  * @param callable $taskLogic The logic to run in the coroutine-enabled child.
  *                            Receives the `OpenSwoole\Process` as its argument.

--- a/template/pages/docs/_sidebar.php
+++ b/template/pages/docs/_sidebar.php
@@ -55,7 +55,7 @@ $apiChip = 'phpdoc';
              hx-push-url="/docs/">All docs<?php if ($current === null): ?><span class="learn-sidebar-chip">home</span><?php endif; ?></a>
         </li>
         <li class="learn-sidebar-item<?= $current === '__api__' ? ' active' : '' ?>" data-num="•">
-          <a href="/docs/api/" class="learn-sidebar-link" hx-boost="false">API Reference<span class="learn-sidebar-chip"><?= htmlspecialchars($apiChip) ?></span></a>
+          <a href="/docs/api/" class="learn-sidebar-link">API Reference<span class="learn-sidebar-chip"><?= htmlspecialchars($apiChip) ?></span></a>
         </li>
       </ul>
     </div>

--- a/template/pages/docs/api-index.php
+++ b/template/pages/docs/api-index.php
@@ -42,7 +42,7 @@ $classCount = array_sum(array_map('count', $apiGroups));
           <ul class="api-index-list">
             <?php foreach ($classes as $cls): ?>
               <li>
-                <a class="api-index-link" href="<?= htmlspecialchars($cls['href'], ENT_QUOTES) ?>" hx-boost="false">
+                <a class="api-index-link" href="<?= htmlspecialchars($cls['href'], ENT_QUOTES) ?>">
                   <code><?= htmlspecialchars($cls['label'], ENT_QUOTES) ?></code>
                 </a>
               </li>

--- a/template/pages/docs/api-wrapped.php
+++ b/template/pages/docs/api-wrapped.php
@@ -37,7 +37,7 @@ $v = defined('ZEALPHP_ASSET_VERSION') ? ZEALPHP_ASSET_VERSION : '';
         <?php foreach ($apiCrumb as $i => $seg): ?>
           <?php if ($i > 0): ?><span class="sep">›</span><?php endif; ?>
           <?php if (!empty($seg['href'])): ?>
-            <a href="<?= htmlspecialchars($seg['href'], ENT_QUOTES) ?>" hx-boost="false"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></a>
+            <a href="<?= htmlspecialchars($seg['href'], ENT_QUOTES) ?>"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></a>
           <?php else: ?>
             <span class="current"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></span>
           <?php endif; ?>


### PR DESCRIPTION
A batch of API-reference + guide doc fixes reported from the live site.

**1. Docblock usage examples now render as code blocks.** Across ~25 src files, class/method docblock examples were either bare-indented or wrapped per-line in single backticks — both render as prose / choppy inline spans instead of a highlighted block (reported on BasicAuthMiddleware). Wrapped ~30 multi-line examples in proper ` ```php ` fences (bare ` ``` ` for multi-line Apache/nginx config), matching the existing IniIsolationMiddleware style. (3-agent sweep — docblocks were inconsistent between the two styles.)

**2. API ref navigates via htmx, not full reloads.** Curated index links, the sidebar "API Reference" link, and the breadcrumb carried `hx-boost="false"` — a defensive flag from before head-support (#52), now obsolete and causing full refresh + sidebar reset on every API click. Removed: API nav now boosts (sidebar scroll preserved, CSS loads, no refresh).

**3. No more stray amber border on code blocks.** The inline-chip rule leaked onto block `<code>` inside `<pre>`. Added a `pre code` reset (higher specificity) — block code borderless, inline chips keep theirs.

**4. runtime-architecture guide:** added a "Custom CGI backends" subsection (`registerCgiBackend()` with Perl/Python/.cgi examples + mode table, links the FastCGI guide), and clarified `G` is a `class_alias` for `RequestContext` (explains the name + why phpdoc documents it under RequestContext).

Verified live: BasicAuth Usage = dark borderless highlighted block; API links boost (JS + sidebar scroll survive); runtime-arch shows CGI section + G note. `php -l` clean on all 25 src files, PHPStan L10 clean (v2), API docs regenerated.