### PR TITLE
fix(learn): standalone chat demo loads learn.js + agent tool_args id

### DIFF
--- a/examples/agents/notes_agent.py
+++ b/examples/agents/notes_agent.py
@@ -192,6 +192,9 @@ async def main():
     result = Runner.run_streamed(agent, input=payload["message"], session=session, context=ctx)
 
     tool_names = {}
+    # tool_args events key by item_id, but tool_call/tool_done key by call_id.
+    # Map item_id -> call_id so a tool_args delta can find its tool card.
+    item_call_map = {}
     async for ev in result.stream_events():
         if ev.type == "raw_response_event":
             t = getattr(ev.data, "type", "")
@@ -207,6 +210,7 @@ async def main():
                 name = ev.data.item.name
                 tool_names[item_id] = name
                 tool_names[call_id] = name
+                item_call_map[item_id] = call_id
                 emit("tool_call", {
                     "id": call_id,
                     "name": name,
@@ -214,7 +218,11 @@ async def main():
                 })
             elif t == "response.function_call_arguments.delta":
                 emit("tool_args", {
-                    "id": ev.data.item_id,
+                    # Translate item_id -> call_id so the JS (learn.js) and PHP
+                    # (Chat.php) sides can match this delta to the tool card,
+                    # which was created on the tool_call event keyed by call_id.
+                    # Without this the streamed arguments render (and persist) empty.
+                    "id": item_call_map.get(ev.data.item_id, ev.data.item_id),
                     "delta": ev.data.delta,
                 })
         elif (

--- a/template/components/_demo_shell.php
+++ b/template/components/_demo_shell.php
@@ -32,6 +32,12 @@ $titleHtml   = htmlspecialchars($title);
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" defer></script>
   <script src="/js/learn-demo-viewers.js?v=<?= $v ?>" defer></script>
   <script src="/js/learn-tictactoe.js?v=<?= $v ?>" defer></script>
+  <!-- The chat widget's behaviour (initChat → loadHistory + SSE send + notes
+       WS sync) lives in learn.js. This shell renders the same _chat_widget
+       partial as the /learn/ai-chat lesson, so it needs learn.js too — without
+       it the standalone chat never initialised: no history loaded (it shares
+       the lesson's thread_id via localStorage) and a dead Send button. -->
+  <script src="/js/learn.js?v=<?= $v ?>" defer></script>
   <link rel="stylesheet" href="/css/demo-shell.css?v=<?= $v ?>">
   <script src="/js/demo-shell.js?v=<?= $v ?>" defer></script>
 </head>


### PR DESCRIPTION
Two bugs in the AI-chat feature, reported comparing `/learn/ai-chat` vs `/demo/view/chat/widget`.

## Bug A — chat history not synced

`/demo/view/chat/widget` renders the **same** `_chat_widget` partial as the lesson, but the standalone demo shell (`_demo_shell.php`) only loaded `learn-demo-viewers.js` / `learn-tictactoe.js` / `demo-shell.js` — **never `/js/learn.js`**, where `initChat()` / `loadHistory()` live. So the demo chat never initialised: it didn't load the thread's history (the thread_id is shared with the lesson via `localStorage`) and the Send button was dead — making it look "out of sync" with the lesson.

**Fix:** load `/js/learn.js` in `_demo_shell.php`.

## Bug B — tool-call arguments render (and persist) empty

`notes_agent.py` emitted the `tool_call` event keyed by `call_id` (and `tool_done` likewise), but the `tool_args` deltas keyed by `item_id`. Both `learn.js:207` and `Chat.php:212` match an args delta to its tool card **by id**, so every delta missed → args empty in the live render *and* the persisted `ChatHistory`. (Mock mode was unaffected — it uses one id per call.)

**Fix:** map `item_id → call_id` in `notes_agent.py` and emit `call_id` on `tool_args`. No JS/PHP change needed — both already key by `call_id`.

## Verification (live, real mode `gpt-4.1-mini`)

- Sent *"Create a note titled VerifyTest with body hello-world"* on `/learn/ai-chat` → tool card showed `argsLen: 43` → `{"title":"VerifyTest","body":"hello-world"}` (was empty before). ✅
- Opened `/demo/view/chat/widget` (same browser): `learnJsLoaded: true`, `chatInitialized: 1`, same `threadId`, and it **loaded that exact conversation** including the tool card + persisted args. ✅

Touches `template/components/_demo_shell.php` (1 line) and `examples/agents/notes_agent.py` (3 lines). No `src/` changes; `python -m py_compile` clean.