### PR TITLE
fix(home): left-align engine/harness lead — drop auto horizontal margin

### DIFF
--- a/public/css/pages/home.css
+++ b/public/css/pages/home.css
@@ -127,7 +127,7 @@
 
 /* --- Engine vs harness section (sits between AI-friendly and Feature grid) - */
 .home-section-engine { background: #fff; padding-top: 3rem; padding-bottom: 3rem; }
-.home-engine-lead { max-width: 760px; margin: 0 auto 2rem; }
+.home-engine-lead { max-width: 760px; margin: 0 0 2rem; }
 .home-engine-grid {
   display: grid; grid-template-columns: 1fr 1fr; gap: 0;
   border: 1px solid var(--border); border-radius: var(--radius);


### PR DESCRIPTION
Single-line CSS fix. .home-engine-lead was margin: 0 auto 2rem (horizontally centered). The surrounding section heading + grid all read left-aligned; the centered lead broke the flow. Now margin: 0 0 2rem.