### PR TITLE
fix(nav): progress bar stuck at 75% on /docs/api/ navigation — hx-preserve + re-query + safety timeout

### DIFF
--- a/public/js/site-nav.js
+++ b/public/js/site-nav.js
@@ -311,7 +311,7 @@ function ensureActiveSidebarVisible(sb) {
   if (!getBar()) return;
   const SHOW_AFTER = 150;    // ms before showing the bar at all
   const CREEP_AFTER = 380;   // ms before transitioning start → mid
-  const SAFETY_MAX = 8000;   // ms — hard ceiling; force-reset if finish() never fires
+  const SAFETY_MAX = 4000;   // ms — hard ceiling; force-reset if finish() never fires
   let pending = 0;
   let visible = false;
   let showTimer = null;

--- a/public/js/site-nav.js
+++ b/public/js/site-nav.js
@@ -302,42 +302,74 @@ function ensureActiveSidebarVisible(sb) {
 // SHOW_AFTER tuning: 150ms is the threshold below which users perceive an
 // action as "instant" (Jakob Nielsen). Above that they want feedback.
 (function () {
-  const bar = document.getElementById('htmx-progress');
-  if (!bar) return;
-  const SHOW_AFTER = 150;   // ms before showing the bar at all
-  const CREEP_AFTER = 380;  // ms before transitioning start → mid
+  // Re-query the bar on every event rather than caching, so a navigation that
+  // detaches the original element (e.g. nav into a non-htmx static section
+  // like /docs/api/, OR an hx-boost swap that for some reason replaces the
+  // preserved element) can't leave us holding a stale reference to a node
+  // that's no longer in the DOM. Tiny perf cost; guarantees correctness.
+  const getBar = () => document.getElementById('htmx-progress');
+  if (!getBar()) return;
+  const SHOW_AFTER = 150;    // ms before showing the bar at all
+  const CREEP_AFTER = 380;   // ms before transitioning start → mid
+  const SAFETY_MAX = 8000;   // ms — hard ceiling; force-reset if finish() never fires
   let pending = 0;
   let visible = false;
   let showTimer = null;
   let creepTimer = null;
+  let safetyTimer = null;
+  const forceReset = () => {
+    // Hard reset path used by the safety timer, htmx:historyRestore, and the
+    // ESC keypath. Idempotent — safe to call from any state.
+    pending = 0;
+    visible = false;
+    clearTimeout(showTimer);
+    clearTimeout(creepTimer);
+    clearTimeout(safetyTimer);
+    const b = getBar();
+    if (b) b.className = 'htmx-progress';
+  };
   const reveal = () => {
     visible = true;
-    bar.className = 'htmx-progress start';
+    const b = getBar();
+    if (b) b.className = 'htmx-progress start';
     creepTimer = setTimeout(() => {
-      if (pending > 0) bar.className = 'htmx-progress mid';
+      if (pending > 0) {
+        const b2 = getBar();
+        if (b2) b2.className = 'htmx-progress mid';
+      }
     }, CREEP_AFTER - SHOW_AFTER);
   };
   const start = () => {
     pending++;
     if (pending > 1) return;
+    clearTimeout(showTimer);
+    clearTimeout(safetyTimer);
     // Don't reveal yet — wait SHOW_AFTER ms. Most clicks resolve faster than
     // that on a fiber connection and never need a loading indicator.
-    clearTimeout(showTimer);
     showTimer = setTimeout(reveal, SHOW_AFTER);
+    // Safety net: if finish() never fires (request aborted by browser nav,
+    // missed event, swap into a non-htmx target like /docs/api/, …) snap the
+    // bar back to idle so it can't be permanently stuck at 75%.
+    safetyTimer = setTimeout(forceReset, SAFETY_MAX);
   };
   const finish = () => {
     pending = Math.max(0, pending - 1);
     if (pending > 0) return;
     clearTimeout(showTimer);
     clearTimeout(creepTimer);
+    clearTimeout(safetyTimer);
     if (!visible) {
       // Fast request — never showed the bar, don't show it now either.
       return;
     }
-    bar.className = 'htmx-progress done';
+    const b = getBar();
+    if (b) b.className = 'htmx-progress done';
     visible = false;
     setTimeout(() => {
-      if (pending === 0 && !visible) bar.className = 'htmx-progress';
+      if (pending === 0 && !visible) {
+        const b2 = getBar();
+        if (b2) b2.className = 'htmx-progress';
+      }
     }, 280);
   };
   // Only NAVIGATION requests drive the bar: full-page swaps (hx-boost), the
@@ -362,4 +394,10 @@ function ensureActiveSidebarVisible(sb) {
   document.addEventListener('htmx:sendError',     (e) => { if (isNavRequest(e)) finish(); });
   document.addEventListener('htmx:swapError',     (e) => { if (isNavRequest(e)) finish(); });
   document.addEventListener('htmx:timeout',       (e) => { if (isNavRequest(e)) finish(); });
+  // Browser back/forward (htmx:historyRestore) can land us in a state where
+  // the previous run's mid-state class is restored via bfcache; force-reset
+  // so a stale bar can't survive a history navigation. Same on pageshow for
+  // bfcache-restored pages that pre-date this script.
+  document.addEventListener('htmx:historyRestore', forceReset);
+  window.addEventListener('pageshow', (e) => { if (e.persisted) forceReset(); });
 })();

--- a/template/_master.php
+++ b/template/_master.php
@@ -9,7 +9,7 @@ $active      ??= $page;
 <html lang="en">
 <?php App::render('/_head', compact('title', 'description', 'page')); ?>
 <body hx-boost="true" hx-ext="head-support">
-<div id="htmx-progress" class="htmx-progress" aria-hidden="true"></div>
+<div id="htmx-progress" class="htmx-progress" aria-hidden="true" hx-preserve="true"></div>
 <?php App::render('/_nav', ['active' => $active]); ?>
 <?php App::render('/components/_banner'); ?>
 <main class="page-body">


### PR DESCRIPTION
## Why

Reproduced on live (`php.zeal.ninja/docs/api/`): clicking any class link OR breadcrumb inside the phpDocumentor pages starts the top-of-page progress bar, the body swaps fine (new content renders), but the bar **stays stuck at the 75% (`mid`) state** instead of completing to idle.

Root cause is layered:

1. **`#htmx-progress` lives inside `<body>`** (`_master.php:12`) and `hx-boost="true"` on `<body>` swaps body contents on every navigation. `site-nav.js` cached the bar reference at script-load time. After the first boosted swap the cached node is detached — subsequent `finish()` calls mutate a detached element while the live bar sits unmanaged.

2. **`/docs/api/` is phpDocumentor's static output** — its HTML doesn't contain a `#htmx-progress` element. Without `hx-preserve`, htmx removes the bar entirely during the swap. The IIFE state machine still thinks `visible=true`, and any later events have nothing to operate on.

3. **Browser back/forward via bfcache** can restore a page whose bar is *visually* stuck in `.mid` while the JS state machine is fresh — no event ever fires to reconcile them.

## Fix — layered, each layer fully fixes a subset

- **`hx-preserve="true"` on `#htmx-progress`** (`template/_master.php`) — htmx now keeps the same element across boosted swaps when the new page has a matching id. Handles in-site nav (the common case).
- **`getBar()` re-query on every event** (`public/js/site-nav.js`) — replaces the cached `bar` const with a `document.getElementById` per event. Tiny perf cost, guarantees we never mutate a detached node.
- **`SAFETY_MAX = 4000` ms safety timer in `start()`** — force-resets the bar if `finish()` never fires (cancelled requests, swaps into a non-htmx-aware target like `/docs/api/`, missed events). The bar can no longer be permanently stuck regardless of root cause. 4 s is short enough that a missed event auto-corrects before the user files a bug, long enough that a genuinely slow 4G request still completes naturally first.
- **`forceReset()` on `htmx:historyRestore` + `pageshow` (bfcache)** — back/forward navigation across boosted pages lands in a clean state.
- **`forceReset()` is idempotent** — safe to call from any state.

No CSS change. Same `.htmx-progress.start/mid/done` class names — purely runtime/timer fixes.

## Test plan

- [x] Reproduces on master: navigate to `/docs/api/`, click a class link — bar starts, body swaps, bar stuck at 75 %.
- [ ] Apply this PR locally, restart, repeat: bar should fully complete to idle on every navigation (or worst-case reset itself within 4 s).
- [ ] Click rapid-fire breadcrumbs (3-4 clicks within 1 s): bar should follow the latest request, never get stuck.
- [ ] Browser back/forward across boosted pages: bar resets cleanly.
- [ ] Navigate INTO `/docs/api/` from a normal page, then back out: bar behaves normally throughout.

## Files

- `template/_master.php` — +1 char (`hx-preserve="true"`)
- `public/js/site-nav.js` — +48 / -10 LOC

## Why a separate PR

This is a production UX bug that affects every visitor browsing the API docs. The bigger `docs/website-pitch-pass` PR (homepage / pitch rewrite) is queued behind a larger review surface; this surgical fix can ship independently without that wait.
