### PR TITLE
fix(css): pointer cursor on every button (baseline button/summary rule)

### DIFF
--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -339,6 +339,12 @@ p  { max-width: 70ch; }
 }
 
 /* ── Buttons ── */
+/* Baseline: every <button> and <summary> is a click target → pointer. Kept at
+   low specificity (element selector) so the intentional overrides still win:
+   .btn:disabled / button:disabled → not-allowed, .htmx-request → progress.
+   Without this, bare buttons that don't carry .btn (chat Send, notes Add note,
+   the login/register submits, the copy buttons) fell back to the UA arrow. */
+button, summary { cursor: pointer; }
 .btn {
   display: inline-flex; align-items: center; gap: .4rem;
   padding: .6rem 1.4rem; border-radius: 7px; font-size: .9rem; font-weight: 600;


### PR DESCRIPTION
## The bug

Buttons across the learn/docs site showed the **UA default cursor instead of a pointer** on hover. Reported on `/learn/websocket`, but it's site-wide.

## Root cause

Only the `.btn` class set `cursor: pointer` (`zealphp.css:345`). There was **no baseline `button` rule**, so any `<button>` that doesn't carry `.btn` fell back to the browser default. A site-wide audit (agent) found these bare offenders:

- `template/components/_chat_widget.php:31` — `Send`
- `template/components/_notes_widget.php:26` — `Add note`
- `template/pages/learn/notes.php:83`, `tictactoe.php:46` — `Log in`
- `template/pages/learn/auth.php:195` — `Register`
- `.auth-toggle` (notes/tictactoe/auth) — login toggle
- `.legacy-convert-copy` (`legacy-apps.php:844`), `.mig-converter-copy` (`migration.php:266`) — Copy buttons
- uncovered `<summary>` disclosure toggles

## The fix

One low-specificity baseline rule in `zealphp.css` (next to `.btn`):

```css
button, summary { cursor: pointer; }
```

Because it's an element selector (specificity `0,0,1`), every intentional override still wins:
- `.btn:disabled` / `button:disabled` → `not-allowed`
- `.htmx-request` → `progress`
- mermaid `zoom-in`/`grab` (not buttons) — untouched

No per-class edits needed — all 8 offenders (the copy buttons and `.auth-toggle` are `<button>`s too) are covered by this single rule.

## Verification (live)

| Element | Cursor |
|---|---|
| bare `Register` `<button>` | `pointer` ✓ |
| `.auth-toggle` login button | `pointer` ✓ |
| `<summary>` | `pointer` ✓ |
| `.btn:disabled` (regression) | `not-allowed` ✓ |
| bare `:disabled` (regression) | `not-allowed` ✓ |
| `.htmx-request` (regression) | `progress` ✓ |

CSS-only — no `src/` changes, no PHPStan/PHPUnit impact.