### PR TITLE
chore: release v0.2.42 — task callback fix + mongodb ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.2.42] - 2026-05-25
+
+Task-worker stability fix + acknowledgment of sibling-package mongodb work.
+
+### Fixed
+
+- **Task callback `ArgumentCountError` worker crash (issue #103).** OpenSwoole 22.x dispatches `$server->on('task', …)` with two different signatures: 2-arg `($server, Task)` when `task_enable_coroutine => true` (our default), or legacy 4-arg `($server, $id, $worker_id, $data)` otherwise. The handler was registered with the 4-arg form only, so production workers running tasks under the default coroutine mode crashed with `Too few arguments to function … 2 passed and exactly 4 expected`. Workers auto-restarted (status=255), so the issue was self-healing but caused intermittent task failures. Fix: extracted `App::dispatchTaskCallback(array $rest): array|false` as a variadic-defensive adapter that tolerates both call shapes — neither user override nor OpenSwoole minor-version shifts can throw mid-worker now. Pinned by 10 unit tests in `tests/Unit/TaskCallbackDispatchTest`.
+
+### Acknowledged
+
+- **`sibidharan/zealphp-mongodb` v0.2.8 → v0.2.11** (issue #104) — sibling-package release stream that makes the MongoDB adapter a drop-in replacement for ext-mongodb. v0.2.8 switched `Collection::wrapDoc()` to return `MongoDB\Model\BSONDocument` so the 106 `instanceof BSONDocument` / 171 `getArrayCopy()` call sites in downstream code work transparently; v0.2.9 added full `MongoDB\Driver\*` polyfills (`Manager`, `BulkWrite`, `WriteResult`, `WriteError`, `WriteConcernError`, `BulkWriteException`) so worker scripts using the raw driver API run without ext-mongodb; v0.2.10/v0.2.11 fixed pass-by-reference bugs where `?? []` temporaries broke calls into the Rust extension layer. The framework `composer.json` doesn't pin the mongodb package (it's a separate `require` per-app), so no framework change is needed — update via `composer update sibidharan/zealphp-mongodb`.
+
+### Note on v0.2.41
+
+v0.2.41 was mis-tagged on Packagist at an orphan commit (`0372c3a`) — the pre-rebase head of PR #100 that did not include the intended release content (FCGI worker pool default, WP-on-proc regression fix, ZealAPI helpers, version-bump docs). v0.2.42 carries the v0.2.41-intended content plus the #103/#104 work above. If `composer require` already pulled v0.2.41, upgrade with `composer require sibidharan/zealphp:^0.2.42`.
+
 ## [0.2.41] - 2026-05-25
 
 ZealPHP-native FCGI-style worker pool — the v0.3.0 "warm + global scope" CGI bridge, shipped. `cgiMode('pool')` is now the framework default. `cgiMode('fork')` removed entirely. The CGI bridge's per-request cost drops from ~30–50 ms (proc) to ~1–3 ms (pool), matching FPM territory, while preserving full mod_php-style global-scope isolation (unmodified WordPress / Drupal works). Parent OpenSwoole worker dispatches to the pool via `Coroutine\Channel` — thousands of concurrent coroutines fan out across N pre-spawned PHP subprocesses without blocking the event loop. PHP HTTP server + FPM-style worker pool + async dispatch.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project sibidharan/zealphp-project:^0.2.41 my-project
+composer create-project sibidharan/zealphp-project:^0.2.42 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -431,8 +431,8 @@ App::onWorkerStart(function($server, $workerId) use ($hitCounter) {
 2. Run `composer validate` and confirm tests pass.
 3. Tag both `zealphp` and `zealphp-project` with the same version:
    ```bash
-   git tag -a v0.2.41 -m "Release v0.2.41"
-   git push origin master && git push origin v0.2.41
+   git tag -a v0.2.42 -m "Release v0.2.42"
+   git push origin master && git push origin v0.2.42
    ```
 4. Trigger Packagist webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.2.41 .
+docker build -t zealphp:0.2.42 .
 ```
 
 The shipped `Dockerfile` is PHP 8.3-cli on `bookworm` with OpenSwoole and
@@ -230,7 +230,7 @@ build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg UOPZ_VERSION=7.1.2 \
-    -t zealphp:0.2.41 .
+    -t zealphp:0.2.42 .
 ```
 
 ### Run (single container)
@@ -242,7 +242,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.2.41
+    zealphp:0.2.42
 ```
 
 ### Production compose
@@ -253,7 +253,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.2.41
+    image: registry.example.com/zealphp-app:0.2.42
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/src/App.php
+++ b/src/App.php
@@ -2101,6 +2101,68 @@ class App
     // -----------------------------------------------------------------------
 
     /**
+     * Dispatch payload for the `$server->on('task', …)` callback.
+     *
+     * OpenSwoole 22.x calls task handlers with TWO different signatures
+     * depending on `task_enable_coroutine`:
+     *
+     *   true  → ($server, OpenSwoole\Server\Task $task)        // 2-arg
+     *   false → ($server, $id, $worker_id, $data)              // 4-arg
+     *
+     * Our default is `task_enable_coroutine => true`, so the 2-arg form
+     * is the production hot path; apps that opt back out get the 4-arg
+     * form. Accepting both shapes here means neither a user override
+     * nor an OpenSwoole minor-version shift can throw `ArgumentCountError`
+     * mid-worker. See issue #103.
+     *
+     * @param  list<mixed> $rest  Variadic args excluding $server.
+     * @return array{task: array<mixed>, result: mixed}|false
+     */
+    public static function dispatchTaskCallback(array $rest): array|false
+    {
+        if (count($rest) === 1 && is_object($rest[0])) {
+            // Coroutine task path: $rest[0] is OpenSwoole\Server\Task
+            $data = $rest[0]->data ?? [];
+        } elseif (count($rest) === 3) {
+            // Legacy 4-arg path: ($id, $worker_id, $data)
+            $data = $rest[2];
+        } else {
+            elog('Task callback received unexpected arity ' . count($rest), 'error');
+            return false;
+        }
+        if (!is_array($data)) {
+            elog('Task payload not an array; dropping', 'error');
+            return false;
+        }
+        $handler = $data['handler'] ?? '';
+        if (!is_string($handler) || $handler === '') {
+            elog('Task payload missing string "handler"; dropping', 'error');
+            return false;
+        }
+        $args = $data['args'] ?? [];
+        if (!is_array($args)) {
+            elog('Task payload "args" must be an array; dropping', 'error');
+            return false;
+        }
+        $_func = basename($handler);
+        if (file_exists(self::$cwd . $handler . '.php')) {
+            include self::$cwd . $handler . '.php';
+            /** @var callable $fn */
+            $fn = $$_func;
+            $result = $fn(...$args);
+            unset($$_func);
+        } else {
+            elog("Task handler not found: $handler", 'error');
+            $result = false;
+        }
+        elog((string) json_encode([$data, $result]), 'task');
+        return [
+            'task'   => $data,
+            'result' => $result,
+        ];
+    }
+
+    /**
      * Fork-join helper — runs every closure in `$tasks` in its own
      * coroutine in parallel and returns the results in input order.
      *
@@ -5913,28 +5975,19 @@ HELP;
         });
 
         if (($effective_settings['task_worker_num'] ?? 0) > 0) {
-            $server->on('task', function ($server, $id, $rid, $data) {
-                assert(is_array($data));
-                $handler = $data['handler'] ?? '';
-                assert(is_string($handler));
-                $args = $data['args'] ?? [];
-                assert(is_array($args));
-                $_func = basename($handler);
-                if(file_exists(App::$cwd.$handler.'.php')){
-                    include App::$cwd.$handler.'.php';
-                    /** @var callable $fn */
-                    $fn = $$_func;
-                    $result = $fn(...$args);
-                    unset($$_func);
-                } else {
-                    elog("Task handler not found: $handler", "error");
-                    $result = false;
-                }
-                elog((string)json_encode([$data, $result]), "task");
-                return [
-                    'task' => $data,
-                    'result' => $result
-                ];
+            // OpenSwoole 22.x dispatches task callbacks with TWO different
+            // signatures depending on settings:
+            //
+            //   task_enable_coroutine = true  → function($server, Task $task)
+            //   task_enable_coroutine = false → function($server, $id, $rid, $data)
+            //
+            // Our default is `task_enable_coroutine => true`, so the 2-arg
+            // form is the production hot path; the 4-arg form is kept for
+            // apps that opt back out. The variadic adapter below tolerates
+            // both, so neither user override nor an OpenSwoole minor-version
+            // shift can cause `ArgumentCountError` mid-worker. See issue #103.
+            $server->on('task', function ($server, ...$rest) {
+                return App::dispatchTaskCallback(array_values($rest));
             });
 
             $server->on('finish', function ($server, $task_id, $data) {

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.2.41
+    image: zealphp:0.2.42
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -177,7 +177,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  sibidharan/zealphp-project:^0.2.41 \
+  sibidharan/zealphp-project:^0.2.42 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, coroutines, shared memory, task workers &mdash;
        first&#8209;class because the server never shuts down between requests.</p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.2.41 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.2.42 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -309,7 +309,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.2.41 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.2.41 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.2.42 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.2.42 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>

--- a/tests/Unit/TaskCallbackDispatchTest.php
+++ b/tests/Unit/TaskCallbackDispatchTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+/**
+ * Pins issue #103 — `App::dispatchTaskCallback()` must tolerate BOTH the
+ * 2-arg coroutine form (`task_enable_coroutine => true`) and the legacy
+ * 4-arg form. A regression here surfaces in production as
+ * `ArgumentCountError: Too few arguments to function … 2 passed and
+ * exactly 4 expected`, crashing worker processes mid-task.
+ *
+ * The handler closure registered on `$server->on('task', …)` is just a
+ * thin shim that passes the variadic rest through to this static
+ * method; the dispatch logic lives here so it's directly testable
+ * without booting a real OpenSwoole server.
+ */
+final class TaskCallbackDispatchTest extends TestCase
+{
+    private static string $tmpDir = '';
+    private static string $origCwd = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$tmpDir = sys_get_temp_dir() . '/zealphp-task-test-' . bin2hex(random_bytes(3));
+        mkdir(self::$tmpDir . '/task', 0775, true);
+        self::$origCwd = App::$cwd ?? '';
+        App::$cwd = self::$tmpDir;
+
+        // A working task handler: task/echo.php returns its args verbatim.
+        file_put_contents(
+            self::$tmpDir . '/task/echo.php',
+            "<?php\n\$echo = function (...\$args) { return ['echoed' => \$args]; };\n"
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        App::$cwd = self::$origCwd;
+        @unlink(self::$tmpDir . '/task/echo.php');
+        @rmdir(self::$tmpDir . '/task');
+        @rmdir(self::$tmpDir);
+    }
+
+    // ── shape acceptance: both 2-arg and 4-arg call forms work ──────
+
+    public function testTwoArgCoroutineFormWithTaskObject(): void
+    {
+        // OpenSwoole 22.x: $server->on('task', function ($server, Task $task))
+        // when task_enable_coroutine => true (our default).
+        $task = new \stdClass();
+        $task->id = 42;
+        $task->worker_id = 0;
+        $task->data = ['handler' => '/task/echo', 'args' => ['hello']];
+
+        $result = App::dispatchTaskCallback([$task]);
+
+        $this->assertIsArray($result);
+        $this->assertSame($task->data, $result['task']);
+        $this->assertSame(['echoed' => ['hello']], $result['result']);
+    }
+
+    public function testLegacyFourArgFormWithPositionalData(): void
+    {
+        // OpenSwoole 22.x: $server->on('task', function ($server, $id, $rid, $data))
+        // when task_enable_coroutine => false.
+        $data = ['handler' => '/task/echo', 'args' => ['world']];
+
+        $result = App::dispatchTaskCallback([7, 0, $data]);
+
+        $this->assertIsArray($result);
+        $this->assertSame($data, $result['task']);
+        $this->assertSame(['echoed' => ['world']], $result['result']);
+    }
+
+    // ── defensive paths: unexpected arity / shape never throw ───────
+
+    public function testUnexpectedArityReturnsFalseWithoutThrowing(): void
+    {
+        // Hypothetical OpenSwoole bump that adds a 3rd shape — the
+        // dispatcher must log + return false rather than throw, so
+        // worker stays alive.
+        $this->assertFalse(App::dispatchTaskCallback([1, 2]));         // 2-arg without object
+        $this->assertFalse(App::dispatchTaskCallback([1, 2, 3, 4]));  // 4-arg
+        $this->assertFalse(App::dispatchTaskCallback([]));             // empty
+    }
+
+    public function testTwoArgFormWithNonObjectIsRejected(): void
+    {
+        // Scalar in position 0 is not a Task; dispatcher returns false.
+        $this->assertFalse(App::dispatchTaskCallback(['not-an-object']));
+    }
+
+    public function testNonArrayPayloadReturnsFalse(): void
+    {
+        $task = new \stdClass();
+        $task->data = 'not an array';
+        $this->assertFalse(App::dispatchTaskCallback([$task]));
+    }
+
+    public function testMissingHandlerKeyReturnsFalse(): void
+    {
+        $task = new \stdClass();
+        $task->data = ['args' => ['x']];  // no 'handler'
+        $this->assertFalse(App::dispatchTaskCallback([$task]));
+    }
+
+    public function testNonArrayArgsReturnsFalse(): void
+    {
+        $task = new \stdClass();
+        $task->data = ['handler' => '/task/echo', 'args' => 'not-an-array'];
+        $this->assertFalse(App::dispatchTaskCallback([$task]));
+    }
+
+    public function testUnknownHandlerFileReturnsTaskShapeWithFalseResult(): void
+    {
+        // Missing handler file is non-fatal — wrapper still returns the
+        // task envelope, with result=false. Keeps the OpenSwoole 'finish'
+        // callback happy.
+        $task = new \stdClass();
+        $task->data = ['handler' => '/task/does-not-exist', 'args' => []];
+        $result = App::dispatchTaskCallback([$task]);
+        $this->assertIsArray($result);
+        $this->assertSame($task->data, $result['task']);
+        $this->assertFalse($result['result']);
+    }
+
+    // ── data flow: args from the task payload reach the handler ─────
+
+    public function testHandlerReceivesArgsInOrder(): void
+    {
+        $task = new \stdClass();
+        $task->data = ['handler' => '/task/echo', 'args' => ['a', 'b', 'c']];
+        $result = App::dispatchTaskCallback([$task]);
+        $this->assertSame(['echoed' => ['a', 'b', 'c']], $result['result']);
+    }
+
+    public function testHandlerWithNoArgsRunsCleanly(): void
+    {
+        $task = new \stdClass();
+        $task->data = ['handler' => '/task/echo', 'args' => []];
+        $result = App::dispatchTaskCallback([$task]);
+        $this->assertSame(['echoed' => []], $result['result']);
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix #103** — `App::dispatchTaskCallback()` variadic-defensive adapter for OpenSwoole 22.x's two task-handler signatures (2-arg coroutine + 4-arg legacy). The 4-arg-only handler crashed prod workers with `Too few arguments to function … 2 passed and exactly 4 expected` under our default `task_enable_coroutine => true`. Self-healing via worker restart, but intermittent task failures while it happened.
- **Acknowledge #104** — `sibidharan/zealphp-mongodb` v0.2.8–v0.2.11 sibling-package release stream (BSONDocument drop-in, `MongoDB\Driver\*` polyfills, pass-by-ref fixes). No framework change needed; CHANGELOG notes the upgrade path.
- **Bump docs 0.2.41 → 0.2.42** — Quick Start panel, getting-started, deployment, Docker tags, README install snippet.
- **Note on v0.2.41** — was mis-tagged on Packagist at an orphan commit (`0372c3a`, pre-rebase head of PR #100). v0.2.42 carries the v0.2.41-intended content plus the #103/#104 fixes.

## Test plan
- [ ] All CI checks green (validate, static-analysis, phpunit 8.3/8.4/8.5, Infection, CodeQL, Perf smoke, gitleaks, codecov/patch)
- [ ] `tests/Unit/TaskCallbackDispatchTest` (10 tests) covers both call shapes + defensive paths
- [ ] Manual: `php app.php` boots cleanly + hero stamp shows "Alpha · v0.2.42"

Closes #103, closes #104.