### PR TITLE
feat: add resolveClubParam(), failAs(), make json() public

### DIFF
--- a/src/ZealAPI.php
+++ b/src/ZealAPI.php
@@ -400,14 +400,21 @@ class ZealAPI extends REST
         throw new \BadMethodCallException("ZealAPI: undefined method \$this->{$method}()");
     }
 
-    /*
-    Encode array into JSON
-    */
+    public function resolveClubParam()
+    {
+        return $this->_request['club'] ?? $this->_request['group'] ?? null;
+    }
+
+    public function failAs(\Throwable $e)
+    {
+        $this->response($this->json(["error" => $e->getMessage()]), 400);
+    }
+
     /**
      * @param mixed $data
      * @return string
      */
-    private function json($data)
+    public function json($data)
     {
         if (is_array($data)) {
             return (string)json_encode($data, JSON_PRETTY_PRINT);

--- a/src/ZealAPI.php
+++ b/src/ZealAPI.php
@@ -400,12 +400,25 @@ class ZealAPI extends REST
         throw new \BadMethodCallException("ZealAPI: undefined method \$this->{$method}()");
     }
 
-    public function resolveClubParam()
+    /**
+     * Resolve the canonical "club" identifier from the current request,
+     * accepting either `club` (the new name) or `group` (the legacy alias
+     * still used by older client code). Returns whatever the request
+     * payload carries — typically a string id — or null when neither key
+     * is present.
+     */
+    public function resolveClubParam(): mixed
     {
-        return $this->_request['club'] ?? $this->_request['group'] ?? null;
+        $req = is_array($this->_request) ? $this->_request : [];
+        return $req['club'] ?? $req['group'] ?? null;
     }
 
-    public function failAs(\Throwable $e)
+    /**
+     * Shorthand for emitting a 400 JSON error from a caught Throwable.
+     * Mirrors the `{"error": "<message>"}` envelope every other ZealAPI
+     * error path uses, so client code can rely on one error shape.
+     */
+    public function failAs(\Throwable $e): void
     {
         $this->response($this->json(["error" => $e->getMessage()]), 400);
     }

--- a/tests/Unit/ZealApiUpstreamPatchesTest.php
+++ b/tests/Unit/ZealApiUpstreamPatchesTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\App;
+use ZealPHP\G;
+use ZealPHP\Tests\TestCase;
+use ZealPHP\ZealAPI;
+
+/**
+ * Pins the three upstream-from-labs patches: resolveClubParam() (club/group
+ * alias), failAs() (Throwable → 400 JSON), and json() (now public so handler
+ * closures can call $this->json() directly).
+ */
+class ZealApiUpstreamPatchesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        App::$cwd = ZEALPHP_ROOT;
+        App::superglobals(true);
+
+        $g = G::instance();
+        $g->server = ['REQUEST_METHOD' => 'GET'];
+        $g->get = [];
+        $g->post = [];
+        $g->zealphp_request = new \stdClass();
+        $g->zealphp_response = new class {
+            /** @var array<string, mixed> */
+            public array $headers = [];
+            public int $status = 200;
+
+            public function header(string $name, mixed $value, bool $ucwords = true): void
+            {
+                $this->headers[$name] = $value;
+            }
+
+            public function status(int $status): void
+            {
+                $this->status = $status;
+            }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        $g = G::instance();
+        $g->zealphp_request = null;
+        $g->zealphp_response = null;
+        $g->server = [];
+        $g->get = [];
+        $g->post = [];
+        parent::tearDown();
+    }
+
+    private function api(): ZealAPI
+    {
+        return new ZealAPI(null, null, sys_get_temp_dir());
+    }
+
+    private function captureStatus(callable $fn): array
+    {
+        $g = G::instance();
+        ob_start();
+        $fn();
+        $echo = (string) ob_get_clean();
+        return ['echo' => $echo, 'status' => $g->zealphp_response->status];
+    }
+
+    // ── resolveClubParam() ─────────────────────────────────────────────
+
+    public function testResolveClubParamReturnsClubWhenPresent(): void
+    {
+        G::instance()->get = ['club' => 'club-42'];
+        $this->assertSame('club-42', $this->api()->resolveClubParam());
+    }
+
+    public function testResolveClubParamFallsBackToGroup(): void
+    {
+        G::instance()->get = ['group' => 'group-7'];
+        $this->assertSame('group-7', $this->api()->resolveClubParam());
+    }
+
+    public function testResolveClubParamPrefersClubOverGroup(): void
+    {
+        G::instance()->get = ['club' => 'club-1', 'group' => 'group-2'];
+        $this->assertSame('club-1', $this->api()->resolveClubParam());
+    }
+
+    public function testResolveClubParamReturnsNullWhenNeitherPresent(): void
+    {
+        G::instance()->get = ['other' => 'x'];
+        $this->assertNull($this->api()->resolveClubParam());
+    }
+
+    // ── failAs() ───────────────────────────────────────────────────────
+
+    public function testFailAsEmits400WithErrorMessageEnvelope(): void
+    {
+        $api = $this->api();
+        $r = $this->captureStatus(fn() => $api->failAs(new \RuntimeException('club not found')));
+        $this->assertSame(400, $r['status']);
+        $body = json_decode($r['echo'], true);
+        $this->assertSame(['error' => 'club not found'], $body);
+    }
+
+    public function testFailAsAcceptsAnyThrowable(): void
+    {
+        $api = $this->api();
+        // \Error (not just \Exception) — Throwable contract.
+        $r = $this->captureStatus(fn() => $api->failAs(new \Error('boom')));
+        $this->assertSame(400, $r['status']);
+        $this->assertSame(['error' => 'boom'], json_decode($r['echo'], true));
+    }
+
+    // ── json() public visibility ───────────────────────────────────────
+
+    public function testJsonIsCallableFromOutsideTheClass(): void
+    {
+        $rm = new \ReflectionMethod(ZealAPI::class, 'json');
+        $this->assertTrue($rm->isPublic(), 'json() must be public so handler closures can use $this->json()');
+    }
+
+    public function testJsonEncodesArrayAsPrettyJson(): void
+    {
+        $out = $this->api()->json(['k' => 'v']);
+        $this->assertJson($out);
+        $this->assertSame(['k' => 'v'], json_decode($out, true));
+    }
+
+    public function testJsonReturnsEmptyObjectForNonArray(): void
+    {
+        $this->assertSame('{}', $this->api()->json('not-an-array'));
+        $this->assertSame('{}', $this->api()->json(null));
+        $this->assertSame('{}', $this->api()->json(42));
+    }
+}


### PR DESCRIPTION
## Summary
- `resolveClubParam()`: resolves `club` or `group` request parameter (used by 13+ club API endpoints)
- `failAs()`: shorthand for error response from exception
- `json()`: changed from `private` to `public` so API handlers can call `$this->json()` directly

These were previously vendor-patched in labs-dashboard-web after every `composer update`.

## Test plan
- [ ] Existing ZealAPI tests pass
- [ ] Verify `json()` visibility change doesn't break REST parent class

🤖 Generated with [Claude Code](https://claude.com/claude-code)