### PR TITLE
fix(docs): API reference polish — TOC divider, admonition icon, breadcrumb/title sizing, package name

### DIFF
--- a/public/css/docs-api.css
+++ b/public/css/docs-api.css
@@ -598,7 +598,7 @@
 }
 .docs-api .phpdocumentor-table-of-contents__entry {
   padding: .3rem 0;
-  border-bottom: 1px dashed rgba(0,0,0,.05);
+  border-bottom: 1px dashed rgba(0,0,0,.2);
 }
 
 /* ---------- Responsive: phpDocumentor's grid can overflow our shell ---------- */

--- a/public/css/docs-api.css
+++ b/public/css/docs-api.css
@@ -613,6 +613,29 @@
   flex-shrink: 0;
 }
 
+/* ---------- Breadcrumbs + the "in package X" title suffix ---------- */
+/* base.css resets the breadcrumb <ul> (list-style:none, no margin/padding) and
+   shrinks the .phpdocumentor-element__package label; it isn't loaded on our
+   wrapped pages, so breadcrumbs showed disc bullets and the in-title
+   "in package X" link inherited the 32px h1 size (looked as big as the title).
+   Normalise both to a small, bullet-free inline row. */
+.docs-api .phpdocumentor-element__package {
+  font-size: .8rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  margin-top: .35rem;
+}
+.docs-api .phpdocumentor-breadcrumbs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  font-size: .8rem;
+}
+.docs-api .phpdocumentor-breadcrumbs > li { display: inline; }
+
 /* ---------- Responsive: phpDocumentor's grid can overflow our shell ---------- */
 @media (max-width: 900px) {
   .docs-api aside.phpdocumentor-sidebar {

--- a/public/css/docs-api.css
+++ b/public/css/docs-api.css
@@ -601,6 +601,18 @@
   border-bottom: 1px dashed rgba(0,0,0,.2);
 }
 
+/* ---------- Admonitions (@deprecated / @see notices) ---------- */
+/* phpDocumentor's admonition icon is an inline <svg> with the class on the
+   <svg> itself. It ships at its intrinsic ~800px size; the max-width:3rem cap
+   lives in phpdoc's base.css, which our wrapped pages DON'T load (only
+   template.css + this overlay) — so the @deprecated exclamation rendered
+   enormous. Pin it to a normal inline icon size. */
+.docs-api .phpdocumentor-admonition__icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
 /* ---------- Responsive: phpDocumentor's grid can overflow our shell ---------- */
 @media (max-width: 900px) {
   .docs-api aside.phpdocumentor-sidebar {

--- a/scripts/build-api-docs.sh
+++ b/scripts/build-api-docs.sh
@@ -45,6 +45,7 @@ php "$PHAR" \
   -d "$ROOT/src" \
   -t "$ROOT/public/docs/api" \
   --title="ZealPHP API Reference" \
+  --defaultpackagename="ZealPHP" \
   --no-interaction
 
 echo "[build-api-docs] done."


### PR DESCRIPTION
Visual + naming polish for the wrapped phpDocumentor API reference — small, surgical changes to `docs-api.css` + the build script.

**Common root cause of the visual bugs:** our wrapped API pages load phpDoc's `template.css` + our overlay, but **not `base.css`** — so several elements `base.css` normally sizes/resets render with unstyled defaults. Each is overridden in `docs-api.css`.

### 1. Table of Contents divider invisible
`1px dashed rgba(0,0,0,.05)` (5%) → `rgba(0,0,0,.2)`. All 184 TOC entries now show the dashed line.

### 2. Giant `@deprecated` admonition icon
Inline `<svg>` rendered at its intrinsic ~805px (`max-width:3rem` cap lives in unloaded `base.css`). Pinned to `1.5rem` → 24×24px.

### 3. Breadcrumb bullets + oversized "in package" title suffix
Breadcrumb `<ul>`s showed disc bullets and the in-title `.phpdocumentor-element__package` inherited the 32px `<h1>` size. Reset `list-style`/inline + a `.8rem` muted package label.

### 4. Package named "ZealPHP" (was phpDoc's default "Application")
Classes carry no `@package` tag, so phpDoc filed them under its default bucket **"Application"**. Added `--defaultpackagename="ZealPHP"` to `build-api-docs.sh` → `packages/ZealPHP.html`, and the in-title link reads "in package ZealPHP".

### Verification (live, regenerated docs)
- TOC: 184 entries `dashed 1px rgba(0,0,0,0.2)`.
- Admonition icon: 24×24px.
- Title: **"App in package ZealPHP"**, suffix 12.8px, breadcrumbs `list-style: none`.
- `packages/ZealPHP.html` → 200; old `Application.html` → 404 (regenerated + gitignored; no external links).

`docs-api.css` + `build-api-docs.sh` only. Generated docs are gitignored and CI sets `ZEALPHP_SKIP_DOCS_BUILD`, so no CI/test impact; no `src/` changes.