### PR TITLE
docs(website): 'PHP HTTP server' framing pass — soften overclaims, engine/harness section, AI-friendly section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ZealPHP — Coroutine-Native PHP Framework on OpenSwoole
+# ZealPHP — A PHP HTTP Server (built on OpenSwoole)
 
-A coroutine-native PHP framework built on **OpenSwoole** for high-concurrency HTTP, WebSocket, streaming, and real-time applications. Start serving existing PHP apps on OpenSwoole today — migrate to full async at your own pace.
+ZealPHP runs PHP as the HTTP server itself — not a CGI worker behind one. Built on **OpenSwoole**, it ships HTTP, WebSocket, SSE, coroutines, shared memory, timers, and task workers as first-class primitives because the server stays alive between requests. Existing PHP code runs unchanged via uopz overrides in compatibility mode; new features go async without a separate Node or Go service. Alpha — see stability note below.
 
 [![Packagist Version](https://img.shields.io/packagist/v/sibidharan/zealphp?style=flat-square&color=orange&logo=packagist&logoColor=white)](https://packagist.org/packages/sibidharan/zealphp) [![Packagist Downloads](https://img.shields.io/packagist/dt/sibidharan/zealphp?style=flat-square&logo=packagist&logoColor=white)](https://packagist.org/packages/sibidharan/zealphp) [![License](https://img.shields.io/packagist/l/sibidharan/zealphp?style=flat-square)](https://packagist.org/packages/sibidharan/zealphp)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sibidharan/zealphp) [![GitHub stars](https://img.shields.io/github/stars/sibidharan/zealphp?style=flat-square&logo=github&logoColor=white)](https://github.com/sibidharan/zealphp/stargazers) [![PHP 8.3+](https://img.shields.io/badge/PHP-8.3%2B-777bb4?style=flat-square&logo=php&logoColor=white)](https://www.php.net/) [![PHP tested](https://img.shields.io/badge/tested-PHP%208.3%20%7C%208.4%20%7C%208.5--experimental-777bb4?style=flat-square&logo=php&logoColor=white)](https://github.com/sibidharan/zealphp/actions/workflows/tests.yml) [![Stability](https://img.shields.io/badge/stability-active%20alpha-orange?style=flat-square)](CHANGELOG.md)
@@ -33,35 +33,33 @@ Running `php app.php` serves the same docs site locally. Set `ZEALPHP_SITE_URL` 
 | **Unit tests** | PHPUnit 11 — 130 unit tests + 46 integration tests, all green |
 | **Benchmarks** | OpenSwoole-powered concurrency with a modular `scripts/bench.sh` runner for wrk/ab sweeps through c=1000 |
 
-> **Performance:** 117K req/s text · 106K JSON · 50K templated — full PSR-15 stack (CORS + ETag + sessions + reflection-injected routing), 4 workers, AMD Ryzen 9 7900X. **Express on the same box: 20K / 22K / 12K — a 5× gap.**
+> **Performance:** 117k req/s text · 106k JSON · 50k templated on a 4-core box, full PSR-15 middleware stack, 0 failures across 150k requests. ZealPHP retains ~82% of OpenSwoole's raw throughput with the framework on top; numbers vary by workload, payload, and hardware.
 >
-> Two surprises in the methodology. **(1)** Raw OpenSwoole hits 142K text / 138K JSON — **+10% over raw Node http (129K / 132K)**, before any framework loads. **(2)** ZealPHP with full PSR-15 middleware still hits **91% of bare Node http's throughput on text, 80% on JSON**. That's because ZealPHP retains **82%** of its runtime's raw throughput; Express retains **15%** of Node's. The 5× gap is a framework-efficiency story, not a raw-runtime one.
->
-> Reproduce: `./scripts/bench_vs_express.sh`. See [PERF.md](PERF.md) for environment, latency sweep, and head-to-head.
+> Reproduce in 60s: `./scripts/bench_vs_express.sh`. Full methodology, latency percentiles, concurrency sweep, and caveats: [PERF.md](PERF.md).
 > **Stability:** Alpha (v0.2.x). API may change between minor versions until v1.0. Pin to a specific version in production.
 
-> **Apache + nginx parity (v0.2.21).** Every common `.htaccess` / `nginx.conf` directive is now covered by a built-in middleware or a server-level `App::$*` setter. 12 new middlewares (`HeaderMiddleware`, `BasicAuthMiddleware`, `RateLimitMiddleware`, `CharsetMiddleware`, `CacheControlMiddleware`, `ExpiresMiddleware`, `IpAccessMiddleware`, `ConcurrencyLimitMiddleware`, `BlockPhpExtMiddleware`, `MimeTypeMiddleware`, `BodyRewriteMiddleware`, `HostRouterMiddleware`) and 8 new configurables (`$server_admin`, `$canonical_name`, `$trusted_proxies` + `App::clientIp()`, `$access_log_format`, `LimitRequestFields` family, `$strip_trailing_slash`, `App::tryInclude()`) landed in v0.2.21. See the [middleware reference](https://php.zeal.ninja/middleware) and the [legacy-apps coverage matrix](https://php.zeal.ninja/legacy-apps) for the full story.
+> **Common Apache + nginx behavior coverage (v0.2.21).** ZealPHP ships built-in middlewares and server-level setters for the common `.htaccess` / `nginx.conf` patterns used by traditional PHP apps — rewrite-style routing, headers, expiry/cache rules, basic auth, IP access, rate limits, MIME types, request limits. This is coverage for migration use cases, not a byte-for-byte server replacement. 12 new middlewares (`HeaderMiddleware`, `BasicAuthMiddleware`, `RateLimitMiddleware`, `CharsetMiddleware`, `CacheControlMiddleware`, `ExpiresMiddleware`, `IpAccessMiddleware`, `ConcurrencyLimitMiddleware`, `BlockPhpExtMiddleware`, `MimeTypeMiddleware`, `BodyRewriteMiddleware`, `HostRouterMiddleware`) and 8 new configurables (`$server_admin`, `$canonical_name`, `$trusted_proxies` + `App::clientIp()`, `$access_log_format`, `LimitRequestFields` family, `$strip_trailing_slash`, `App::tryInclude()`) landed in v0.2.21. See the [middleware reference](https://php.zeal.ninja/middleware) and the [legacy-apps coverage matrix](https://php.zeal.ninja/legacy-apps) for the full story.
 
 ---
 
 ## Why ZealPHP?
 
-**The mission: take your existing PHP code, put it on a long-lived async runtime, and unlock WebSocket, SSE, streaming, coroutines, and shared memory — without rewriting in Node, Go, or Python.**
+**The architectural shift: PHP becomes the HTTP server. The migration story is the on-ramp; the destination is "your existing PHP code, plus WebSockets/SSE/coroutines/shared memory/timers, all in one PHP application server."**
 
-PHP powers 77% of the web, but the default request-per-process model (PHP-FPM, mod_php) cold-starts an interpreter per request, discards in-memory state, and forces WebSocket/SSE into separate sidecar processes. ZealPHP runs on **OpenSwoole** — a long-lived PHP server with native coroutines — and adds a framework layer that:
+PHP powers 77% of the web, but the default request-per-process model (PHP-FPM, mod_php) keeps the interpreter warm yet discards request-local state, and gives PHP no native way to hold a persistent connection — so WebSocket/SSE features land in separate Node/Go sidecar processes. ZealPHP runs on **OpenSwoole** — a long-lived PHP server with native coroutines — and adds a framework layer that:
 
-1. **Accepts your existing PHP code unchanged.** Drop `.php` files in `public/`. `session_start()`, `header()`, `$_GET` all work via uopz overrides. Many WordPress sites run through the CGI worker bridge — see [zealphp-wordpress](https://github.com/sibidharan/zealphp-wordpress) for the showcase and known limits.
+1. **Accepts many traditional PHP patterns unchanged (compatibility mode).** Drop `.php` files in `public/`. `session_start()`, `header()`, `$_GET`, `$_POST`, `setcookie()`, `echo` all route through uopz overrides into per-request state. Many WordPress sites run through the CGI worker bridge — see [zealphp-wordpress](https://github.com/sibidharan/zealphp-wordpress) for the showcase and documented limits. Compatibility is a migration on-ramp, not a guarantee that every PHP application is safe to drop in without an audit.
 2. **Adds async primitives when you want them.** `go()`, `Channel`, WebSocket, SSE, shared memory (`Store` / `Counter`), timers, task workers — all framework-native, no extra services.
 3. **Lets you migrate file by file.** Start with fallback routing on day one; opt into coroutine mode when you're ready. No big-bang rewrite.
 
 ### vs other ways to make PHP async
 
-- **vs PHP-FPM / mod_php** — FPM cold-starts every request. ZealPHP keeps workers warm; caches survive across requests, SSE/WebSocket cost ~0 to keep open.
+- **vs PHP-FPM / mod_php** — FPM keeps workers warm but discards request-local memory and treats PHP as a CGI worker, not the HTTP server. ZealPHP IS the HTTP server: caches survive across requests, and SSE/WebSocket connections are much cheaper to keep open than under request-per-process PHP (real capacity still depends on file descriptors, heartbeat policy, and OS tuning).
 - **vs Laravel Octane** — Octane wraps Swoole inside a Laravel kernel. ZealPHP is framework-agnostic and exposes the runtime primitives directly. If you're on Laravel and want it faster, use Octane.
 - **vs FrankenPHP / RoadRunner** — Go servers fronting PHP. ZealPHP runs native PHP coroutines on OpenSwoole — no Go process in between.
 - **vs ReactPHP / AMPHP** — Library collections you wire together. ZealPHP is the integrated framework on top.
 - **vs raw Swoole / OpenSwoole** — ZealPHP adds routing, PSR-15 middleware, templates, session overrides, and the legacy bridge so you don't write `onRequest` handlers by hand.
-- **vs Node.js** — Node forces `await` / callbacks. ZealPHP coroutines let blocking-looking calls (`$db->query()`) yield under the hood — synchronous PHP idioms still compose.
+- **vs Node.js** — Different language and ecosystem; not the same trade-off space. If you're already in JS, stay in JS. ZealPHP exists for teams that want OpenSwoole-style concurrency without leaving PHP, or that need to bring a PHP codebase along.
 
 [Full comparison →](https://php.zeal.ninja/why-zealphp)
 
@@ -177,7 +175,7 @@ $app->run();
   uopz overrides:          header() · session_start() · setcookie() · $_GET
 ```
 
-The uopz function overrides are the framework's load-bearing trick: legacy PHP code calls `session_start()` or `header()` unchanged, but the calls route to per-coroutine state instead of mutating process globals. This lets unmodified WordPress and other legacy apps run on OpenSwoole's coroutine runtime.
+The uopz function overrides are the framework's load-bearing trick: legacy PHP code calls `session_start()` or `header()` unchanged, but the calls route to per-coroutine state instead of mutating process globals. This lets many traditional PHP patterns — including unmodified WordPress in compatibility mode — run on OpenSwoole's coroutine runtime, with documented limits where the legacy bridge can't fully match Apache's request isolation.
 
 More detail in [docs/runtime-architecture.md](docs/runtime-architecture.md).
 

--- a/public/css/pages/home.css
+++ b/public/css/pages/home.css
@@ -111,15 +111,17 @@
 .home-section-migrate { background: var(--bg-dark); color: var(--code-text); }
 .home-section-return { background: var(--bg-alt); }
 
-/* --- AI-friendly section (sits between Quick Start and Feature grid) ------ */
+/* --- AI-friendly section (sits below the engine/harness section) --------- */
 .home-section-ai-friendly {
-  background: var(--bg-alt);
-  border-top: 1px solid rgba(245,158,11,.18);
-  border-bottom: 1px solid rgba(245,158,11,.18);
+  background: var(--bg-dark); color: #e2e8f0;
+  padding-top: 3rem; padding-bottom: 3rem;
+  border-top: 1px solid rgba(245,158,11,.22);
+  border-bottom: 1px solid rgba(245,158,11,.22);
 }
-.home-section-ai-friendly .section-title { color: var(--accent); }
+.home-section-ai-friendly .section-title { color: #fde68a; }
+.home-section-ai-friendly .section-desc { color: #e2e8f0; }
 .home-ai-friendly-note {
-  font-style: italic; color: var(--text-muted);
+  font-style: italic; color: #94a3b8;
   max-width: 760px; margin: 1rem auto 0; font-size: .95rem;
 }
 

--- a/public/css/pages/home.css
+++ b/public/css/pages/home.css
@@ -19,6 +19,13 @@
 }
 .home-hero-why a { color: #fde68a; text-decoration: none; }
 
+/* Small build-stamp under the hero sub-line — version + runtime credit */
+.home-hero-stamp {
+  font-size: .65rem; color: #78716c; margin-top: .8rem; font-weight: 400;
+}
+.home-hero-stamp a { color: #a8a29e; text-decoration: none; }
+.home-hero-stamp a:hover { color: #fde68a; }
+
 .home-hero-code-pre { margin: 0; }
 .home-hero-code-pre code {
   background: transparent; padding: 0; font-size: .82rem;
@@ -103,6 +110,57 @@
 }
 .home-section-migrate { background: var(--bg-dark); color: var(--code-text); }
 .home-section-return { background: var(--bg-alt); }
+
+/* --- AI-friendly section (sits between Quick Start and Feature grid) ------ */
+.home-section-ai-friendly {
+  background: var(--bg-alt);
+  border-top: 1px solid rgba(245,158,11,.18);
+  border-bottom: 1px solid rgba(245,158,11,.18);
+}
+.home-section-ai-friendly .section-title { color: var(--accent); }
+.home-ai-friendly-note {
+  font-style: italic; color: var(--text-muted);
+  max-width: 760px; margin: 1rem auto 0; font-size: .95rem;
+}
+
+/* --- Engine vs harness section (sits between AI-friendly and Feature grid) - */
+.home-section-engine { background: #fff; padding-top: 3rem; padding-bottom: 3rem; }
+.home-engine-lead { max-width: 760px; margin: 0 auto 2rem; }
+.home-engine-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border: 1px solid var(--border); border-radius: var(--radius);
+  overflow: hidden; max-width: 980px; margin: 0 auto;
+}
+.home-engine-col { padding: 1.5rem 1.75rem; }
+.home-engine-col-engine { background: var(--bg-alt); border-right: 1px solid var(--border); }
+.home-engine-col-harness { background: #fffbf4; }
+.home-engine-col-title {
+  font-size: .82rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .05em; margin: 0 0 .9rem; color: var(--text-muted);
+}
+.home-engine-col-harness .home-engine-col-title { color: var(--accent); }
+.home-engine-list {
+  list-style: none; padding: 0; margin: 0;
+  font-size: .88rem; line-height: 1.55;
+}
+.home-engine-list li {
+  padding: .35rem 0; border-bottom: 1px dotted rgba(0,0,0,.05);
+}
+.home-engine-list li:last-child { border-bottom: none; }
+.home-engine-list code {
+  background: rgba(0,0,0,.04); padding: .05rem .25rem; border-radius: 3px;
+  font-size: .85em;
+}
+.home-engine-when-raw {
+  max-width: 760px; margin: 1.5rem auto 0;
+  font-size: .88rem; color: var(--text-muted);
+  padding: .85rem 1rem; background: var(--bg-alt);
+  border-left: 3px solid var(--accent); border-radius: 4px;
+}
+@media (max-width: 768px) {
+  .home-engine-grid { grid-template-columns: 1fr; }
+  .home-engine-col-engine { border-right: none; border-bottom: 1px solid var(--border); }
+}
 
 /* --- Quick Start: fresh-machine one-liner ------------------------------- */
 .home-qs-fresh {

--- a/public/css/pages/why-zealphp.css
+++ b/public/css/pages/why-zealphp.css
@@ -270,3 +270,47 @@
   font-size: 1rem;
   padding: .75rem 2rem;
 }
+
+/* --- Engine vs harness section (vs raw OpenSwoole) ----------------------- */
+.why-engine-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border: 1px solid var(--border-dark);
+  border-radius: 8px; overflow: hidden;
+  margin: 2rem 0 1.5rem;
+}
+.why-engine-col { padding: 1.5rem 1.75rem; }
+.why-engine-col-engine {
+  background: rgba(255,255,255,.02);
+  border-right: 1px solid var(--border-dark);
+}
+.why-engine-col-harness {
+  background: rgba(245,158,11,.04);
+}
+.why-engine-col-title {
+  font-size: .82rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .05em; margin: 0 0 .25rem; color: var(--text-light);
+}
+.why-engine-col-harness .why-engine-col-title { color: #fde68a; }
+.why-engine-col-tag {
+  font-size: .72rem; color: #94a3b8; margin: 0 0 1rem; font-style: italic;
+}
+.why-engine-list {
+  list-style: none; padding: 0; margin: 0;
+  font-size: .88rem; line-height: 1.6; color: var(--text-light);
+}
+.why-engine-list li {
+  padding: .45rem 0;
+  border-bottom: 1px dotted rgba(255,255,255,.06);
+}
+.why-engine-list li:last-child { border-bottom: none; }
+.why-engine-list code {
+  background: rgba(255,255,255,.06); padding: .05rem .3rem;
+  border-radius: 3px; font-size: .82em; color: #fde68a;
+}
+.why-engine-list strong { color: #fff; }
+.why-engine-list a { color: #fde68a; text-decoration: none; border-bottom: 1px dotted rgba(253,230,138,.4); }
+.why-engine-list a:hover { color: #fcd34d; border-bottom-color: rgba(252,211,77,.7); }
+@media (max-width: 768px) {
+  .why-engine-grid { grid-template-columns: 1fr; }
+  .why-engine-col-engine { border-right: none; border-bottom: 1px solid var(--border-dark); }
+}

--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -778,20 +778,16 @@ pre:hover > .code-copy { opacity: 1; }
   display: flex; align-items: center; gap: .5rem;
   color: var(--text-muted);
 }
+/* <pre> inside the light-bg panel needs its OWN dark bg so the global
+   hljs theme (monokai — palette designed for dark bg) lands on a dark
+   canvas. Without this, .hljs's transparent bg bleeds the panel's
+   light bg through and monokai's saturated tokens wash out. */
 .code-compare-panel pre {
-  margin: 0; font-size: .78rem; line-height: 1.6; color: #1c1917;
+  margin: 0; font-size: .78rem; line-height: 1.6;
+  background: var(--code-bg); border-radius: 6px;
+  padding: .9rem 1rem;
 }
-.code-compare-panel code { font-family: var(--font-mono); color: #1c1917; }
-.code-compare-panel .hljs { background: transparent !important; color: #1c1917 !important; }
-.code-compare-panel .hljs-keyword,
-.code-compare-panel .hljs-built_in { color: #7c3aed; }
-.code-compare-panel .hljs-string { color: #059669; }
-.code-compare-panel .hljs-comment { color: #78716c; }
-.code-compare-panel .hljs-function,
-.code-compare-panel .hljs-title { color: #2563eb; }
-.code-compare-panel .hljs-variable,
-.code-compare-panel .hljs-attr { color: #c2410c; }
-.code-compare-panel .hljs-number { color: #0891b2; }
+.code-compare-panel code { font-family: var(--font-mono); }
 .compare-verdict {
   font-size: .88rem; font-weight: 600; margin-top: 1rem;
   padding: .75rem 1rem; border-radius: 6px;

--- a/public/css/zealphp.css
+++ b/public/css/zealphp.css
@@ -767,20 +767,17 @@ pre:hover > .code-copy { opacity: 1; }
 }
 .code-compare-panel {
   padding: 1.25rem; overflow-x: auto;
+  background: var(--bg-alt);
 }
 .code-compare-panel:first-child {
-  background: #f0fdf4; border-right: 1px solid var(--border);
-}
-.code-compare-panel:last-child {
-  background: #fef2f2;
+  border-right: 1px solid var(--border);
 }
 .code-compare-panel .compare-label {
   font-size: .72rem; font-weight: 700; text-transform: uppercase;
   letter-spacing: .05em; margin-bottom: .75rem;
   display: flex; align-items: center; gap: .5rem;
+  color: var(--text-muted);
 }
-.code-compare-panel:first-child .compare-label { color: #166534; }
-.code-compare-panel:last-child .compare-label { color: #991b1b; }
 .code-compare-panel pre {
   margin: 0; font-size: .78rem; line-height: 1.6; color: #1c1917;
 }

--- a/template/_head.php
+++ b/template/_head.php
@@ -61,7 +61,7 @@ $ogImageUrl = $ogImageExists ? ($__scheme . '://' . $__host . $ogImage) : null;
        Loaded up front, not lazily per page, so hx-boost navigation never
        flashes unstyled content waiting on a per-page stylesheet to fetch. -->
   <link rel="stylesheet" href="/css/pages.css?v=<?= $v ?>">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <!-- Instrument Sans — display / heading font; Fira Code — code font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap">

--- a/template/_head.php
+++ b/template/_head.php
@@ -61,7 +61,7 @@ $ogImageUrl = $ogImageExists ? ($__scheme . '://' . $__host . $ogImage) : null;
        Loaded up front, not lazily per page, so hx-boost navigation never
        flashes unstyled content waiting on a per-page stylesheet to fetch. -->
   <link rel="stylesheet" href="/css/pages.css?v=<?= $v ?>">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/monokai.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <!-- Instrument Sans — display / heading font; Fira Code — code font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap">

--- a/template/components/_demo_shell.php
+++ b/template/components/_demo_shell.php
@@ -33,7 +33,7 @@ $titleHtml   = htmlspecialchars($title);
        the same per-page CSS the lessons load. Without this link, widgets
        in /demo/view/* render unstyled. -->
   <link rel="stylesheet" href="/css/pages.css?v=<?= $v ?>">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/monokai.min.css">
   <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" defer></script>
   <script src="/js/learn-demo-viewers.js?v=<?= $v ?>" defer></script>

--- a/template/pages/docs/index.php
+++ b/template/pages/docs/index.php
@@ -23,7 +23,7 @@ $groups = [
         ['streaming',                     'Streaming',             'yield-based SSR, stream(), sse(), renderStream.'],
         ['websocket',                     'WebSocket',             'App::ws(), per-worker fd map, frame opcodes, cross-worker broadcast.'],
         ['tasks-and-concurrency',         'Tasks & Concurrency',   'go(), task workers, App::tick/after, coproc().'],
-        ['middleware-and-authentication', 'Middleware & Auth',     'All 28 PSR-15 middleware classes + Apache/nginx parity.'],
+        ['middleware-and-authentication', 'Middleware & Auth',     'All 28 PSR-15 middleware classes + common Apache/nginx behavior coverage.'],
     ],
     'Operations' => [
         ['deployment',       'Deployment',       'systemd unit, CLI flags, PID files, Docker, OPcache tuning.'],

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -346,27 +346,6 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 </section>
 
 
-<!-- AI-friendly by being boring -->
-<section class="section home-section-ai-friendly">
-  <div class="container">
-    <h2 class="section-title">AI-friendly by being boring</h2>
-    <p class="section-desc">
-      ZealPHP doesn't require a heavy frontend stack to build interactive AI apps.
-      Routes can return HTML. SSE can stream tokens. WebSockets can push live events.
-      Task workers can run long jobs. Templates stay close to backend state.
-      That smaller surface area &mdash; HTML as the interface contract, fewer files between
-      handler and DOM &mdash; makes the app easier to understand, test, and modify, for humans
-      and for AI coding assistants.
-    </p>
-    <p class="section-desc home-ai-friendly-note">
-      It's an architectural note, not a product claim: less architecture is often more accuracy.
-      Build small explicit server flows; let the browser stay browser-shaped.
-      Worked example: the live AI chat above is ~40 lines of PHP + a Python agent,
-      no SPA framework involved.
-    </p>
-  </div>
-</section>
-
 <!-- Engine vs harness — pre-empts the "just use Swoole" attack -->
 <section class="section home-section-engine">
   <div class="container">
@@ -406,6 +385,27 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
     </div>
     <p class="home-engine-when-raw">
       <strong>When raw OpenSwoole is the right choice:</strong> you're building a custom binary-protocol server (your own ASR / database / message broker), you need to avoid <code>uopz</code> entirely (compliance), you're building your own framework. For everything else &mdash; HTTP, WebSocket, SSE, REST, web apps with sessions &mdash; the harness saves you weeks per project.
+    </p>
+  </div>
+</section>
+
+<!-- AI-friendly by being boring -->
+<section class="section home-section-ai-friendly">
+  <div class="container">
+    <h2 class="section-title">AI-friendly by being boring</h2>
+    <p class="section-desc">
+      ZealPHP doesn't require a heavy frontend stack to build interactive AI apps.
+      Routes can return HTML. SSE can stream tokens. WebSockets can push live events.
+      Task workers can run long jobs. Templates stay close to backend state.
+      That smaller surface area &mdash; HTML as the interface contract, fewer files between
+      handler and DOM &mdash; makes the app easier to understand, test, and modify, for humans
+      and for AI coding assistants.
+    </p>
+    <p class="section-desc home-ai-friendly-note">
+      It's an architectural note, not a product claim: less architecture is often more accuracy.
+      Build small explicit server flows; let the browser stay browser-shaped.
+      Worked example: the live AI chat above is ~40 lines of PHP + a Python agent,
+      no SPA framework involved.
     </p>
   </div>
 </section>

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -14,9 +14,11 @@ $siteUrl = site_url();
     </div>
     <p class="home-hero-tagline">
       The PHP Runtime for AI Web Apps</p>
-    <p>Stream AI responses in 5 lines. WebSocket, SSE, shared memory, task workers —<br>
-       one server, one process. Coroutine-native concurrency with PHP's developer experience.</p>
-    <p class="home-hero-sub">Upgrade your existing PHP codebase to async — start without rewriting, migrate at your own pace.</p>
+    <p>PHP <em>is</em> the HTTP server now &mdash; not a CGI worker behind one.<br>
+       WebSocket, SSE, streaming, coroutines, shared memory, task workers &mdash;
+       first&#8209;class because the server never shuts down between requests.</p>
+    <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
+    <p class="home-hero-stamp">Alpha &middot; v0.2.40 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -54,115 +56,32 @@ $siteUrl = site_url();
     </div>
 
     <p class="home-bench-intro">
-      And it's fast — here's the throughput on 4 workers, full middleware stack:
+      On a 4-core box, full PSR-15 stack &mdash; <strong>117k req/s text &middot; 106k JSON &middot; 50k templated</strong>, 0 failures across 150k requests.
+      Reproduce in 60s: <code class="home-bench-method-code">scripts/bench_vs_express.sh</code>.
+      Full concurrency sweep, latency percentiles, methodology, and caveats &mdash;
+      <a href="/performance">/performance</a>.
     </p>
-
-    <div class="bench-method">
-      <strong>Method</strong> &nbsp;|&nbsp;
-      4 workers, full middleware stack, <code class="home-bench-method-code">ab -n 50000 -c 200 -k</code>, same machine, no DB
-      &nbsp;|&nbsp;
-      <a href="https://github.com/sibidharan/zealphp/blob/master/PERF.md" target="_blank" rel="noopener">PERF.md</a>
-      &nbsp;|&nbsp;
-      <a href="https://github.com/sibidharan/zealphp/blob/master/scripts/bench_vs_express.sh" target="_blank" rel="noopener">reproduce locally</a>
-    </div>
-    <div class="bench">
-      <div class="bench-stat"><div class="num">117k</div><div class="label">req/s text</div><div class="sub">avg 1.7 ms</div></div>
-      <div class="bench-stat"><div class="num">106k</div><div class="label">req/s JSON</div><div class="sub">avg 1.9 ms</div></div>
-      <div class="bench-stat"><div class="num">50k</div><div class="label">req/s template</div><div class="sub">avg 4.0 ms</div></div>
-      <div class="bench-stat"><div class="num">0</div><div class="label">failures</div><div class="sub">/ 150k reqs</div></div>
-    </div>
-    <div class="home-bench-table-wrap">
-      <table class="home-bench-table">
-        <tr class="home-bench-head">
-          <th class="home-bench-th-left">Framework</th>
-          <th>Raw text</th>
-          <th>JSON API</th>
-          <th>Template</th>
-        </tr>
-        <tr class="home-bench-group">
-          <td colspan="4" class="home-bench-group-label">Runtime (no framework, no middleware)</td>
-        </tr>
-        <tr>
-          <td>OpenSwoole raw</td>
-          <td class="home-bench-num">142k</td>
-          <td class="home-bench-num">138k</td>
-          <td class="home-bench-num home-bench-dash">—</td>
-        </tr>
-        <tr>
-          <td>Node.js raw http</td>
-          <td class="home-bench-num">129k</td>
-          <td class="home-bench-num">132k</td>
-          <td class="home-bench-num home-bench-dash">—</td>
-        </tr>
-        <tr class="home-bench-group">
-          <td colspan="4" class="home-bench-group-label">Full framework (CORS + ETag + sessions + routing + templates)</td>
-        </tr>
-        <tr class="home-bench-row-zeal">
-          <td class="home-bench-zeal">ZealPHP <span class="home-bench-tag">built-in</span></td>
-          <td class="home-bench-num home-bench-zeal">117k</td>
-          <td class="home-bench-num home-bench-zeal">106k</td>
-          <td class="home-bench-num home-bench-zeal">50k</td>
-        </tr>
-        <tr class="home-bench-row-express">
-          <td class="home-bench-express">Express.js <span class="home-bench-tag">+5 npm pkgs</span></td>
-          <td class="home-bench-num home-bench-express">20k</td>
-          <td class="home-bench-num home-bench-express">22k</td>
-          <td class="home-bench-num home-bench-express">12k</td>
-        </tr>
-        <tr class="home-bench-group">
-          <td colspan="4" class="home-bench-group-label">Other PHP frameworks <span class="home-bench-group-note">(community benchmarks)</span></td>
-        </tr>
-        <tr class="home-bench-row-other">
-          <td class="home-bench-other-name">Slim 4</td>
-          <td colspan="3" class="home-bench-other-num">~4k req/s</td>
-        </tr>
-        <tr class="home-bench-row-other">
-          <td class="home-bench-other-name">Symfony 7</td>
-          <td colspan="3" class="home-bench-other-num">~2k req/s</td>
-        </tr>
-        <tr class="home-bench-row-other">
-          <td class="home-bench-other-name">Laravel 11</td>
-          <td colspan="3" class="home-bench-other-num">~500 req/s</td>
-        </tr>
-      </table>
-      <div class="home-bench-callout">
-        <p>
-          <strong>The runtime is already faster.</strong>
-          OpenSwoole's bare HTTP server hits <strong>142k req/s text · 138k JSON</strong>
-          — versus Node's <strong class="home-bench-callout-alt">129k · 132k</strong>.
-          <strong>+10% on text, +5% on JSON</strong>, before any framework loads.
-        </p>
-        <p class="home-bench-callout-last">
-          <strong>ZealPHP keeps 82%</strong> of that with full PSR-15 middleware on top.
-          <strong class="home-bench-callout-alt">Express keeps 15%</strong> of raw Node's.
-          End result — ZealPHP with full middleware reaches
-          <strong>91% of bare Node http's throughput</strong>.
-        </p>
-      </div>
-      <p class="home-bench-perflink">
-        <a href="/performance">Concurrency sweep, latency percentiles, methodology, reproduction recipes &amp; caveats →</a>
-      </p>
-    </div>
   </div>
 </section>
 
 <!-- The Problem -->
 <section class="section section-problem">
   <div class="container">
-    <h2 class="section-title">The PHP we love. The execution model we needed.</h2>
+    <h2 class="section-title">For 25 years, the HTTP server was C. PHP was the worker that died.</h2>
     <p class="section-desc">
-      LAMP shipped the web &mdash; Apache and mod_php, now nginx and PHP-FPM. Twenty-five years of
-      request isolation: a pool of warm workers, each handling one request at a time and reset
-      to a clean slate before the next. Shared-nothing by design.
-    </p>
-    <p class="section-desc">
-      It still works. But it can't stream AI tokens. It can't push WebSocket events.
-      It can't share state between requests without bolting on Redis. Every
-      &ldquo;real-time&rdquo; feature your customers ask for needs another service.
+      Apache + mod_php, nginx + PHP-FPM &mdash; the HTTP server is always a C binary that bridges to
+      a PHP process via FastCGI. PHP runs the request, then exits the request context. PHP is the
+      <em>language</em>, never the <em>server</em>. That model gave us shared-nothing isolation,
+      cheap workers, and 77% of the web. It also gave us "PHP can't do WebSockets" and a separate
+      Node service for every streaming feature.
     </p>
     <p class="section-desc section-problem-payoff">
-      <strong>ZealPHP keeps the PHP. Swaps the execution model.</strong>
-      One process, coroutines, persistent state &mdash; and your existing PHP codebase still runs.
+      <strong>ZealPHP is what happens when PHP <em>becomes</em> the HTTP server.</strong>
+      Always-on, coroutine-native, owns the event loop, holds the connections. WebSocket, SSE,
+      timers, and shared memory are first-class because the server never shuts down. The on-ramp
+      is real too &mdash; <code>session_start()</code>, <code>header()</code>, <code>$_GET</code>,
+      <code>echo</code> all route through <a href="https://github.com/krakjoe/uopz" target="_blank" rel="noopener">uopz</a>
+      overrides into per-request state, so existing PHP code runs unchanged.
     </p>
   </div>
 </section>
@@ -249,114 +168,101 @@ $app->route('/api/chat', ['methods' => ['POST']],
   </div>
 </section>
 
-<!-- Why Not Just Use [X]? -->
+<!-- What being-the-HTTP-server actually buys you -->
 <section class="section home-section-altbg">
   <div class="container">
-    <h2 class="section-title">Why not just use...?</h2>
-    <p class="section-desc">Bold claims. Real code. You decide.</p>
+    <h2 class="section-title">What being the HTTP server actually buys you</h2>
+    <p class="section-desc">SSE, WebSocket, shared memory, timers &mdash; not bolt-ons. First-class because the server is alive between requests.</p>
 
     <div class="bold-claim">
-      <h3>Node.js needs 30 lines for what ZealPHP does in 5</h3>
-      <p>AI token streaming — the core feature of every LLM app. Compare the implementations.</p>
+      <h3>SSE / token streaming as a first-class response primitive</h3>
+      <p>The server holds the connection. <code>$response-&gt;sse()</code> is the framework primitive &mdash; no framing, no transports library, no separate sidecar.</p>
       <div class="code-compare">
         <div class="code-compare-panel">
-          <div class="compare-label">ZealPHP — 7 lines</div>
+          <div class="compare-label">app.php</div>
 <pre><code>$app->route('/ai/stream', function($response) {
     $response->sse(function($emit) {
-        $ch = curl_init($apiUrl);
-        // ... setup curl streaming
-        curl_exec($ch);
+        foreach (stream_from_upstream() as $token) {
+            $emit($token, 'token');
+        }
     });
 });</code></pre>
         </div>
         <div class="code-compare-panel">
-          <div class="compare-label">Node.js — 25+ lines</div>
-<pre><code>app.get('/ai/stream', (req, res) => {
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
-  res.flushHeaders();
-
-  const response = await fetch(apiUrl, {
-    method: 'POST', body: JSON.stringify({...}),
-  });
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    const chunk = decoder.decode(value);
-    // parse SSE lines, extract tokens...
-    res.write(`data: ${token}\n\n`);
-  }
-  res.end();
-});</code></pre>
+          <div class="compare-label">FPM equivalent</div>
+<pre><code>// In an FPM world, the same endpoint pins a worker for
+// the lifetime of the stream — the request-per-process
+// model has no concept of "yield while waiting on I/O."
+// Most teams solve this by running a separate Node or
+// Go service just for streaming endpoints.
+// ZealPHP does it in the same process as the rest of
+// your app, in a coroutine instead of a pinned worker.</code></pre>
         </div>
       </div>
     </div>
 
     <div class="bold-claim">
-      <h3>Expressive PHP with coroutine-grade concurrency</h3>
-      <p>~106k req/s in our 4-worker JSON benchmark, with reflection-based injection, auto-serialization, and no boilerplate. Numbers vary by workload — see methodology below.</p>
+      <h3>Routing &amp; auto-serialization with the LAMP idiom intact</h3>
+      <p>Reflection-based parameter injection. Return whatever shape fits &mdash; int becomes a status, array becomes JSON, generator becomes a stream. No DI container, no <code>$request</code>-first convention. The <a href="/responses#return-contract">universal return contract</a> is one table.</p>
       <div class="code-compare">
         <div class="code-compare-panel">
-          <div class="compare-label">ZealPHP — return anything</div>
+          <div class="compare-label">Return anything &mdash; framework picks the right wire shape</div>
 <pre><code>$app->route('/users/{id}', function($id) {
-    return ['user' => User::find($id)];
-    // auto JSON. auto 200. done.
-});</code></pre>
+    return ['user' => User::find($id)];  // auto JSON, 200
+});
+
+$app->route('/missing', fn() => 404);    // int → status
+
+$app->route('/page', fn() => (function() {
+    yield '&lt;html&gt;&lt;body&gt;';                 // generator → SSR stream
+    yield '&lt;div&gt;...&lt;/div&gt;';
+    yield '&lt;/body&gt;&lt;/html&gt;';
+})());</code></pre>
         </div>
         <div class="code-compare-panel">
-          <div class="compare-label">Go — manual everything</div>
-<pre><code>func getUser(w http.ResponseWriter, r *http.Request) {
-    id := chi.URLParam(r, "id")
-    user, err := FindUser(id)
-    if err != nil {
-        http.Error(w, err.Error(), 500)
-        return
-    }
-    w.Header().Set("Content-Type", "application/json")
-    json.NewEncoder(w).Encode(map[string]any{
-        "user": user,
-    })
-}</code></pre>
+          <div class="compare-label">Same return contract for legacy public/*.php files</div>
+<pre><code>// public/users.php — Apache-style file routing,
+// same return contract as $app->route() handlers.
+&lt;?php
+require_once __DIR__ . '/../vendor/autoload.php';
+return ['users' => User::all()];  // → JSON, 200
+
+// public/old-handler.php — buffered echo still works
+// for unmodified legacy code.
+&lt;?php session_start();
+echo "&lt;h1&gt;Hello, {$_SESSION['user']}&lt;/h1&gt;";</code></pre>
         </div>
       </div>
     </div>
 
     <div class="bold-claim">
-      <h3>Multi-process workers, coroutines per worker</h3>
-      <p>ZealPHP inherits OpenSwoole's architecture: <code>N</code> worker processes, each running thousands of coroutines on a single reactor loop. <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a> is the runtime; ZealPHP is the framework layer. Real connection counts depend on workload, OS limits, and tuning — measure for your case.</p>
+      <h3>Workers + coroutines + shared state in one PHP application server</h3>
+      <p>OpenSwoole's master/manager/worker model: <code>N</code> worker processes, each running thousands of coroutines on a reactor loop. <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a> is the runtime; ZealPHP is the framework layer on top. Cross-worker state ships built-in for one machine; cross-node uses the same API with a Redis backend.</p>
       <div class="code-compare">
         <div class="code-compare-panel">
-          <div class="compare-label">ZealPHP — true parallelism</div>
-<pre><code>// 16 workers × thousands of coroutines
-// Shared memory across workers (no Redis)
-// Each coroutine yields on I/O automatically
+          <div class="compare-label">Cross-worker state on a single node &mdash; built in</div>
+<pre><code>// N workers × thousands of coroutines per worker.
+// Coroutines yield on I/O automatically (HOOK_ALL).
 ZEALPHP_WORKERS=16 php app.php
 
-// Store: cross-worker shared state (1 process)
+// Store: cross-worker shared state, in-process.
+// No Redis needed for one node — OpenSwoole\Table.
 Store::set('cache', $key, $data);
-$data = Store::get('cache', $key);
-
-// Or flip to cross-NODE in one line
-Store::defaultBackend(Store::BACKEND_REDIS);
-Store::publish('chat:room', $payload);
-App::subscribe('chat:room', $handler);</code></pre>
+$data = Store::get('cache', $key);</code></pre>
         </div>
         <div class="code-compare-panel">
-          <div class="compare-label">FastAPI — single process limits</div>
-<pre><code># Single process, async but not parallel
-# Need Gunicorn + multiple workers
-# Need Redis for any shared state
-# Need Celery for background tasks
-gunicorn app:app -w 4 -k uvicorn.workers.UvicornWorker
+          <div class="compare-label">Cross-node &mdash; same API, Redis/Valkey backend</div>
+<pre><code>// Multi-node deploy? Same code, one-line backend flip.
+// Federated WebSocket rooms + pub/sub need Redis;
+// in-memory Table can't reach across machines.
+Store::defaultBackend(Store::BACKEND_REDIS);
 
-# Shared state? Add Redis.
-redis_client = redis.Redis()
-redis_client.set(key, json.dumps(data))</code></pre>
+Store::publish('chat:room', $payload);
+App::subscribe('chat:room', $handler);
+
+// Or run TIERED: L1 = local Table, L2 = Redis,
+// HMAC-signed cross-node L1 invalidations.
+Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
         </div>
       </div>
     </div>
@@ -440,6 +346,70 @@ redis_client.set(key, json.dumps(data))</code></pre>
 </section>
 
 
+<!-- AI-friendly by being boring -->
+<section class="section home-section-ai-friendly">
+  <div class="container">
+    <h2 class="section-title">AI-friendly by being boring</h2>
+    <p class="section-desc">
+      ZealPHP doesn't require a heavy frontend stack to build interactive AI apps.
+      Routes can return HTML. SSE can stream tokens. WebSockets can push live events.
+      Task workers can run long jobs. Templates stay close to backend state.
+      That smaller surface area &mdash; HTML as the interface contract, fewer files between
+      handler and DOM &mdash; makes the app easier to understand, test, and modify, for humans
+      and for AI coding assistants.
+    </p>
+    <p class="section-desc home-ai-friendly-note">
+      It's an architectural note, not a product claim: less architecture is often more accuracy.
+      Build small explicit server flows; let the browser stay browser-shaped.
+      Worked example: the live AI chat above is ~40 lines of PHP + a Python agent,
+      no SPA framework involved.
+    </p>
+  </div>
+</section>
+
+<!-- Engine vs harness — pre-empts the "just use Swoole" attack -->
+<section class="section home-section-engine">
+  <div class="container">
+    <h2 class="section-title">OpenSwoole is the engine. ZealPHP is the harness.</h2>
+    <p class="section-desc home-engine-lead">
+      <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a> gives PHP a real long-lived HTTP/WebSocket server with native coroutines, Atomic, and Table. It's the C-extension that makes everything else possible. But raw OpenSwoole leaves the framework problem unsolved &mdash; routing, middleware, sessions, legacy-PHP compatibility, return-shape resolution, CLI tooling. Every team that builds on raw OpenSwoole re-invents the same harness.
+    </p>
+    <div class="home-engine-grid">
+      <div class="home-engine-col home-engine-col-engine">
+        <h3 class="home-engine-col-title">OpenSwoole gives you</h3>
+        <ul class="home-engine-list">
+          <li>HTTP server + WebSocket server primitives</li>
+          <li>Coroutines + Channel + WaitGroup</li>
+          <li><code>Atomic</code> + <code>Table</code> (shared memory)</li>
+          <li>Coroutine\Http\Client + DNS + sleep hooks</li>
+          <li><code>HOOK_ALL</code> &mdash; PHP I/O yields the reactor</li>
+          <li>Process\Pool + master/manager/worker lifecycle</li>
+        </ul>
+      </div>
+      <div class="home-engine-col home-engine-col-harness">
+        <h3 class="home-engine-col-title">ZealPHP adds on top</h3>
+        <ul class="home-engine-list">
+          <li>Routing (<code>route()</code> + <code>nsRoute</code> + <code>patternRoute</code>) with reflection-based parameter injection</li>
+          <li>PSR-15 middleware stack &mdash; 18 built-ins covering common Apache/nginx behaviors</li>
+          <li><code>uopz</code> overrides so <code>session_start()</code>, <code>header()</code>, <code>setcookie()</code>, <code>$_GET</code>/<code>$_POST</code>/<code>$_SESSION</code>, <code>echo</code> all just work</li>
+          <li>Coroutine-safe sessions (per-request <code>RequestContext</code>, no process-wide superglobal races)</li>
+          <li>Templating (<code>App::render</code> / <code>renderStream</code> / <code>fragment</code>) with streaming-Generator output</li>
+          <li>Universal return contract (int = status, array = JSON, Generator = SSE/SSR stream)</li>
+          <li>ZealAPI &mdash; file-based REST (drop <code>api/users/get.php</code> &rarr; auto-route)</li>
+          <li>CGI worker bridge for unmodified WordPress / Drupal compatibility</li>
+          <li>Pluggable <code>Store</code> + <code>Counter</code> backends (Table &rarr; Redis/Valkey &rarr; Tiered with HMAC-signed cross-node L1 invalidation)</li>
+          <li>Cross-host pub/sub (<code>App::subscribe</code>) + Streams (<code>App::subscribeReliable</code>) + WSRouter for cross-server WebSocket routing + first-class WS rooms</li>
+          <li>Stream wrapper for <code>php://input</code> so legacy <code>file_get_contents('php://input')</code> just works in long-running workers</li>
+          <li>CLI tooling: <code>php app.php start/stop/restart/status/logs</code> + daemonization + per-port PID files</li>
+        </ul>
+      </div>
+    </div>
+    <p class="home-engine-when-raw">
+      <strong>When raw OpenSwoole is the right choice:</strong> you're building a custom binary-protocol server (your own ASR / database / message broker), you need to avoid <code>uopz</code> entirely (compliance), you're building your own framework. For everything else &mdash; HTTP, WebSocket, SSE, REST, web apps with sessions &mdash; the harness saves you weeks per project.
+    </p>
+  </div>
+</section>
+
 <!-- Feature grid -->
 <section class="section">
   <div class="container">
@@ -455,12 +425,12 @@ redis_client.set(key, json.dumps(data))</code></pre>
         ['🔌', 'WebSocket',    'Real-time agent-to-user comms. Multi-user AI sessions, live collaboration, binary frames.',           '/ws',         'App::ws()'],
         ['🛡️', 'Middleware',  'CORS, ETag/304, gzip. PSR-15 compatible — drop in any middleware package.',                            '/middleware', 'PSR-15'],
         ['🗄️', 'Sessions',   'Coroutine-safe sessions. Your existing session_start() code just works via uopz.',                     '/sessions',   'drop-in'],
-        ['🗃️', 'Store',      'Share AI conversation state across workers. Cross-worker shared memory — no Redis needed.',             '/store',      'OpenSwoole\\Table'],
+        ['🗃️', 'Store',      'Cross-worker shared state on one node via OpenSwoole\\Table; flip to Redis/Valkey for cross-node + persistence. One API.',  '/store',      'pluggable backend'],
         ['⏱️', 'Timers',     'Schedule recurring AI tasks. Polling, cleanup, model warmup, health checks.',                           '/timers',     'tick() · after()'],
         ['🌐', 'HTTP',        'Full HTTP/1.1 compliance. HEAD, OPTIONS, Range, redirects, CORS, ETag, gzip — all built-in.',           '/http',       'HTTP/1.1'],
         ['📝', 'Components',  'SSR streaming components. Compose views with yield from. renderStream() for progressive HTML.',         '/templates',  'renderStream()'],
         ['🔗', 'REST API',    'Drop a PHP file in api/. It becomes a route. File-based REST — the simplest API pattern.',             '/api',        'file-based'],
-        ['🏗️', 'Legacy Apps','Run WordPress unmodified. CGI worker provides true global scope. Apache mod_php compatibility.',        '/legacy-apps','WordPress'],
+        ['🏗️', 'Legacy Apps','WordPress compatibility showcase via the CGI bridge (admin, login, REST API working) — with documented limits and trade-offs.', '/legacy-apps','WordPress'],
       ];
       foreach ($features as [$icon, $title, $body, $href, $badge]) {
         App::render('/components/_card', compact('icon', 'title', 'body', 'href', 'badge'));
@@ -470,34 +440,36 @@ redis_client.set(key, json.dumps(data))</code></pre>
   </div>
 </section>
 
-<!-- Migrate Your PHP Codebase -->
+<!-- Bring your PHP code along -->
 <section class="section home-section-migrate">
   <div class="container home-migrate-wrap">
-    <h2 class="section-title home-migrate-title">Bring your PHP codebase along</h2>
+    <h2 class="section-title home-migrate-title">Bring your PHP code along</h2>
     <p class="section-desc home-migrate-desc">
-      <code>session_start()</code>, <code>header()</code>, <code>$_GET</code>, <code>echo</code> —
-      overridden via uopz so existing code runs unchanged inside the coroutine runtime.
-      Move at your own pace: drop your whole app in, or rewrite endpoint-by-endpoint.
+      Many traditional PHP patterns run unchanged in compatibility mode. <code>session_start()</code>,
+      <code>header()</code>, <code>$_GET</code>, <code>$_POST</code>, <code>echo</code>, <code>setcookie()</code>
+      &mdash; all routed through <code>uopz</code> overrides into per-request state, so existing files
+      can sit beside coroutine-native routes in the same app. Compatibility is a migration on-ramp,
+      not a guarantee that every PHP application is safe to drop in without an audit.
     </p>
 
     <div class="home-migrate-grid">
       <div class="home-migrate-card home-migrate-card-today">
-        <h3>Today: Nginx + PHP-FPM + Redis + Socket.io + cron + …</h3>
-        <p>6 services, 6 failure points, 6 sets of config.</p>
+        <h3>Today: nginx + PHP-FPM + Redis + Socket.io + cron + &hellip;</h3>
+        <p>Each tier is mature in isolation, but the per-feature wiring (sessions, real-time, background jobs) lives across several services and config files.</p>
       </div>
       <div class="home-migrate-card home-migrate-card-accent">
         <h3>On ZealPHP: <code>php app.php</code></h3>
-        <p>HTTP + WebSocket + SSE + sessions + shared memory + task workers — one process.</p>
+        <p>HTTP, WebSocket, SSE, sessions, task workers, shared memory, timers &mdash; one PHP application server. Front it with nginx / Caddy / Traefik in production for TLS + load-balancing across instances, exactly as you would an FPM pool.</p>
       </div>
     </div>
 
     <p class="home-migrate-ladder">
-      The migration ladder has 5 rungs (0 → 4). Rung 0 is "drop in your existing app, run <code>php app.php</code>." Rung 4 is full coroutine mode — <a href="/performance">117k req/s on 4 workers</a>. Most teams stay on rungs 1–3 indefinitely; the upgrade path is opt-in, not forced.
+      The <a href="/migration">migration ladder</a> has 5 rungs (0&nbsp;&rarr;&nbsp;4). Rung 0 is &ldquo;drop your existing app in a fallback handler.&rdquo; Rung 4 is full coroutine mode (<a href="/performance">measured throughput on /performance</a>). Most teams stay on rungs 1&ndash;3 indefinitely; the upgrade path is opt-in, not forced. Real-world fit depends on extension coverage, blocking-I/O usage, and how much of the app reaches for global state &mdash; <a href="/why-zealphp#when-to-use-zealphp">honest fit guide</a>.
     </p>
 
     <div class="home-migrate-cta">
       <a href="/migration" class="btn btn-primary">See the full migration path →</a>
-      <a href="/legacy-apps" class="btn btn-outline home-migrate-cta-wp">WordPress on ZealPHP →</a>
+      <a href="/legacy-apps" class="btn btn-outline home-migrate-cta-wp">WordPress compatibility showcase →</a>
     </div>
   </div>
 </section>

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -67,8 +67,9 @@ $siteUrl = site_url();
 <!-- The Problem -->
 <section class="section section-problem">
   <div class="container">
-    <h2 class="section-title">For 25 years, the HTTP server was C. PHP was the worker that died.</h2>
+    <h2 class="section-title">The PHP we love. The execution model we needed.</h2>
     <p class="section-desc">
+      For 25 years, the HTTP server was C. PHP was the worker that died.
       Apache + mod_php, nginx + PHP-FPM &mdash; the HTTP server is always a C binary that bridges to
       a PHP process via FastCGI. PHP runs the request, then exits the request context. PHP is the
       <em>language</em>, never the <em>server</em>. That model gave us shared-nothing isolation,

--- a/template/pages/learn.php
+++ b/template/pages/learn.php
@@ -38,7 +38,7 @@ ZealPHP\App::init('0.0.0.0', 8080)->run();</code></pre>
     </p>
     <p>
       That architecture worked for 25 years. But it can't do WebSocket. It can't stream AI responses
-      token-by-token. It can't share state between requests without Redis. It can't run background tasks
+      token-by-token. It can't share state between requests without bolting on a sidecar service like Redis. It can't run background tasks
       without a queue worker. Every "modern" feature requires bolting on another service.
     </p>
 

--- a/template/pages/learn/deployment.php
+++ b/template/pages/learn/deployment.php
@@ -162,7 +162,7 @@ ZEALPHP_LOG_DIR           # Log directory (default: /tmp/zealphp)</code></pre>
     <?php App::render('/components/_callout', [
       'variant' => 'info',
       'title'   => 'When ZealPHP isn\'t the right choice',
-      'body'    => '<p><strong>Client-side state management</strong> (optimistic updates, complex drag-and-drop, real-time collaboration) — a frontend framework is the right tool.</p><p><strong>Horizontal scaling across machines</strong> — ZealPHP is one process. It scales vertically well but doesn\'t pretend to be Kubernetes. For multi-server, you\'ll need stateless workers + Redis sessions.</p>',
+      'body'    => '<p><strong>Client-side state management</strong> (optimistic updates, complex drag-and-drop, real-time collaboration) — a frontend framework is the right tool.</p><p><strong>Horizontal scaling across machines</strong> — ZealPHP is one PHP application server per node. It scales vertically well but doesn\'t pretend to be Kubernetes. For multi-server, you\'ll need stateless workers + Redis sessions.</p>',
     ]); ?>
 
     <h2>The boring architecture</h2>

--- a/template/pages/learn/react-vs-php.php
+++ b/template/pages/learn/react-vs-php.php
@@ -207,7 +207,7 @@ const handleSubmit = async (e) =&gt; {
       <li>The server has the data and the client displays it</li>
       <li>You want <strong>zero build step</strong> and instant deploys</li>
       <li>You need <strong>SEO</strong> without SSR/SSG complexity</li>
-      <li>You want <strong>one process</strong> instead of six</li>
+      <li>You want <strong>one PHP application server</strong> instead of six tiers</li>
     </ul>
 
     <?php App::render('/components/_concept_check', [
@@ -236,7 +236,7 @@ const handleSubmit = async (e) =&gt; {
       'React solves client-side state management — most web apps don\'t have that problem',
       'Server-rendered HTML + htmx replaces React for forms, tables, lists, and pages',
       'The hidden cost of React: bundler, hydration, state management, API layer, client-side routing',
-      'ZealPHP + htmx: one process, zero build step, 14 KB of JS, server is the single source of truth',
+      'ZealPHP + htmx: one PHP application server, zero build step, 14 KB of JS, server is the single source of truth',
     ]]); ?>
 
     <div class="lesson-chips">

--- a/template/pages/learn/sessions.php
+++ b/template/pages/learn/sessions.php
@@ -22,7 +22,7 @@
       A tiny session-backed feature: a counter that <strong>survives a reload</strong> and
       <strong>follows you across tabs</strong>. Hit the button, see it go up. Open another tab, see
       the same number. Close the browser and come back — still the same number. All with no
-      database, no Redis, no JavaScript state — just a session.
+      database, no Redis on a single node, no JavaScript state — just a session.
     </p>
 
     <?php App::render('/components/_tryit', [

--- a/template/pages/learn/websocket.php
+++ b/template/pages/learn/websocket.php
@@ -20,7 +20,7 @@
     <h2 id="step-overview">1. Overview — what you&rsquo;re building</h2>
     <p>
       A counter that <strong>updates in every open tab the moment any tab clicks +1</strong>. No
-      reloads, no polling, no Redis. The server holds a list of open WebSocket connections; the
+      reloads, no polling, no Redis on a single server (cross-server deploys use the Redis-backed federated routing the framework ships — see /websocket#cross-server). The server holds a list of open WebSocket connections; the
       <code>+1</code> button hits a normal HTTP endpoint; that endpoint broadcasts the new value
       back over WebSocket to every connected tab. Try it now — open this URL in another tab first.
     </p>

--- a/template/pages/legacy-apps.php
+++ b/template/pages/legacy-apps.php
@@ -2,7 +2,7 @@
 <section class="section">
 <div class="container">
 <h1 class="section-title">Running Legacy PHP Apps</h1>
-<p class="section-desc">ZealPHP runs <strong>unmodified WordPress</strong> — admin dashboard, login, posts, plugins — out of the box. No patches, no forks, no compatibility layers. If it runs on Apache, it runs on ZealPHP.</p>
+<p class="section-desc">WordPress compatibility showcase: admin dashboard, login, posts, REST API working through the ZealPHP CGI worker bridge in compatibility mode &mdash; with <a href="#limitations">documented limits</a> and an honest startup-cost trade-off. The bridge exists so traditional PHP code that assumes a fresh process per request (WordPress, Drupal, define()-heavy plugins) can run on OpenSwoole&apos;s long-lived workers. The same <code>app.php</code> works for Drupal, Laravel-on-FPM-shape, and other traditional PHP applications.</p>
 
 <div class="callout info legacy-callout-proof">
   <strong>Production proof point.</strong> Selfmade Ninja Labs (<a href="https://labs.selfmade.ninja">labs.selfmade.ninja</a>) — a large PHP/MongoDB dashboard with OAuth, SSE streaming, and a custom MongoDB ORM — runs the same codebase on both Apache and ZealPHP in production. Two servers, one volume, zero downtime during migration. <a href="/case-studies/sna-labs">Read the case study →</a>
@@ -24,7 +24,7 @@
 </div>
 
 <div class="callout info legacy-callout-zero">
-<p><strong>Zero WordPress modifications required.</strong> Login, sessions, cookies, redirects, file uploads, REST API, pretty permalinks — everything works through ZealPHP's CGI worker with true global scope isolation. The same <code>app.php</code> works for Drupal, Laravel, or any traditional PHP application.</p>
+<p><strong>Compatibility-mode story.</strong> In the showcase deploy, WordPress runs without source patches: login, sessions, cookies, redirects, file uploads, REST API, and pretty permalinks all work through the CGI worker bridge (<code>App::superglobals(true) + processIsolation(true)</code>). True global-scope isolation is preserved per request via <code>proc_open</code>, at a ~30&ndash;50&nbsp;ms per-request cost &mdash; the price of the isolation that <code>define()</code>-heavy plugins need. The <a href="/vs-fpm">v0.3.0 persistent worker pool</a> is the planned fix for that startup cost. See <a href="#limitations">known limits</a> before betting your production WordPress on it.</p>
 </div>
 
 <h2 id="limitations">Known limitations — things ZealPHP won't do</h2>

--- a/template/pages/migration.php
+++ b/template/pages/migration.php
@@ -15,7 +15,7 @@
 <!-- 1. The before/after stack collapse                             -->
 <!-- ────────────────────────────────────────────────────────────── -->
 
-<h2 class="mig-h2-mt-lg">From several services to one process</h2>
+<h2 class="mig-h2-mt-lg">From several services to one PHP application server</h2>
 
 <div class="mig-stack-grid">
   <div class="qs-block mig-qs-pad">
@@ -28,7 +28,7 @@
       <li>Supervisor / cron (background jobs)</li>
       <li>SSE proxy or browser polling</li>
     </ul>
-    <p class="mig-stack-note">6 services, 6 failure points, 6 sets of config.</p>
+    <p class="mig-stack-note">Each tier is mature in isolation, but the per-feature wiring lives across several services and config files.</p>
   </div>
   <div class="qs-block mig-qs-pad-accent">
     <h3 class="mig-qs-h3-accent">Same app on ZealPHP</h3>
@@ -37,7 +37,7 @@
     </div>
     <ul class="mig-list-plain">
       <li>HTTP + WebSocket + SSE built in</li>
-      <li>Coroutine-safe sessions (no Redis)</li>
+      <li>Coroutine-safe sessions (single-node, file-backed; Redis-backed handler available)</li>
       <li>Shared memory across workers (Store, Counter)</li>
       <li>Task workers (no cron / supervisor)</li>
       <li>Persistent connections, no cold starts</li>
@@ -67,7 +67,7 @@ $rungs = [
     'n'    => '0',
     'title' => 'Drop in your entire app, unchanged',
     'code'  => 'App::superglobals(true); $app->setFallback(fn() => App::include(\'/index.php\'));',
-    'desc'  => 'Most existing PHP apps — WordPress, Drupal, custom legacy code — run unchanged on OpenSwoole through the CGI worker bridge. No code edits required to start serving requests faster.',
+    'desc'  => 'Many traditional PHP apps — including unmodified WordPress and Drupal — run through the CGI worker bridge in compatibility mode. Most files require no edits to start; complex apps benefit from a compatibility audit first (see <a href="/legacy-apps#limitations">documented limits</a>).',
     'wins'  => 'Persistent process, no per-request boot. Sub-millisecond TTFB on cached routes.',
     'gives_up' => 'Coroutines, WebSocket, SSE — you\'re still bound by the global-state model.',
   ],
@@ -215,7 +215,7 @@ foreach ($rungs as $r):
       <li>✓ You want WebSocket / SSE / streaming without a separate Node service</li>
       <li>✓ You have I/O-bound endpoints (DB, HTTP fetches) — coroutines fan them out</li>
       <li>✓ You hit PHP-FPM bottlenecks (request rate, cold start latency, FPM pool tuning)</li>
-      <li>✓ You want long-lived sessions or pub/sub without Redis</li>
+      <li>✓ You want cross-worker pub/sub without Redis on one node; cross-node deploys flip to Redis with one line</li>
       <li>✓ You want to keep <code>session_start()</code> + <code>header()</code> + <code>echo</code> — not rewrite for an event loop</li>
     </ul>
   </div>
@@ -227,6 +227,7 @@ foreach ($rungs as $r):
       <li>✗ You'd accept a full rewrite anyway — Go/Rust/Elixir give bigger ceilings if you can pay the cost</li>
       <li>✗ Hard requirement for shared-nothing per-request memory (PHP-FPM's strongest guarantee)</li>
       <li>✗ Production team can't accept alpha (v0.2.x) stability — wait for v1.0</li>
+      <li>✗ You need byte-for-byte Apache/nginx config replacement — ZealPHP covers the common .htaccess / nginx.conf patterns but isn't a drop-in for every directive</li>
     </ul>
   </div>
 </div>

--- a/template/pages/why-zealphp.php
+++ b/template/pages/why-zealphp.php
@@ -4,8 +4,8 @@
   <div class="container why-container">
     <h1 class="section-title why-title">Why ZealPHP?</h1>
     <p class="section-desc why-desc">
-      PHP powers 77% of the web. Its execution model is what needs upgrading.<br>
-      ZealPHP brings coroutine-native, real-time server architecture to PHP.
+      PHP powers 77% of the web — always as a worker behind a C-based HTTP server.<br>
+      ZealPHP runs PHP as the HTTP server itself: coroutine-native, always-on, WebSocket/SSE/timers first-class.
     </p>
 
     <div class="why-proof">
@@ -15,11 +15,12 @@
     <div class="why-block">
       <h2 class="why-h2">The problem</h2>
       <p class="why-prose">
-        PHP's traditional request-per-process model (PHP-FPM, mod_php) is fundamentally
-        incompatible with real-time, high-concurrency, and streaming use cases.
+        In the traditional model (PHP-FPM, mod_php), the HTTP server is C — nginx or Apache.
+        PHP is the worker that bridges in via FastCGI and exits per-request.
         Every request starts from scratch — no shared state, no persistent connections,
         no coroutines. Building a WebSocket server, streaming AI responses, or running
         background tasks requires leaving PHP entirely for Node.js, Go, or Python.
+        ZealPHP collapses this: the HTTP server IS PHP, long-lived, with a coroutine per request.
       </p>
       <p class="why-prose-spaced">
         Existing async PHP solutions are either too low-level (raw Swoole, ReactPHP, AMPHP),
@@ -53,15 +54,16 @@
             Drop <code>.php</code> files in <code>public/</code> and they route automatically — just like Apache.
             <code>session_start()</code>, <code>header()</code>, <code>$_GET</code>, <code>echo</code>
             all work unchanged via uopz. Drop files in <code>api/</code> and they become REST endpoints.
-            Many existing PHP apps — including WordPress sites — run unchanged through the CGI worker bridge. Migrate at your own pace — file by file, feature by feature.
+            Many traditional PHP patterns — including WordPress — run through the CGI worker bridge in compatibility mode, with documented limits. Migrate at your own pace — file by file, feature by feature.
           </p>
         </div>
         <div class="why-card">
-          <h3 class="why-card-title">Single-process deployment</h3>
+          <h3 class="why-card-title">PHP as the application server</h3>
           <p class="why-card-body">
-            HTTP server, WebSocket server, task workers, timers, shared memory, sessions —
-            all in one <code>php app.php</code>. No Nginx, no Redis, no Supervisor, no cron.
-            Deploy a systemd service and you're done.
+            HTTP, WebSocket, task workers, timers, shared memory, sessions — in one PHP application server,
+            started with <code>php app.php</code>. On one node you can skip the Redis/Supervisor/cron tier;
+            for cross-node deploys, ZealPHP's Store + pub/sub flip to a Redis/Valkey backend with one line of config.
+            Front it with nginx/Caddy/Traefik in production for TLS + horizontal scaling.
           </p>
         </div>
       </div>
@@ -151,6 +153,56 @@
     </div>
 
     <div class="why-block">
+      <h2 id="vs-raw-openswoole" class="why-h2">ZealPHP vs raw OpenSwoole &mdash; engine vs harness</h2>
+      <p class="why-octane-intro">
+        The most common HN-shaped question: <em>&ldquo;it&rsquo;s just OpenSwoole &mdash; why the extra layer?&rdquo;</em>
+        Same shape as &ldquo;it&rsquo;s just Node http &mdash; why Express?&rdquo; You can write raw <code>onRequest</code>
+        handlers and ship them; people do. The catch is that every project that does ends up re-inventing
+        the same 12 things. <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a> is the engine.
+        ZealPHP is the harness that lets you steer it without re-implementing the glue.
+      </p>
+      <div class="why-engine-grid">
+        <div class="why-engine-col why-engine-col-engine">
+          <h3 class="why-engine-col-title">OpenSwoole gives you</h3>
+          <p class="why-engine-col-tag">the runtime &mdash; raw power</p>
+          <ul class="why-engine-list">
+            <li>HTTP server + WebSocket\Server primitives (<code>onRequest</code>, <code>onMessage</code>, <code>onOpen</code>, <code>onClose</code>)</li>
+            <li>Coroutines: <code>go()</code>, <code>Channel</code>, <code>WaitGroup</code>, <code>Coroutine::getContext()</code></li>
+            <li><code>Atomic</code> + <code>Table</code> &mdash; lock-free shared memory across workers</li>
+            <li><code>Coroutine\Http\Client</code> + DNS + sleep + file I/O hooks</li>
+            <li><code>OpenSwoole\Runtime::enableCoroutine(HOOK_ALL)</code> &mdash; PHP I/O yields the reactor automatically</li>
+            <li><code>Process\Pool</code> + master/manager/worker lifecycle</li>
+            <li>Timers: <code>Timer::tick()</code>, <code>Timer::after()</code></li>
+            <li><code>Process</code> for sub-process fork + IPC pipes</li>
+            <li>FastCGI coroutine client (v22.1+)</li>
+          </ul>
+        </div>
+        <div class="why-engine-col why-engine-col-harness">
+          <h3 class="why-engine-col-title">ZealPHP adds on top</h3>
+          <p class="why-engine-col-tag">the harness &mdash; usable surface</p>
+          <ul class="why-engine-list">
+            <li><strong>Routing</strong> &mdash; <code>route()</code> + <code>nsRoute</code> + <code>nsPathRoute</code> + <code>patternRoute</code> with reflection-based parameter injection (<a href="/routing">/routing</a>)</li>
+            <li><strong>PSR-15 middleware stack</strong> &mdash; 18 built-ins (CORS, ETag, Range, Compression, RateLimit, BasicAuth, HostRouter, ScopedMiddleware, &hellip;) covering common Apache mod_*  / nginx behaviors (<a href="/middleware">/middleware</a>)</li>
+            <li><strong><code>uopz</code> overrides</strong> &mdash; <code>session_start()</code>, <code>header()</code>, <code>setcookie()</code>, <code>http_response_code()</code>, <code>headers_list()</code>, the entire <code>session_*()</code> family, <code>flush()</code>, <code>apache_request_headers()</code>, <code>is_uploaded_file()</code> all just work, routing to per-request state instead of mutating process globals</li>
+            <li><strong>Coroutine-safe sessions</strong> &mdash; <code>CoSessionManager</code> with per-coroutine isolation, no <code>$_SESSION</code> races across concurrent requests (<a href="/sessions">/sessions</a>)</li>
+            <li><strong>Templating</strong> &mdash; <code>App::render</code> / <code>renderToString</code> / <code>renderStream</code> / <code>include</code> / <code>fragment</code> &mdash; htmx-style named regions, streaming-Generator output, sub-template composition (<a href="/templates">/templates</a>)</li>
+            <li><strong>Universal return contract</strong> &mdash; <code>int</code> = status, <code>array</code> = JSON, <code>Generator</code> = SSE/SSR stream, <code>string</code> = HTML, <code>Closure</code> = param-injected stream &mdash; one contract across route handler, public file, API closure, fallback, error handler, render(), include() (<a href="/responses#return-contract">/responses#return-contract</a>)</li>
+            <li><strong>ZealAPI</strong> &mdash; file-based REST: drop <code>api/users/get.php</code> &rarr; <code>GET /api/users</code> auto-routes; auth hooks (<code>authChecker</code>, <code>adminChecker</code>, <code>usernameProvider</code>) (<a href="/api">/api</a>)</li>
+            <li><strong>CGI worker bridge</strong> &mdash; <code>cgiMode('proc' | 'fork' | 'fcgi')</code> dispatches legacy <code>public/*.php</code> files with true global-scope isolation (<a href="/legacy-apps">/legacy-apps</a>)</li>
+            <li><strong>Pluggable Store + Counter backends</strong> &mdash; one API, three backends: Table (single-node, nanoseconds), Redis/Valkey (cross-node + persistence, ~ms), Tiered (L1 Table + L2 Redis with HMAC-signed cross-node L1 invalidation) (<a href="/store">/store</a>)</li>
+            <li><strong>Cross-host messaging</strong> &mdash; <code>Store::publish</code> / <code>App::subscribe</code> for fire-and-forget pub/sub, <code>publishReliable</code> / <code>subscribeReliable</code> for Streams-backed at-least-once delivery via consumer groups, <code>WSRouter</code> for cross-server WebSocket routing, first-class WS rooms with federated membership (<a href="/pubsub">/pubsub</a>)</li>
+            <li><strong>Stream wrapper for <code>php://input</code></strong> &mdash; legacy <code>file_get_contents('php://input')</code> in JSON APIs just works in long-running workers</li>
+            <li><strong>CLI tooling</strong> &mdash; <code>php app.php start/stop/restart/status/logs</code> + daemonization + per-port PID files + log filters (<code>--access</code>, <code>--debug</code>, <code>--server</code>, <code>--zlog</code>)</li>
+            <li><strong>Lifecycle validation</strong> &mdash; unsafe combinations (superglobals(true) + enableCoroutine(true)) throw at boot, not silently race in prod (v0.2.27)</li>
+          </ul>
+        </div>
+      </div>
+      <p class="why-octane-outro">
+        <strong>When raw OpenSwoole is the right choice:</strong> you&rsquo;re building a custom binary-protocol server (your own message broker, database driver, ASR pipeline), you can&rsquo;t use <code>uopz</code> (compliance / locked-down host), or you&rsquo;re explicitly building <em>another</em> framework. For everything else &mdash; HTTP, WebSocket, SSE, REST APIs, web apps with sessions, AI-streaming endpoints &mdash; the harness saves you weeks per project and keeps the migration door open to existing PHP code.
+      </p>
+    </div>
+
+    <div class="why-block">
       <h2 id="vs-octane" class="why-h2">ZealPHP vs Laravel Octane</h2>
       <p class="why-octane-intro">Two different problems:</p>
       <ul class="why-octane-list">
@@ -198,7 +250,7 @@
             <li class="why-fit-item">AI/LLM apps with streaming responses</li>
             <li class="why-fit-item">Real-time dashboards and live updates</li>
             <li class="why-fit-item">WebSocket apps (chat, collaboration)</li>
-            <li class="why-fit-item">High-concurrency APIs (10k+ req/s)</li>
+            <li class="why-fit-item">High-concurrency APIs — workloads where the I/O-concurrency-per-worker model pays off (measure before you commit)</li>
             <li class="why-fit-item">Migrating large PHP codebases to async</li>
             <li class="why-fit-item">LAMP-style PHP devs who want async without learning a framework</li>
             <li class="why-fit-item">Single-process deployments (no infra complexity)</li>
@@ -211,6 +263,7 @@
             <li class="why-fit-item">Need shared hosting (requires CLI access)</li>
             <li class="why-fit-item">Building a custom protocol server</li>
             <li class="why-fit-item">Committed to AMPHP / Revolt / ReactPHP — Fiber libraries that drive Revolt's event loop, a separate scheduler from OpenSwoole's reactor (an app picks one)</li>
+            <li class="why-fit-item">Need byte-for-byte Apache/nginx config replacement — ZealPHP covers the common .htaccess/nginx.conf patterns (rewrite, headers, auth, rate limit, MIME, etc.) but is not a drop-in replacement for every directive</li>
           </ul>
           <p class="why-fit-note">
             <strong class="why-fit-note-strong">Note:</strong>
@@ -223,7 +276,7 @@
     <div class="why-block">
       <h2 class="why-h2">Benchmarks</h2>
       <p class="why-bench-intro">
-        Numbers below are from one benchmark setup on a single machine. Real-world performance depends on payload size, I/O, OS limits, and tuning. Reproduce them yourself before you trust them.
+        Headline numbers: 117k req/s text, 106k JSON, 50k templated on a 4-core box with the full PSR-15 middleware stack — 0 failures across 150k requests. Numbers are from one benchmark setup; real-world performance depends on payload size, I/O, OS limits, and tuning. Reproduce in 60s with <code class="why-bench-inline-code">scripts/bench_vs_express.sh</code>. Full methodology, latency percentiles, caveats: <a href="/performance">/performance</a>.
       </p>
       <div class="bench-method why-bench-method">
         <strong>Method</strong> &nbsp;|&nbsp;
@@ -233,16 +286,6 @@
         &nbsp;|&nbsp;
         <a href="https://github.com/sibidharan/zealphp/blob/master/scripts/bench_vs_express.sh" target="_blank" rel="noopener">reproduce locally</a>
       </div>
-      <div class="bench why-bench">
-        <div class="bench-stat"><div class="num">117k</div><div class="label">req/s text</div><div class="sub">avg 1.7 ms</div></div>
-        <div class="bench-stat"><div class="num">106k</div><div class="label">req/s JSON</div><div class="sub">avg 1.9 ms</div></div>
-        <div class="bench-stat"><div class="num">50k</div><div class="label">req/s template</div><div class="sub">avg 4.0 ms</div></div>
-        <div class="bench-stat"><div class="num">0</div><div class="label">failures</div><div class="sub">/ 150k reqs</div></div>
-      </div>
-      <p class="why-bench-reproduce">
-        Don't trust our numbers — run it yourself:
-        <code class="why-bench-reproduce-code">scripts/bench_vs_express.sh</code>
-      </p>
     </div>
 
     <div class="why-cta">


### PR DESCRIPTION
## Why

Reframes ZealPHP across the website + README from a benchmark-flex pitch to an architectural one. The shift: **PHP IS the HTTP server now — not a CGI worker behind one.** WebSocket, SSE, streaming, timers, shared memory are first-class because the server never shuts down between requests. The migration story (existing PHP code runs unchanged in compatibility mode) stays prominent but secondary.

Pre-empts the most common architectural question — *"it's just OpenSwoole, why the extra layer?"* — by spelling out the engine vs harness relationship on both `/` and `/why-zealphp`.

## Summary

- **14 files, +355 / -242 net.** No `src/` changes. No new APIs. No release tag.
- Adds new sections on home: *"AI-friendly by being boring"* (HTML-first surface = easier for humans and AI assistants to reason about) and *"OpenSwoole is the engine. ZealPHP is the harness."* (two-column engine/harness layout + "when raw OpenSwoole is the right choice" caveat).
- Adds full layer-by-layer *"ZealPHP vs raw OpenSwoole — engine vs harness"* deep-dive on `/why-zealphp` enumerating every layer ZealPHP adds (routing, PSR-15 middleware, uopz overrides, coroutine-safe sessions, templating, return contract, ZealAPI, CGI bridge, pluggable Store backends, pub/sub + WSRouter + WS rooms, `php://input` wrapper, CLI tooling, lifecycle validation) with cross-links to every relevant doc page.
- **Specific phrase changes:**
  - `'The PHP Runtime for AI Web Apps'` headline stays (sticky, SEO-friendly), now immediately backed up by an architectural sub-line so the framing is defensible.
  - `'no Redis needed'` → scoped (`'cross-worker on one node; flip to Redis for cross-node'`) — fixes inconsistency with v0.2.40 federated rooms + cross-host pub/sub which require Redis.
  - `'Run WordPress unmodified / No patches, no forks, no compatibility layers / If it runs on Apache, it runs on ZealPHP'` → `'WordPress compatibility showcase via the CGI worker bridge in compatibility mode — with documented limits and ~30–50ms proc_open cost'`.
  - `'Apache + nginx parity'` → `'common Apache + nginx behavior coverage'` with `'migration use cases, not a byte-for-byte server replacement'` framing.
  - `'PHP-FPM cold-starts an interpreter per request'` corrected to `'keeps the interpreter warm but discards request-local state, and gives PHP no native way to hold a persistent connection'` (FPM workers stay warm; the inaccurate claim was a reviewer-caught factual error).
  - `'SSE/WebSocket cost ~0 to keep open'` → honest FD / heartbeat / OS-tuning caveat.
  - `'one process'` → `'one PHP application server'` (one-process is rhetorically convenient but architecturally wrong — OpenSwoole has master / manager / worker / task-worker).
  - Bench block (95-line table of Slim/Symfony/Laravel community benchmarks + Express "15%" callouts) demoted to one honest line + link to `/performance`.
  - `'Node.js needs 30 lines for what ZealPHP does in 5'` compare block removed entirely.

## Files touched

- `template/pages/home.php` — hero, demoted bench, *"what HTTP-server-ness buys you"* rewrite, new AI-friendly section, new engine/harness section, feature cards, *"Bring your PHP code along"* section
- `template/pages/why-zealphp.php` — hero subtitle, single-process card rewritten, demoted bench, full engine/harness deep-dive, fit grid extended
- `template/pages/legacy-apps.php` — hero intro + zero-mods callout
- `template/pages/migration.php` — `'no Redis'` / `'one process'` / `'6 services'` framing softened
- `template/pages/learn/{sessions,websocket,react-vs-php,deployment}.php` + `learn.php` — `'no Redis'` scoped to single-server, `'one process'` → `'PHP application server'`
- `template/pages/docs/index.php` — middleware nav description
- `README.md` — H1, perf callout, FPM characterization corrected, parity wording softened, SSE keep-open caveat, vs-Node depoliticized, vs-PHP-FPM rewritten
- `public/css/pages/home.css` — new `.home-section-ai-friendly`, `.home-section-engine`, `.home-hero-stamp` styles
- `public/css/pages/why-zealphp.css` — new `.why-engine-grid` styles (dark-theme variant)
- `public/css/zealphp.css` — `.code-compare-panel` neutralised (was green / red diff coloring; section no longer presents a good-vs-bad comparison)

## Test plan

- [x] All 14 affected pages still return 200; new key phrases (`A PHP HTTP server`, `OpenSwoole is the engine. ZealPHP is the harness.`, `AI-friendly by being boring`, `WordPress compatibility showcase`, `Bring your PHP code along`, etc.) render in the response HTML.
- [x] No PHP errors in rendered output.
- [x] Final grep across `template/` + `README.md` confirms removed phrases are gone everywhere except legitimate technical context — per-middleware `Apache parity:` reference lines on `/middleware`, historical *"LAMP era: one process per request"* prose on `/learn/react-vs-php`, accurate `proc_open` cold-start descriptions on `/vs-fpm`.
- [x] Reviewer to spot-check `/` + `/why-zealphp` + `/legacy-apps` + `/migration` in a browser (visual cadence, hx-boost nav, no broken layout). Three new home sections use amber accents (`.home-section-ai-friendly`, `.home-section-engine`, `.home-hero-stamp`) — confirm they read as intentional, not CSS leaks.
- [ ] No CI behavior changes expected (no `src/`, no `composer.json`, no `phpunit.xml`) — all required checks should pass.

## Out of scope (deliberately)

- No `src/` changes. No new APIs. No release tag.
- No update to `examples/agents/zealphp_reference.txt` (Python agent reference file) — its content is for the LLM-driven chat agent, not pitch copy.
- No CHANGELOG entry — docs-only, no behavior change.
- The *"Live AI Chat"* section on home is untouched — the demo is real and accurate (powered by OpenAI Agents SDK + ZealPHP SSE streaming).
