### PR TITLE
fix(site): responsive tables + git-based asset versioning

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -505,14 +505,9 @@ The site uses **htmx** globally. `_master.php` sets `hx-boost="true"` on `<body>
 - Prefer `hx-get`/`hx-post` + `hx-target` + `hx-swap` over custom `fetch()` for standard interactions
 - For server-push (streaming, real-time), use WebSocket (`App::ws()`) or SSE (`$response->sse()`)
 
-### Known Tech Debt (do NOT copy these patterns)
+### Separation of concerns (formerly tech debt — now enforced)
 
-| Anti-pattern | Worst offenders |
-|-------------|----------------|
-| Inline `style=` attributes (~600 total) | `home.php`, `performance.php`, `why-zealphp.php`, `getting-started.php`, `migration.php` |
-| Inline `<script>` blocks | `home.php` (4 blocks, ~100 lines JS), `streaming.php`, `websocket.php`, `timers.php` |
-
-When modifying these files, extract inline JS/CSS to external files rather than adding more inline code.
+The inline `style=` / inline `<script>` tech debt was fully cleared in the Dec-2024 sweep: ~1200 inline styles → `public/css/pages/*.css`, the inline scripts (incl. `home.php`'s 4 blocks and the `_master.php` nav script) → `public/js/{,pages/}*.js`. **Keep it that way** — templates produce HTML only; CSS goes to `public/css/`, JS to `public/js/`. The single allowed `style=` left in `template/` is inside an escaped `<pre><code>` *sample* (displayed code, not a real attribute). Don't reintroduce inline styles/scripts.
 
 ---
 
@@ -549,7 +544,9 @@ template/
     templates.php, legacy-apps.php
 ```
 
-CSS: `public/css/zealphp.css` — single file, CSS variables, amber accent. Legacy pages still have ~600 inline `style=` attrs (tech debt); new code must use CSS classes only.
+CSS: `public/css/zealphp.css` — global stylesheet, CSS variables, amber accent. Page-specific styles live in `public/css/pages/{page-key}.css` (one per template, `$page` slashes→dashes); they're concatenated at boot into `public/css/pages.css` (gitignored, built in `app.php`) and loaded **eagerly** up front in `_head.php` so hx-boost navigation never flashes unstyled content. **No inline `style=`/`<script>` in templates** — the Dec-2024 sweep extracted all ~1200 inline styles + inline scripts into `public/css/pages/*.css` and `public/js/{,pages/}*.js` (the lone remaining `style=` lives inside an escaped `<pre><code>` sample). New code keeps that contract: CSS classes only, JS in `public/js/`.
+
+**Asset cache-busting** — `ZEALPHP_ASSET_VERSION` (defined in `app.php`, used as `?v=…` on every CSS/JS tag in `_head.php`) resolves in order: (1) the **git commit short hash** read straight from `.git/HEAD` — bumps on every commit and is identical for the same commit across deploys, so caches stay valid until a real change; (2) when there's no `.git` (composer installs), the **newest mtime across `public/css` + `public/js`** — so JS-only edits still bust caches, not just `zealphp.css`; (3) boot `time()` as a last resort. There is **no build step** for assets — they're hand-written static files (only `pages.css` is concatenated at boot).
 
 ### Demo API Endpoints
 

--- a/app.php
+++ b/app.php
@@ -25,15 +25,56 @@ if ($tz !== false && $tz !== '') {
 }
 
 // Asset cache-bust key — drives ?v=… on CSS/JS in template/_head.php.
-// Tracks filemtime of the main stylesheet (changes when styling changes); no
-// git dependency (composer installs don't ship .git). Falls back to boot time
-// so a missing file never kills startup.
+// Resolution order (best → fallback):
+//   1. Git commit (read from .git, no shell): bumps on EVERY commit so any
+//      asset change busts caches, and is identical for the same commit across
+//      deploys/nodes — so CDN/browser caches stay valid until a real change.
+//   2. Newest mtime across public/css + public/js (composer installs ship no
+//      .git): covers ALL assets, so JS-only edits bust too — not just one file.
+//   3. Boot time: last resort, so a missing source never kills startup.
 if (!defined('ZEALPHP_ASSET_VERSION')) {
-    $assetSource = __DIR__ . '/public/css/zealphp.css';
-    define(
-        'ZEALPHP_ASSET_VERSION',
-        (string) (is_file($assetSource) ? filemtime($assetSource) : time())
-    );
+    $zealAssetVersion = (static function (string $root): string {
+        // 1. Git commit, read straight from .git (no shell dependency).
+        $head = $root . '/.git/HEAD';
+        if (is_file($head)) {
+            $ref = trim((string) file_get_contents($head));
+            if (str_starts_with($ref, 'ref: ')) {
+                $name    = substr($ref, 5);
+                $refFile = $root . '/.git/' . $name;
+                if (is_file($refFile)) {
+                    return substr(trim((string) file_get_contents($refFile)), 0, 12);
+                }
+                $packed = $root . '/.git/packed-refs';            // packed ref
+                if (is_file($packed)) {
+                    foreach (file($packed, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+                        if (str_ends_with($line, ' ' . $name)) {
+                            return substr($line, 0, 12);
+                        }
+                    }
+                }
+            } elseif (strlen($ref) >= 7) {
+                return substr($ref, 0, 12);                        // detached HEAD = the SHA
+            }
+        }
+        // 2. Newest mtime across all CSS + JS (catches JS-only edits).
+        $newest = 0;
+        foreach (['/public/css', '/public/js'] as $dir) {
+            if (!is_dir($root . $dir)) {
+                continue;
+            }
+            /** @var \SplFileInfo $f */
+            foreach (new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root . $dir, \FilesystemIterator::SKIP_DOTS)
+            ) as $f) {
+                if ($f->isFile()) {
+                    $newest = max($newest, $f->getMTime());
+                }
+            }
+        }
+        return (string) ($newest > 0 ? $newest : time());          // 3. last resort
+    })(__DIR__);
+
+    define('ZEALPHP_ASSET_VERSION', $zealAssetVersion);
 }
 
 // Auto-build the API reference at /docs/api/ on first boot. The build

--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -468,7 +468,7 @@ p  { max-width: 70ch; }
 .badge-feature { background: #fef3c7; color: #92400e; }
 
 /* ── Table ── */
-.ztable { width: 100%; border-collapse: collapse; font-size: .875rem; margin: 1rem 0; }
+.ztable { display: block; width: max-content; max-width: 100%; overflow-x: auto; border-collapse: collapse; font-size: .875rem; margin: 1rem 0; }
 .ztable th { background: var(--bg-alt); font-weight: 600; padding: .6rem 1rem; text-align: left; border-bottom: 2px solid var(--border); }
 .ztable td { padding: .6rem 1rem; border-bottom: 1px solid var(--border); }
 .ztable tr:last-child td { border-bottom: none; }
@@ -1062,7 +1062,15 @@ pre:hover > .code-copy { opacity: 1; }
 
 /* Tables */
 .docs-markdown table {
-  width: 100%;
+  /* Responsive: size to content but cap at the container width and scroll
+   * horizontally instead of overflowing the page (esp. on mobile). The
+   * display:block + width:max-content + overflow-x:auto trio is the
+   * standard GitHub-markdown approach — the row/cell display values keep
+   * the table layout intact inside the scrollable block. */
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   margin: 1rem 0 1.5rem;
   font-size: .93rem;


### PR DESCRIPTION
**1. Table overflow.** Tables pushed past their container (bad on mobile, sometimes desktop). Applied the GitHub-markdown responsive pattern (`display:block; width:max-content; max-width:100%; overflow-x:auto`) to `.docs-markdown table` + `.ztable` — wide tables scroll horizontally inside their box, page no longer overflows. Verified live.

**2. Asset versioning.** `ZEALPHP_ASSET_VERSION` was `filemtime(zealphp.css)` only → JS-only edits never busted cache, and fresh deploys got non-deterministic (mtime=checkout-time) versions. Now: git commit short hash from `.git/HEAD` (deterministic, bumps per commit) → newest mtime across css+js when no `.git` (composer) → `time()`. Documented in CLAUDE.md (+ cleared the stale inline-style tech-debt note).

Verified: ?v= = 12-char commit hash; PHPStan L10 clean.