### PR TITLE
fix(ui): show the htmx progress bar only for navigation, not in-place widgets

### DIFF
--- a/public/js/site-nav.js
+++ b/public/js/site-nav.js
@@ -340,10 +340,26 @@ function ensureActiveSidebarVisible(sb) {
       if (pending === 0 && !visible) bar.className = 'htmx-progress';
     }, 280);
   };
-  document.addEventListener('htmx:beforeRequest', start);
-  document.addEventListener('htmx:afterRequest', finish);
-  document.addEventListener('htmx:responseError', finish);
-  document.addEventListener('htmx:sendError', finish);
-  document.addEventListener('htmx:swapError', finish);
-  document.addEventListener('htmx:timeout', finish);
+  // Only NAVIGATION requests drive the bar: full-page swaps (hx-boost), the
+  // .lesson-content swaps (sidebar / lesson chips / API inline nav), or anything
+  // that pushes the URL. In-place widgets — the session counter (hx-target=this),
+  // search-as-you-type, chat, login forms, demo viewers — must NOT flash the top
+  // bar. Filtering finish too keeps `pending` balanced, so an in-place request
+  // completing mid-navigation can't hide the bar early.
+  const isNavRequest = (e) => {
+    const d = e && e.detail;
+    if (!d) return false;
+    if (d.boosted || (d.requestConfig && d.requestConfig.boosted)) return true;
+    const el = d.elt;
+    if (!el || typeof el.getAttribute !== 'function') return false;
+    if (el.getAttribute('hx-target') === '.lesson-content') return true;
+    if (el.hasAttribute('hx-push-url')) return true;
+    return false;
+  };
+  document.addEventListener('htmx:beforeRequest', (e) => { if (isNavRequest(e)) start(); });
+  document.addEventListener('htmx:afterRequest',  (e) => { if (isNavRequest(e)) finish(); });
+  document.addEventListener('htmx:responseError', (e) => { if (isNavRequest(e)) finish(); });
+  document.addEventListener('htmx:sendError',     (e) => { if (isNavRequest(e)) finish(); });
+  document.addEventListener('htmx:swapError',     (e) => { if (isNavRequest(e)) finish(); });
+  document.addEventListener('htmx:timeout',       (e) => { if (isNavRequest(e)) finish(); });
 })();


### PR DESCRIPTION
On `/learn/sessions`, clicking the session counter flashed the top-of-page navigation progress bar — and the same would happen for search-as-you-type, the chat, login forms, and demo viewers.

**Cause:** the progress bar (`site-nav.js`) bound `start`/`finish` to **every** `htmx:beforeRequest`/`afterRequest`, with no filter — so any in-place htmx update drove the navigation indicator.

**Fix:** gate it to *navigation* requests only — `hx-boost`, `hx-target=".lesson-content"` (sidebar / lesson chips / API inline nav), or anything with `hx-push-url`. The counter uses `hx-target="this"` (and search/chat/login target small feedback divs), so they're excluded. `finish` is filtered the same way so `pending` stays balanced (an in-place request can't hide the bar mid-navigation).

**Verified** live with synthetic htmx events (timing-independent — localhost is faster than the 150ms show-threshold): counter → bar stays idle; `hx-push-url` nav element → bar shows. Single-file JS change.