### PR TITLE
chore(theme): swap hljs theme monokai -> stackoverflow-dark

### DIFF
--- a/template/_head.php
+++ b/template/_head.php
@@ -61,7 +61,7 @@ $ogImageUrl = $ogImageExists ? ($__scheme . '://' . $__host . $ogImage) : null;
        Loaded up front, not lazily per page, so hx-boost navigation never
        flashes unstyled content waiting on a per-page stylesheet to fetch. -->
   <link rel="stylesheet" href="/css/pages.css?v=<?= $v ?>">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/monokai.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/stackoverflow-dark.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <!-- Instrument Sans — display / heading font; Fira Code — code font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap">

--- a/template/components/_demo_shell.php
+++ b/template/components/_demo_shell.php
@@ -33,7 +33,7 @@ $titleHtml   = htmlspecialchars($title);
        the same per-page CSS the lessons load. Without this link, widgets
        in /demo/view/* render unstyled. -->
   <link rel="stylesheet" href="/css/pages.css?v=<?= $v ?>">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/monokai.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/stackoverflow-dark.min.css">
   <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" defer></script>
   <script src="/js/learn-demo-viewers.js?v=<?= $v ?>" defer></script>


### PR DESCRIPTION
Stack Overflow's editor palette: muted blue keywords, soft green strings, gold function names, dim grey comments. More docs-tone than monokai's vivid editor look. Same library version + CDN; only the stylesheet swap. 2-file change (template/_head.php + template/components/_demo_shell.php).