### PR TITLE
fix(learn): show validation errors on the inline auth forms (+ teach the htmx 2xx gotcha)

### DIFF
--- a/public/css/learn.css
+++ b/public/css/learn.css
@@ -332,7 +332,9 @@
 .auth-card input { padding: .55rem .7rem; border: 1px solid #d6d3d1; border-radius: 6px; font: inherit; }
 .auth-card button { padding: .55rem 1rem; border: 0; border-radius: 6px; background: var(--accent, #f59e0b); color: #fff; font-weight: 600; cursor: pointer; }
 .auth-card .auth-toggle { background: transparent; color: var(--accent, #f59e0b); border: 1px solid var(--accent, #f59e0b); }
-.auth-error { color: #b91c1c; font-size: .85rem; margin-top: .5rem; }
+/* Specific enough to beat `.auth-card p` / `.lesson-content p` (both 0,1,1),
+   which otherwise repaint the swapped-in error in muted body grey. */
+.lesson-content .auth-error { color: #b91c1c; font-size: .85rem; margin-top: .5rem; font-weight: 600; }
 
 /* Chat */
 /* Chat widget — two-column: notes left, chat right */

--- a/public/js/site-nav.js
+++ b/public/js/site-nav.js
@@ -266,6 +266,28 @@ function ensureActiveSidebarVisible(sb) {
   });
 })();
 
+// Show validation errors on the inline auth forms (learn/auth, learn/notes,
+// learn/tictactoe). /api/learn/{login,register} answer failures with an honest
+// 4xx — 409 username taken, 401 bad login, 422 invalid input, 429 rate-limited
+// — and put the human-readable reason in the body as <p class="auth-error">…</p>.
+// But htmx 2.x does NOT swap non-2xx responses by default (responseHandling maps
+// 4xx/5xx to swap:false, error:true), so that fragment was being discarded and
+// the forms showed nothing on error. Opt just those two endpoints back into
+// swapping so the message reaches the form's feedback div. The status codes stay
+// honest on purpose: the JSON clients (the demo widgets) rely on the 4xx to know
+// the attempt failed — so this is fixed on the client, not by downgrading to 200.
+(function () {
+  document.addEventListener('htmx:beforeSwap', (e) => {
+    const cfg = e.detail && e.detail.requestConfig;
+    const path = (cfg && cfg.path) || '';
+    const status = e.detail && e.detail.xhr ? e.detail.xhr.status : 0;
+    if (status >= 400 && /^\/api\/learn\/(login|register)$/.test(path)) {
+      e.detail.shouldSwap = true;  // swap the <p class="auth-error"> into the target
+      e.detail.isError = false;    // a handled validation message, not a console error
+    }
+  });
+})();
+
 // Top-of-page progress bar for in-flight htmx requests. NProgress / Linear /
 // Vercel-docs pattern: a 2px amber strip animated via CSS transform.
 // Two-threshold behavior so it works on BOTH fast and slow connections:

--- a/template/pages/learn/auth.php
+++ b/template/pages/learn/auth.php
@@ -121,6 +121,70 @@ $register = function () {
       the class does the work. This pattern scales — your API files stay under 20 lines each.
     </p>
 
+    <h2 id="showing-errors">Showing errors: <code>register()</code> returns <code>null</code>, and htmx's 2xx rule</h2>
+    <p>
+      Two things go wrong on the way to a new account, and both are easy to swallow silently.
+    </p>
+    <p>
+      <strong>First, the username might be taken.</strong> The <code>users.username</code> column is
+      <code>UNIQUE</code>, so a duplicate <code>INSERT</code> throws a <code>PDOException</code>. That's why
+      <code>register()</code>'s return type is <code>?int</code> — catch the constraint violation and return
+      <code>null</code> so the caller can tell "created" from "already exists":
+    </p>
+    <pre><code class="language-php">// src/Learn/Auth.php — register(), the real version
+public static function register(\PDO $db, string $username, string $password): ?int
+{
+    try {
+        $stmt = $db->prepare(
+            'INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)'
+        );
+        $stmt-&gt;execute([$username, password_hash($password, PASSWORD_DEFAULT), time()]);
+        return (int) $db-&gt;lastInsertId();
+    } catch (\PDOException $e) {
+        return null;          // UNIQUE constraint → username already exists
+    }
+}</code></pre>
+    <p>
+      The endpoint turns that <code>null</code> into an honest HTTP status and a one-line message — a real
+      <code>409 Conflict</code>, not a <code>200</code> with the error buried in the body:
+    </p>
+    <pre><code class="language-php">// api/learn/register.php — fail with the right status
+$userId = Auth::register(DB::open(), $creds['username'], $creds['password']);
+if ($userId === null) {
+    header('Content-Type: text/html; charset=utf-8');
+    return $this-&gt;response('&lt;p class="auth-error"&gt;That username is already taken.&lt;/p&gt;', 409);
+}</code></pre>
+    <p>
+      <strong>Second — the subtle one — htmx won't show that message by default.</strong> The form posts with
+      <code>hx-post</code> and swaps the response into a feedback <code>&lt;div&gt;</code>:
+    </p>
+    <pre><code class="language-html">&lt;form hx-post="/api/learn/register" hx-target="#auth-feedback-reg" hx-swap="innerHTML"&gt;
+  …
+  &lt;div id="auth-feedback-reg"&gt;&lt;/div&gt;
+&lt;/form&gt;</code></pre>
+    <p>
+      htmx 2.x only swaps <code>2xx</code> responses. A <code>4xx</code> is treated as an error: the body is
+      <em>discarded</em> and <code>htmx:responseError</code> fires instead. So the <code>409</code> arrives, the
+      message is right there in the response — and the form shows <em>nothing</em>. Don't "fix" it by returning
+      <code>200</code> (your JSON clients depend on the real status); instead opt these two endpoints back into
+      swapping with a one-time <code>htmx:beforeSwap</code> listener:
+    </p>
+    <pre><code class="language-javascript">// public/js/site-nav.js — let auth errors render in the form
+document.addEventListener('htmx:beforeSwap', (e) =&gt; {
+  const path = (e.detail.requestConfig &amp;&amp; e.detail.requestConfig.path) || '';
+  const status = e.detail.xhr ? e.detail.xhr.status : 0;
+  if (status &gt;= 400 &amp;&amp; /^\/api\/learn\/(login|register)$/.test(path)) {
+    e.detail.shouldSwap = true;  // swap the &lt;p class="auth-error"&gt; into the target
+    e.detail.isError = false;    // a handled validation message, not a console error
+  }
+});</code></pre>
+    <p>
+      Now a duplicate registration — or a wrong password on the login form below — shows a red message in
+      place, no page reload, while the API still returns a correct <code>409</code>/<code>401</code> for
+      non-browser clients. That's the htmx way to do form validation: honest status codes on the wire, a
+      single <code>beforeSwap</code> opt-in on the client.
+    </p>
+
     <?php App::render('/components/_tryit', ['title' => 'Register now', 'body' => $user
       ? '<p>You\'re logged in as <strong>' . htmlspecialchars($user['username']) . '</strong>. <a href="/api/learn/logout">Log out</a> to try registering a new account, or head to <a href="/learn/notes">Lesson 18</a> to start building notes.</p>'
       : '<p>Pick a username and password. This creates a real account stored in SQLite. You\'ll use it in the next three lessons to save notes and chat with the AI.</p>


### PR DESCRIPTION
## The bug

On `/learn/auth`, `/learn/notes` and `/learn/tictactoe`, the inline **login/register forms silently showed nothing on failure** — a duplicate username, a wrong password, invalid input, or a rate-limit all produced *no visible feedback*.

## Root cause

The site runs **htmx 2.0.10**, whose default `responseHandling` only swaps `2xx`/`3xx` responses — `4xx`/`5xx` are mapped to `swap:false, error:true`, so the **response body is discarded**. `/api/learn/{login,register}` correctly answer failures with an honest status + a one-line fragment:

| Case | Status | Body |
|---|---|---|
| Username taken | `409` | `<p class="auth-error">That username is already taken.</p>` |
| Wrong password | `401` | `<p class="auth-error">Wrong username or password.</p>` |
| Invalid input | `422` | … |
| Rate-limited | `429` | … |

…but htmx threw the body away, so the feedback `<div>` stayed empty. (The demo widgets aren't affected — they use `fetch` and read the JSON `error` directly.)

## The fix

Client-side, **not** by downgrading the status codes — the JSON clients (demo widgets) rely on the 4xx to detect failure.

1. **`public/js/site-nav.js`** — a one-time `htmx:beforeSwap` listener opts *just* `/api/learn/{login,register}` back into swapping their 4xx body (`shouldSwap = true`, `isError = false`). Fixes all 6 form surfaces at once; no per-template change.
2. **`public/css/learn.css`** — `.auth-error` (specificity `0,1,0`) was being repainted muted-grey by `.auth-card p` / `.lesson-content p` (both `0,1,1`). Scoped it to `.lesson-content .auth-error` (`0,2,0`) so the message renders red + bold.
3. **`template/pages/learn/auth.php`** — new lesson section *"Showing errors: `register()` returns `null`, and htmx's 2xx rule"* documenting the `?int`/`null`-on-`UNIQUE` return, the `409`, and the `beforeSwap` opt-in. The lesson previously only taught the happy path.

## Verification (live, local server)

- `/learn/auth`: register-duplicate → "That username is already taken." **red bold**; login-wrong-password → "Wrong username or password." **red bold**; sidebar + form intact, no reload.
- `/learn/notes`: same two cases, both **red bold** (different container — confirms the `.lesson-content .auth-error` scoping wins there too). `/learn/tictactoe` shares the identical pattern.
- New lesson section renders; all 4 code blocks (PHP register, PHP endpoint, HTML form, JS handler) syntax-highlighted.
- No new console noise: the `409` network log was already emitted pre-fix (honest status); the handler suppresses htmx's *extra* `responseError` log.

Docs/JS/CSS only — no `src/` changes, so no PHPStan/PHPUnit impact.