### PR TITLE
feat(docs): API ref inline navigation + G discoverable in search/API ref

### DIFF
--- a/api/docs/search.php
+++ b/api/docs/search.php
@@ -101,9 +101,25 @@ $search = function () {
         }
     }
 
-    // Merge — guides first so they appear ahead of API symbols when
-    // both match. Final ordering still goes through the score sort.
-    $combined = array_merge($guides, $index);
+    // `G` is a runtime class_alias of RequestContext (no source declaration),
+    // so phpDocumentor never indexes it — searching "G" would otherwise find
+    // nothing. Prepend a synthetic entry pointing at the RequestContext page.
+    // It MUST come first: "g" is a common substring, so the 100-match
+    // collection ceiling below is hit long before the end of the list —
+    // prepending guarantees it's collected, and its exact-name match scores
+    // 0 so it sorts to the very top.
+    $gAlias = [
+        'fqsen'   => '\\ZealPHP\\G',
+        'name'    => 'G',
+        'summary' => 'Alias of RequestContext — the per-request global state container ($g, G::instance()).',
+        'url'     => '/docs/api/classes/ZealPHP-RequestContext.html',
+        '_kind'   => 'Classes',
+        '_parent' => 'ZealPHP',
+    ];
+
+    // Merge — G alias first, then guides (ahead of API symbols when both
+    // match). Final ordering still goes through the score sort.
+    $combined = array_merge([$gAlias], $guides, $index);
     if (!$combined) {
         $this->response('', 200);
         return;

--- a/route/docs.php
+++ b/route/docs.php
@@ -93,6 +93,14 @@ $app->patternRoute('#^/docs/api(/.*)?$#', function ($response) {
         return null;
     }
 
+    // `G` is a runtime class_alias of RequestContext, so phpDocumentor emits
+    // no ZealPHP-G.html page. Redirect the old short name to the canonical
+    // class page instead of 404ing, so links/searches for `G` resolve.
+    if ($rel === '/classes/ZealPHP-G.html') {
+        $response->redirect('/docs/api/classes/ZealPHP-RequestContext.html', 301);
+        return null;
+    }
+
     $target = $apiRoot . $rel;
     $realTarget = realpath($target);
     if ($realTarget === false

--- a/route/docs.php
+++ b/route/docs.php
@@ -187,7 +187,20 @@ $app->patternRoute('#^/docs/api(/.*)?$#', function ($response) {
             return $base . $val;
         };
         foreach ($xpath->query('.//a[@href]', $mainNode) as $node) {
-            $node->setAttribute('href', $rewriteAttr($node->getAttribute('href')));
+            $href = $rewriteAttr($node->getAttribute('href'));
+            $node->setAttribute('href', $href);
+            // Inline-swap internal API page links (a clean /docs/api/*.html
+            // with no #fragment) so navigating within the reference swaps
+            // .lesson-content in place — no full reload, sidebar preserved —
+            // matching the guide nav. Anchor (#method) links keep plain
+            // behaviour (in-page jumps).
+            if (preg_match('~^/docs/api/[^#?]+\.html$~', $href) === 1) {
+                $node->setAttribute('hx-get', $href);
+                $node->setAttribute('hx-target', '.lesson-content');
+                $node->setAttribute('hx-select', '.lesson-content');
+                $node->setAttribute('hx-swap', 'outerHTML show:.learn-layout:top');
+                $node->setAttribute('hx-push-url', $href);
+            }
         }
         foreach ($xpath->query('.//img[@src]|.//script[@src]', $mainNode) as $node) {
             $node->setAttribute('src', $rewriteAttr($node->getAttribute('src')));

--- a/template/_footer.php
+++ b/template/_footer.php
@@ -7,7 +7,7 @@
     <div class="footer-links">
       <a href="https://github.com/sibidharan/zealphp" target="_blank">GitHub</a>
       <a href="https://github.com/sibidharan/zealphp/issues" target="_blank">Issues</a>
-      <a href="/routing">Docs</a>
+      <a href="/docs/">Docs</a>
       <a href="https://openswoole.com" target="_blank">OpenSwoole</a>
     </div>
   </div>

--- a/template/pages/docs/_sidebar.php
+++ b/template/pages/docs/_sidebar.php
@@ -55,7 +55,12 @@ $apiChip = 'phpdoc';
              hx-push-url="/docs/">All docs<?php if ($current === null): ?><span class="learn-sidebar-chip">home</span><?php endif; ?></a>
         </li>
         <li class="learn-sidebar-item<?= $current === '__api__' ? ' active' : '' ?>" data-num="•">
-          <a href="/docs/api/" class="learn-sidebar-link">API Reference<span class="learn-sidebar-chip"><?= htmlspecialchars($apiChip) ?></span></a>
+          <a href="/docs/api/" class="learn-sidebar-link"
+             hx-get="/docs/api/"
+             hx-target=".lesson-content"
+             hx-select=".lesson-content"
+             hx-swap="outerHTML show:.learn-layout:top"
+             hx-push-url="/docs/api/">API Reference<span class="learn-sidebar-chip"><?= htmlspecialchars($apiChip) ?></span></a>
         </li>
       </ul>
     </div>

--- a/template/pages/docs/api-index.php
+++ b/template/pages/docs/api-index.php
@@ -36,13 +36,23 @@ $classCount = array_sum(array_map('count', $apiGroups));
     </header>
 
     <div class="api-index">
+      <?php
+      // Inline-swap nav (matches the guide sidebar): clicking a class swaps
+      // ONLY .lesson-content — hx-select pulls it out of the class page's
+      // full HTML — so the sidebar/nav/footer stay put and there's no full
+      // page reload. The class page's CSS rides along inside .lesson-content.
+      $apiHx = static fn (string $url): string => 'hx-get="' . htmlspecialchars($url, ENT_QUOTES) . '"'
+          . ' hx-target=".lesson-content" hx-select=".lesson-content"'
+          . ' hx-swap="outerHTML show:.learn-layout:top"'
+          . ' hx-push-url="' . htmlspecialchars($url, ENT_QUOTES) . '"';
+      ?>
       <?php foreach ($apiGroups as $group => $classes): ?>
         <section class="api-index-group">
           <h2 class="api-index-group-title"><?= htmlspecialchars($group, ENT_QUOTES) ?></h2>
           <ul class="api-index-list">
             <?php foreach ($classes as $cls): ?>
               <li>
-                <a class="api-index-link" href="<?= htmlspecialchars($cls['href'], ENT_QUOTES) ?>">
+                <a class="api-index-link" href="<?= htmlspecialchars($cls['href'], ENT_QUOTES) ?>" <?= $apiHx($cls['href']) ?>>
                   <code><?= htmlspecialchars($cls['label'], ENT_QUOTES) ?></code>
                 </a>
               </li>

--- a/template/pages/docs/api-wrapped.php
+++ b/template/pages/docs/api-wrapped.php
@@ -18,10 +18,16 @@
 use ZealPHP\App;
 
 $v = defined('ZEALPHP_ASSET_VERSION') ? ZEALPHP_ASSET_VERSION : '';
-?>
-<link rel="stylesheet" href="<?= htmlspecialchars($apiCssHref, ENT_QUOTES) ?>">
-<link rel="stylesheet" href="/css/docs-api.css?v=<?= $v ?>">
 
+// htmx attributes that make an API link swap ONLY the .lesson-content
+// region in place (like the guide nav) instead of a full reload. hx-select
+// pulls .lesson-content out of the target page's full HTML. Reused for the
+// breadcrumb here and the phpdoc-internal links (rewritten in route/docs.php).
+$apiHxAttrs = static fn (string $url): string => 'hx-get="' . htmlspecialchars($url, ENT_QUOTES) . '"'
+    . ' hx-target=".lesson-content" hx-select=".lesson-content"'
+    . ' hx-swap="outerHTML show:.learn-layout:top"'
+    . ' hx-push-url="' . htmlspecialchars($url, ENT_QUOTES) . '"';
+?>
 <div class="learn-layout docs-api-layout">
   <?php
   // We DO render our docs sidebar even on API pages so users can jump
@@ -30,6 +36,15 @@ $v = defined('ZEALPHP_ASSET_VERSION') ? ZEALPHP_ASSET_VERSION : '';
   ?>
 
   <article class="lesson-content docs-api">
+    <?php
+    // phpDocumentor's stylesheet + our amber overlay live INSIDE the swapped
+    // region so an inline .lesson-content swap (hx-select) carries the API
+    // styling with it — navigating from a guide into the API ref still loads
+    // the CSS without a full page reload. Browsers accept <link> in <body>;
+    // re-inserting the same href on subsequent swaps is served from cache. ?>
+    <link rel="stylesheet" href="<?= htmlspecialchars($apiCssHref, ENT_QUOTES) ?>">
+    <link rel="stylesheet" href="/css/docs-api.css?v=<?= $v ?>">
+
     <?php App::render('/pages/docs/_search'); ?>
 
     <?php $apiCrumb = $apiCrumb ?? []; if (!empty($apiCrumb)): ?>
@@ -37,7 +52,7 @@ $v = defined('ZEALPHP_ASSET_VERSION') ? ZEALPHP_ASSET_VERSION : '';
         <?php foreach ($apiCrumb as $i => $seg): ?>
           <?php if ($i > 0): ?><span class="sep">›</span><?php endif; ?>
           <?php if (!empty($seg['href'])): ?>
-            <a href="<?= htmlspecialchars($seg['href'], ENT_QUOTES) ?>"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></a>
+            <a href="<?= htmlspecialchars($seg['href'], ENT_QUOTES) ?>" <?= $apiHxAttrs($seg['href']) ?>><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></a>
           <?php else: ?>
             <span class="current"><?= htmlspecialchars($seg['label'], ENT_QUOTES) ?></span>
           <?php endif; ?>


### PR DESCRIPTION
Two docs UX improvements.

**1. API reference now navigates inline (htmx swap), like the guides.** Every API click reloaded the whole page — the curated index, breadcrumb, sidebar "API Reference" link, and phpDocumentor's own in-content cross-links. Now they all `hx-get` + `hx-select=".lesson-content"` → swap just the content region (no reload, sidebar/scroll-on-nav preserved). phpdoc's internal `/docs/api/*.html` page links are rewritten with the same attrs in `route/docs.php` (`#anchor` jumps stay plain; fixed a regex-delimiter bug where `#` collided with `[^#?]`). The phpdoc CSS + overlay moved inside `.lesson-content` so an inline swap carries the styling. Verified: index→class and class→class keep JS context (no reload), CSS applies, sidebar persists.

**2. `G` is discoverable.** `G` is a runtime `class_alias` of `RequestContext`, so phpDocumentor never indexed it — searching "G" found nothing and the G URL 404'd. (A real subclass was ruled out: `RequestContextInvariantsTest` pins that instances are `instanceof` *both* names, which only an alias satisfies.) Added a synthetic "G" search entry → RequestContext, and a 301 redirect `/docs/api/classes/ZealPHP-G.html` → RequestContext.

Also: footer "Docs" link pointed at `/routing` → fixed to `/docs/`.

The inline demo login (fetch+reload, learn-demo-viewers.js) is unaffected — it deliberately bypasses htmx; only `HX-Request` flows changed. PHPStan L10 clean; RequestContextInvariantsTest + unit suite green.