### PR TITLE
chore(ci): refresh mutation MSI badge to 94%

### DIFF
--- a/.github/badges/mutation.json
+++ b/.github/badges/mutation.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "mutation MSI",
-  "message": "93%",
+  "message": "94%",
   "color": "brightgreen",
   "style": "flat-square"
 }


### PR DESCRIPTION
Supersedes #59. MSI rose to 94% after this session's added tests. The mutation.yml auto-PR can't pass CI (GITHUB_TOKEN doesn't trigger workflows), so re-applying the value as a normal commit. Will close #59.