### PR TITLE
fix(docs): fastcgi-backends API-reference link was a broken GitHub blob

### DIFF
--- a/docs/fastcgi-backends.md
+++ b/docs/fastcgi-backends.md
@@ -152,6 +152,6 @@ fork) instead — see [runtime-architecture.md](runtime-architecture.md) and
 
 - Framework-wide setter: `App::cgiMode()` + `App::fcgiAddress()`
 - Per-extension registry: `App::registerCgiBackend()` / `App::resolveCgiBackend()`
-- FastCGI client: `ZealPHP\Legacy\FastCgiClient` (in the [API reference](../docs/api/))
+- FastCGI client: `ZealPHP\Legacy\FastCgiClient` (in the [API reference](/docs/api/classes/ZealPHP-Legacy-FastCgiClient.html))
 - Runnable demo: `examples/multi-lang-cgi/`
 - Related: [tasks-and-concurrency.md](tasks-and-concurrency.md) (the CGI-mode trade-off table), [runtime-architecture.md](runtime-architecture.md) (lifecycle setters)


### PR DESCRIPTION
The FastCGI guide's Reference section linked the API page as `[(API reference)](../docs/api/)` — MarkdownRenderer rewrites relative non-guide links to GitHub blob URLs, so it resolved to `github.com/.../blob/master/docs/api/` (broken). Changed to an absolute `/docs/api/classes/ZealPHP-Legacy-FastCgiClient.html` (absolute paths untouched by the renderer). Verified live: resolves to the FastCgiClient page (200).