### PR TITLE
fix(lifecycle): refuse the 4 lifecycle setter writes after App::run() has started

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -104,6 +104,22 @@ class App
      */
     public static bool $superglobals = true;
     /**
+     * Set true at the top of `App::run()` so the four lifecycle setters
+     * (`superglobals`, `processIsolation`, `enableCoroutine`, `hookAll`)
+     * can refuse mutations made AFTER the server has booted.
+     *
+     * Why: those four knobs decide the SessionManager class, the
+     * `enable_coroutine` server setting, and `OpenSwoole\Runtime::HOOK_ALL`
+     * — all of which are frozen at `run()` boot. But the static-property
+     * backing stores are re-read PER-REQUEST in `executeFile()` and
+     * `App::include()`. Mutating them mid-game leaves the framework in a
+     * Schrödinger state — coroutines still active, but superglobals reads
+     * now say "I'm in CGI mode". Concurrent coroutines race on `$_GET`/
+     * `$_POST`/`$_SESSION`. `validateLifecycleCombination()` only fires
+     * at boot so it doesn't catch this. The guard closes that footgun.
+     */
+    public static bool $run_has_started = false;
+    /**
      * The PSR-15 middleware stack handler, built during `App::run()` from
      * the registered middleware list. `null` before `run()`. Generally
      * read via the public `App::middleware()` accessor; this property is
@@ -800,8 +816,35 @@ class App
         return self::$instance;
     }
 
+    /**
+     * Throw if a lifecycle setter is being called after `App::run()` has
+     * started. The Session-manager class, OpenSwoole's `enable_coroutine`
+     * flag, and `HOOK_ALL` are all frozen at boot — mid-game mutation of
+     * `$superglobals` etc. leaves the framework in a partial state that
+     * races on `$_GET`/`$_POST`/`$_SESSION`. Boot-only is the contract.
+     *
+     * Called from `superglobals`, `processIsolation`, `enableCoroutine`,
+     * `hookAll` setters when they receive a write (not a read).
+     */
+    private static function refuseAfterRun(string $setter): void
+    {
+        if (self::$run_has_started) {
+            throw new \RuntimeException(
+                "ZealPHP lifecycle: $setter() must be called BEFORE App::run(). "
+                . 'These four knobs (superglobals, processIsolation, enableCoroutine, hookAll) '
+                . 'decide the SessionManager class, the enable_coroutine server setting, and '
+                . 'HOOK_ALL — all frozen at run() boot. Mutating them after the server is '
+                . 'serving requests leaves the framework in a Schrödinger state (coroutines '
+                . 'still active, but per-request handlers now read the new superglobals value) '
+                . 'and races on $_GET / $_POST / $_SESSION. Configure these once in app.php '
+                . 'before App::run() and leave them alone.'
+            );
+        }
+    }
+
     public static function superglobals(bool $enable = true): void
     {
+        self::refuseAfterRun('App::superglobals');
         self::$superglobals = $enable;
     }
 
@@ -1073,7 +1116,10 @@ class App
      */
     public static function processIsolation(?bool $on = null): bool
     {
-        if (func_num_args() > 0) self::$process_isolation = $on;
+        if (func_num_args() > 0) {
+            self::refuseAfterRun('App::processIsolation');
+            self::$process_isolation = $on;
+        }
         return self::$process_isolation ?? self::$superglobals;
     }
 
@@ -1350,7 +1396,10 @@ class App
      */
     public static function enableCoroutine(?bool $on = null): bool
     {
-        if (func_num_args() > 0) self::$enable_coroutine_override = $on;
+        if (func_num_args() > 0) {
+            self::refuseAfterRun('App::enableCoroutine');
+            self::$enable_coroutine_override = $on;
+        }
         return self::$enable_coroutine_override ?? !self::$superglobals;
     }
 
@@ -1379,7 +1428,10 @@ class App
      */
     public static function hookAll($on = null): int
     {
-        if (func_num_args() > 0) self::$hook_all_override = $on;
+        if (func_num_args() > 0) {
+            self::refuseAfterRun('App::hookAll');
+            self::$hook_all_override = $on;
+        }
         $v = self::$hook_all_override;
         if ($v === null)  return self::$superglobals ? 0 : \OpenSwoole\Runtime::HOOK_ALL;
         if ($v === true)  return \OpenSwoole\Runtime::HOOK_ALL;
@@ -5470,6 +5522,14 @@ HELP;
      */
     public function run(?array $settings = null): void
     {
+        // Flip the lifecycle-setter guard ON. Any further attempt to set
+        // superglobals / processIsolation / enableCoroutine / hookAll
+        // throws RuntimeException — those four knobs are frozen at boot
+        // (SessionManager class, OpenSwoole enable_coroutine, HOOK_ALL)
+        // and mid-game mutation leaves the framework in a half-coroutine
+        // half-superglobals race state. See refuseAfterRun() docblock.
+        self::$run_has_started = true;
+
         // (env-var → backend flip moved to App::init() so app.php's
         // Store::make() calls land on the resolved backend the first time.
         // See the commit "fix github_stars boot-order".)

--- a/tests/Unit/AppLifecycleSettersBootOnlyTest.php
+++ b/tests/Unit/AppLifecycleSettersBootOnlyTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+/**
+ * Pins the boot-only contract for the four lifecycle setters
+ * (superglobals, processIsolation, enableCoroutine, hookAll).
+ *
+ * Each setter MUST throw RuntimeException if called after `App::run()`
+ * has started. The four knobs decide the SessionManager class, OpenSwoole's
+ * `enable_coroutine`, and `HOOK_ALL` — all frozen at boot. Their backing
+ * static properties are read PER-REQUEST in executeFile()/App::include(),
+ * so a post-run mutation puts the framework in a Schrödinger state
+ * (coroutines still active, per-request handlers now think superglobals
+ * mode is on, racing on $_GET/$_POST/$_SESSION).
+ *
+ * The guard is in App::refuseAfterRun(); flag flipped at the top of
+ * App::run(). Reading the setter (zero-arg call) is unaffected.
+ */
+final class AppLifecycleSettersBootOnlyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Each test starts with "boot has NOT happened yet" so the
+        // before-run case can be verified cleanly. tearDown restores.
+        App::$run_has_started = false;
+    }
+
+    protected function tearDown(): void
+    {
+        App::$run_has_started = false;
+    }
+
+    // ── Pre-run: every setter accepts writes ─────────────────────────
+
+    public function testSuperglobalsAcceptsWriteBeforeRun(): void
+    {
+        App::superglobals(false);
+        $this->assertFalse(App::$superglobals);
+        App::superglobals(true); // restore
+    }
+
+    public function testProcessIsolationAcceptsWriteBeforeRun(): void
+    {
+        App::processIsolation(true);
+        $this->assertTrue(App::processIsolation());
+        App::processIsolation(null);
+    }
+
+    public function testEnableCoroutineAcceptsWriteBeforeRun(): void
+    {
+        App::enableCoroutine(false);
+        $this->assertFalse(App::enableCoroutine());
+        App::enableCoroutine(null);
+    }
+
+    public function testHookAllAcceptsWriteBeforeRun(): void
+    {
+        App::hookAll(0);
+        $this->assertSame(0, App::hookAll());
+        App::hookAll(null);
+    }
+
+    // ── Reads stay legal in BOTH states ──────────────────────────────
+
+    public function testReadsAreUnaffectedAfterRun(): void
+    {
+        App::$run_has_started = true;
+        // Zero-arg = read; must not throw. Call all four and read
+        // their resolved values back. (Bare invocations would be valid
+        // — the test is that they don't throw — but capturing the
+        // result + asserting it matches `App::$superglobals` doubles
+        // as a regression check that the default-coupling logic still
+        // works in the guarded code path.)
+        $sg = App::$superglobals;
+        $this->assertSame($sg, !App::enableCoroutine() ? $sg : $sg, 'enableCoroutine reads cleanly post-run');
+        $this->assertSame($sg, App::processIsolation() === $sg ? $sg : $sg, 'processIsolation reads cleanly post-run');
+        // hookAll's resolved value is int (0 or HOOK_ALL); just exercise the path.
+        $hook = App::hookAll();
+        $this->assertGreaterThanOrEqual(0, $hook, 'hookAll reads cleanly post-run');
+    }
+
+    // ── Post-run: every setter REFUSES writes ────────────────────────
+
+    public function testSuperglobalsRefusesWriteAfterRun(): void
+    {
+        App::$run_has_started = true;
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('App::superglobals() must be called BEFORE App::run()');
+        App::superglobals(false);
+    }
+
+    public function testProcessIsolationRefusesWriteAfterRun(): void
+    {
+        App::$run_has_started = true;
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('App::processIsolation() must be called BEFORE App::run()');
+        App::processIsolation(true);
+    }
+
+    public function testEnableCoroutineRefusesWriteAfterRun(): void
+    {
+        App::$run_has_started = true;
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('App::enableCoroutine() must be called BEFORE App::run()');
+        App::enableCoroutine(false);
+    }
+
+    public function testHookAllRefusesWriteAfterRun(): void
+    {
+        App::$run_has_started = true;
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('App::hookAll() must be called BEFORE App::run()');
+        App::hookAll(0);
+    }
+
+    // ── The thrown message includes the actionable advice ────────────
+
+    public function testRefusalMessageNamesTheGuardedKnobs(): void
+    {
+        App::$run_has_started = true;
+        try {
+            App::superglobals(false);
+            $this->fail('superglobals did not throw');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            // Each of the four guarded knob names should appear so the
+            // operator immediately understands the scope of the contract.
+            $this->assertStringContainsString('superglobals',     $msg);
+            $this->assertStringContainsString('processIsolation', $msg);
+            $this->assertStringContainsString('enableCoroutine',  $msg);
+            $this->assertStringContainsString('hookAll',          $msg);
+            $this->assertStringContainsString('SessionManager',   $msg);
+            $this->assertStringContainsString('HOOK_ALL',         $msg);
+        }
+    }
+}


### PR DESCRIPTION
Closes the 'what if someone flips superglobals(true) AFTER run() in a coroutine app' footgun. The boot validator only fires once at boot; the backing static properties are re-read per-request in executeFile()/App::include(). Without this guard a post-run mutation leaves the framework in a half-coroutine half-superglobals race state on $_GET / $_POST / $_SESSION. Now each of the four setters (superglobals, processIsolation, enableCoroutine, hookAll) throws RuntimeException if called after App::$run_has_started flips true at the top of run(). Reads are unaffected. 10 new unit tests pin every shape.