### PR TITLE
chore: release v0.2.43 — CGI-isolation session fix (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.2.43] - 2026-05-25
+
+CGI-isolation session-persistence fix. `App::superglobals(true)` (legacy CGI) sessions now survive across requests as expected.
+
 ### Fixed
 
 - **Session data loss in CGI isolation mode (issue #108).** With `App::superglobals(true)` (which defaults `processIsolation(true)` and now defaults `cgiMode('pool')` since v0.2.42), session writes inside a CGI subprocess were silently lost — the reporter's "Value: EMPTY" reproducer was deterministic. Two independent bugs intersecting:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project sibidharan/zealphp-project:^0.2.42 my-project
+composer create-project sibidharan/zealphp-project:^0.2.43 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -431,8 +431,8 @@ App::onWorkerStart(function($server, $workerId) use ($hitCounter) {
 2. Run `composer validate` and confirm tests pass.
 3. Tag both `zealphp` and `zealphp-project` with the same version:
    ```bash
-   git tag -a v0.2.42 -m "Release v0.2.42"
-   git push origin master && git push origin v0.2.42
+   git tag -a v0.2.43 -m "Release v0.2.43"
+   git push origin master && git push origin v0.2.43
    ```
 4. Trigger Packagist webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.2.42 .
+docker build -t zealphp:0.2.43 .
 ```
 
 The shipped `Dockerfile` is PHP 8.3-cli on `bookworm` with OpenSwoole and
@@ -230,7 +230,7 @@ build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg UOPZ_VERSION=7.1.2 \
-    -t zealphp:0.2.42 .
+    -t zealphp:0.2.43 .
 ```
 
 ### Run (single container)
@@ -242,7 +242,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.2.42
+    zealphp:0.2.43
 ```
 
 ### Production compose
@@ -253,7 +253,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.2.42
+    image: registry.example.com/zealphp-app:0.2.43
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.2.42
+    image: zealphp:0.2.43
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -177,7 +177,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  sibidharan/zealphp-project:^0.2.42 \
+  sibidharan/zealphp-project:^0.2.43 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, coroutines, shared memory, task workers &mdash;
        first&#8209;class because the server never shuts down between requests.</p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.2.42 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.2.43 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -309,7 +309,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.2.42 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.2.42 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.2.43 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.2.43 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>


### PR DESCRIPTION
## Summary

Release v0.2.43 — bundles the issue #108 fix shipped in PR #109.

The actual code change landed in master as `2b6068d` via PR #109; this PR only:
- Promotes the `[Unreleased]` CHANGELOG entry to `[0.2.43] - 2026-05-25`.
- Bumps user-facing version references from `v0.2.42` to `v0.2.43`:
  - `README.md` — Quick Start install + tag-command example.
  - `template/pages/{home,getting-started,deployment}.php` — Quick Start panel + hero stamp + Docker image tag.
  - `docs/deployment.md` — Docker `build -t` / `image:` examples.

No code change, no PHPStan or PHPUnit impact (already green at PR #109 merge).

## Test plan

- [x] `grep -rn '\b0\.2\.42\b'` across README/template/docs returns 0 hits outside CHANGELOG history.
- [x] `composer create-project sibidharan/zealphp-project:^0.2.43` will resolve once the tag is published (Packagist + scaffold sync done as part of the post-merge tagging step).