### PR TITLE
fix(perf-copy): say '4 HTTP workers' instead of '4-core box' (the actual bench lever)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Running `php app.php` serves the same docs site locally. Set `ZEALPHP_SITE_URL` 
 | **Unit tests** | PHPUnit 11 — 130 unit tests + 46 integration tests, all green |
 | **Benchmarks** | OpenSwoole-powered concurrency with a modular `scripts/bench.sh` runner for wrk/ab sweeps through c=1000 |
 
-> **Performance:** 117k req/s text · 106k JSON · 50k templated on a 4-core box, full PSR-15 middleware stack, 0 failures across 150k requests. ZealPHP retains ~82% of OpenSwoole's raw throughput with the framework on top; numbers vary by workload, payload, and hardware.
+> **Performance:** 117k req/s text · 106k JSON · 50k templated with 4 HTTP workers under the full PSR-15 middleware stack, 0 failures across 150k requests. ZealPHP retains ~82% of OpenSwoole's raw throughput with the framework on top; numbers vary by workload, payload, and hardware.
 >
 > Reproduce in 60s: `./scripts/bench_vs_express.sh`. Full methodology, latency percentiles, concurrency sweep, and caveats: [PERF.md](PERF.md).
 > **Stability:** Alpha (v0.2.x). API may change between minor versions until v1.0. Pin to a specific version in production.

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -56,7 +56,7 @@ $siteUrl = site_url();
     </div>
 
     <p class="home-bench-intro">
-      On a 4-core box, full PSR-15 stack &mdash; <strong>117k req/s text &middot; 106k JSON &middot; 50k templated</strong>, 0 failures across 150k requests.
+      With 4 HTTP workers, full PSR-15 stack &mdash; <strong>117k req/s text &middot; 106k JSON &middot; 50k templated</strong>, 0 failures across 150k requests.
       Reproduce in 60s: <code class="home-bench-method-code">scripts/bench_vs_express.sh</code>.
       Full concurrency sweep, latency percentiles, methodology, and caveats &mdash;
       <a href="/performance">/performance</a>.

--- a/template/pages/why-zealphp.php
+++ b/template/pages/why-zealphp.php
@@ -276,7 +276,7 @@
     <div class="why-block">
       <h2 class="why-h2">Benchmarks</h2>
       <p class="why-bench-intro">
-        Headline numbers: 117k req/s text, 106k JSON, 50k templated on a 4-core box with the full PSR-15 middleware stack — 0 failures across 150k requests. Numbers are from one benchmark setup; real-world performance depends on payload size, I/O, OS limits, and tuning. Reproduce in 60s with <code class="why-bench-inline-code">scripts/bench_vs_express.sh</code>. Full methodology, latency percentiles, caveats: <a href="/performance">/performance</a>.
+        Headline numbers: 117k req/s text, 106k JSON, 50k templated with 4 HTTP workers under the full PSR-15 middleware stack — 0 failures across 150k requests. Numbers are from one benchmark setup; real-world performance depends on payload size, I/O, OS limits, and tuning. Reproduce in 60s with <code class="why-bench-inline-code">scripts/bench_vs_express.sh</code>. Full methodology, latency percentiles, caveats: <a href="/performance">/performance</a>.
       </p>
       <div class="bench-method why-bench-method">
         <strong>Method</strong> &nbsp;|&nbsp;


### PR DESCRIPTION
/performance says the bench machine is AMD Ryzen 9 7900X (12 cores) with 4 HTTP workers configured. The 'on a 4-core box' wording on home, why-zealphp, and README conflated worker count with core count. '4 HTTP workers' is the honest framing — and matches what readers see when they click through to the /performance methodology table.

3 files, 3 lines.