### PR TITLE
fix: first-timer smoke test — setup.sh, lessons, docs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -330,6 +330,7 @@ install_dependencies() {
         "php${php_version}-xml" 
         "php${php_version}-curl"
         "php${php_version}-intl"
+        "php${php_version}-sqlite3"
         "php${php_version}-mysqli"
         "openssl" 
         "libssl-dev" 

--- a/setup.sh
+++ b/setup.sh
@@ -87,6 +87,11 @@ is_root() {
         echo -e "${RED}Please run as root.${RESET}"
         return 1 # Not root
     fi
+    # When already root (Docker, `curl | sudo bash`), sudo may not be installed.
+    SUDO=""
+    if [ "$EUID" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+    fi
     # Suppress interactive apt prompts (tzdata, etc.) — required for
     # `curl … | sudo bash` and for fresh Docker images where the timezone
     # dialog would otherwise hang the install.
@@ -156,7 +161,7 @@ get_confirmation() {
 update_package_lists() {
     echo -e "${YELLOW}Updating package lists.${RESET}"
 
-    if ! sudo apt update; then
+    if ! $SUDO apt update; then
         echo -e "${RED}Failed to update package lists.${RESET}"
         return 1 # Return an error code if the update fails
     fi
@@ -170,7 +175,7 @@ update_package_lists() {
 install_add_apt_repository() {
     if ! command -v add-apt-repository &>/dev/null; then
         echo -e "${YELLOW}Installing software-properties-common.${RESET}"
-        sudo apt install -y software-properties-common || {
+        $SUDO apt install -y software-properties-common || {
             echo -e "${RED}Failed to install software-properties-common.${RESET}"
             return 1 # Installation fails
         }
@@ -219,7 +224,7 @@ get_php_version_confirmation() {
         read -rp "Enter your choice (1/2/3): " choice
         case "$choice" in
         1)
-            sudo apt purge -y "php*" || { # Remove all PHP packages if user agrees
+            $SUDO apt purge -y "php*" || { # Remove all PHP packages if user agrees
                 echo -e "${RED}Failed to remove PHP $current_version. Aborting setup.${RESET}"
                 return 1 # Exit if removal fails
             }
@@ -247,14 +252,14 @@ install_php_8.3() {
     echo -e "${YELLOW}Installing PHP 8.3.${RESET}"
 
     echo -e "${GREEN}Adding Ondrej PHP repository.${RESET}"
-    sudo add-apt-repository -y ppa:ondrej/php || {
+    $SUDO add-apt-repository -y ppa:ondrej/php || {
         echo -e "${RED}Failed to add PHP repository.${RESET}"
         return 1 # The repository addition fails
     }
 
     update_package_lists || return 1
 
-    sudo apt install -y php8.3 || {
+    $SUDO apt install -y php8.3 || {
         echo -e "${RED}Failed to install PHP 8.3.${RESET}"
         return 1 # Installation fails
     }
@@ -266,7 +271,7 @@ install_php_8.3() {
 # Returns 0 if the configuration is successful, 1 if the configuration fails
 configure_php_path() {
     echo -e "${YELLOW}Configuring PHP path.${RESET}"
-    sudo update-alternatives --set php /usr/bin/php8.3 || {
+    $SUDO update-alternatives --set php /usr/bin/php8.3 || {
         echo -e "${RED}Failed to configure PHP path.${RESET}"
         return 1 # Configuration fails
     }
@@ -291,7 +296,7 @@ configure_php_extension() {
     echo -e "${YELLOW}Configuring PHP extension $extension.${RESET}"
 
     # Ensure the configuration file exists
-    sudo touch "$config_file"
+    $SUDO touch "$config_file"
 
     # Check if the extension is already in the configuration file
     if grep -q "^$extension$" "$config_file"; then
@@ -300,7 +305,7 @@ configure_php_extension() {
     fi
 
     # Add the extension to the configuration file
-    echo "$extension" | sudo tee -a "$config_file" >/dev/null || {
+    echo "$extension" | $SUDO tee -a "$config_file" >/dev/null || {
         echo -e "${RED}Failed to add $extension to $config_file.${RESET}"
         return 1 # Failed to add extension to PHP config
     }
@@ -323,8 +328,9 @@ install_dependencies() {
         "php${php_version}-common" 
         "php${php_version}-mbstring" 
         "php${php_version}-xml" 
-        "php${php_version}-curl" 
-        "php${php_version}-mysqli" 
+        "php${php_version}-curl"
+        "php${php_version}-intl"
+        "php${php_version}-mysqli"
         "openssl" 
         "libssl-dev" 
         "curl" 
@@ -335,13 +341,13 @@ install_dependencies() {
         "libpq-dev"
     )
 
-    sudo apt install -y "${packages[@]}" || {
+    $SUDO apt install -y "${packages[@]}" || {
         echo -e "${RED}Failed to install dependencies.${RESET}"
         return 1 # Installation fails
     }
 
     # Ensure the MySQL extension is enabled
-    sudo phpenmod mysqli || {
+    $SUDO phpenmod mysqli || {
         echo -e "${RED}Failed to enable the MySQL extension.${RESET}"
         return 1 # Enabling fails
     }
@@ -358,7 +364,7 @@ check_and_remove_openswoole() {
     # Check and remove installation via apt
     if dpkg -l | grep -q 'php-openswoole'; then
         echo -e "${GREEN}OpenSwoole is installed via apt. Removing.${RESET}"
-        sudo apt remove -y php-openswoole || {
+        $SUDO apt remove -y php-openswoole || {
             echo -e "${RED}Failed to remove OpenSwoole installed via apt.${RESET}"
             return 1 # removal fails
         }
@@ -376,7 +382,7 @@ check_and_remove_openswoole() {
     # Check and disable PHP extension if loaded
     if php -m | grep -q '^swoole$'; then
         echo -e "${GREEN}OpenSwoole PHP extension is loaded. Disabling.${RESET}"
-        sudo phpdismod openswoole || {
+        $SUDO phpdismod openswoole || {
             echo -e "${RED}Failed to disable OpenSwoole PHP extension.${RESET}"
             return 1 # disabling fails
         }
@@ -411,7 +417,7 @@ check_and_remove_uopz() {
         echo -e "${YELLOW}uopz is installed via apt. Removing.${RESET}"
 
         # Remove uopz installed via apt
-        sudo apt remove -y php-uopz || {
+        $SUDO apt remove -y php-uopz || {
             echo -e "${RED}Failed to remove uopz installed via apt.${RESET}"
             return 1 # removal fails
         }
@@ -431,7 +437,7 @@ check_and_remove_uopz() {
     # Check if uopz PHP extension is loaded
     if php -m | grep -q '^uopz$'; then
         echo -e "${RED}uopz PHP extension is loaded. Disabling.${RESET}"
-        sudo phpdismod uopz || {
+        $SUDO phpdismod uopz || {
             echo -e "${RED}Failed to disable uopz PHP extension.${RESET}"
             return 1 # disabling fails
         }
@@ -446,7 +452,7 @@ check_and_remove_uopz() {
 install_uopz() {
     echo -e "${YELLOW}Installing uopz${RESET}"
 
-    if sudo pecl install uopz 2>/dev/null; then
+    if $SUDO pecl install uopz 2>/dev/null; then
         echo -e "${GREEN}uopz installed via PECL.${RESET}"
     else
         echo -e "${YELLOW}PECL uopz failed (likely PHP 8.4+). Building from git source.${RESET}"
@@ -457,7 +463,7 @@ install_uopz() {
             rm -rf "$tmpdir"
             return 1
         }
-        (cd "$tmpdir" && phpize && ./configure && make -j"$(nproc)" && sudo make install) || {
+        (cd "$tmpdir" && phpize && ./configure && make -j"$(nproc)" && $SUDO make install) || {
             echo -e "${RED}Failed to build uopz from source.${RESET}"
             rm -rf "$tmpdir"
             return 1
@@ -486,7 +492,7 @@ check_composer_installed() {
 install_composer() {
     echo "Installing Composer using apt."
 
-    sudo apt install -y composer || {
+    $SUDO apt install -y composer || {
         echo "Failed to install Composer."
         return 1 # Installation fails
     }

--- a/template/pages/coroutines.php
+++ b/template/pages/coroutines.php
@@ -2,7 +2,7 @@
 <section class="section">
 <div class="container">
 <h1 class="section-title">Coroutines</h1>
-<p class="section-desc">OpenSwoole coroutines are cooperative — they yield only on I/O, making parallel fetch trivial. ZealPHP enables HOOK_ALL so all PHP I/O (file, curl, PDO) becomes coroutine-aware automatically.</p>
+<p class="section-desc">OpenSwoole coroutines are cooperative — they yield only on I/O, making parallel fetch trivial. ZealPHP enables HOOK_ALL so most PHP I/O (file, curl, sleep) becomes coroutine-aware automatically.</p>
 
 <?php
 $demos = [
@@ -50,7 +50,7 @@ foreach ($demos as [$id, $title, $url, $code]) {
   <tr><td><code>co::sleep(float $s)</code></td><td>Yield for N seconds without blocking the event loop.</td></tr>
   <tr><td><code>new Channel(int $capacity)</code></td><td>Buffered queue for coroutine communication. <code>push()</code> + <code>pop()</code>.</td></tr>
   <tr><td><code>usleep(int $us)</code></td><td>Coroutine-aware micro-sleep under HOOK_ALL (use for sub-second delays).</td></tr>
-  <tr><td><code>OpenSwoole\Runtime::HOOK_ALL</code></td><td>Makes all PHP I/O — curl, file, PDO, sleep — yield the event loop.</td></tr>
+  <tr><td><code>OpenSwoole\Runtime::HOOK_ALL</code></td><td>Makes most PHP I/O — curl, file, sleep — yield the event loop. PDO is <strong>not</strong> hooked in OpenSwoole 22.1&ndash;26.2.</td></tr>
 </table>
 
 <div class="callout info coro-mt">

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -370,7 +370,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
         <h3 class="home-engine-col-title">ZealPHP adds on top</h3>
         <ul class="home-engine-list">
           <li>Routing (<code>route()</code> + <code>nsRoute</code> + <code>patternRoute</code>) with reflection-based parameter injection</li>
-          <li>PSR-15 middleware stack &mdash; 18 built-ins covering common Apache/nginx behaviors</li>
+          <li>PSR-15 middleware stack &mdash; 28 built-ins covering common Apache/nginx behaviors</li>
           <li><code>uopz</code> overrides so <code>session_start()</code>, <code>header()</code>, <code>setcookie()</code>, <code>$_GET</code>/<code>$_POST</code>/<code>$_SESSION</code>, <code>echo</code> all just work</li>
           <li>Coroutine-safe sessions (per-request <code>RequestContext</code>, no process-wide superglobal races)</li>
           <li>Templating (<code>App::render</code> / <code>renderStream</code> / <code>fragment</code>) with streaming-Generator output</li>

--- a/template/pages/learn/ai-chat.php
+++ b/template/pages/learn/ai-chat.php
@@ -26,6 +26,19 @@ $active = $active ?? 'learn/ai-chat';
       or deletes them on command. The reply <strong>streams token by token</strong>, like ChatGPT,
       so a slow model never feels frozen.
     </p>
+
+    <div class="callout info">
+      <strong>Build it yourself.</strong> The AI logic classes (<code>Chat</code>, <code>ChatHistory</code>)
+      ship with the framework in <code>vendor/</code>. You&rsquo;ll create:
+      <ol>
+        <li><code>api/learn/chat.php</code> &mdash; SSE streaming endpoint</li>
+        <li><code>api/learn/chat_status.php</code> &mdash; reports whether real AI is enabled</li>
+        <li><code>template/components/_chat_widget.php</code> &mdash; the chat UI</li>
+      </ol>
+      No OpenAI API key needed &mdash; the framework includes a rule-based mock that works identically.
+      Set <code>OPENAI_API_KEY</code> to switch to a real model.
+    </div>
+
     <p>
       Five pieces, in build order:
     </p>

--- a/template/pages/learn/auth.php
+++ b/template/pages/learn/auth.php
@@ -107,8 +107,7 @@ if (!$user) {
 
     <h2>Architecture: proper OOP</h2>
     <p>
-      Notice how the auth logic lives in <a href="https://github.com/sibidharan/zealphp/blob/master/src/Learn/Auth.php" target="_blank"><code>src/Learn/Auth.php</code></a> — a proper class, autoloaded
-      via Composer. The API endpoint (<a href="https://github.com/sibidharan/zealphp/blob/master/api/learn/register.php" target="_blank"><code>api/learn/register.php</code></a>) is a thin wrapper:
+      The auth logic lives in <a href="https://github.com/sibidharan/zealphp/blob/master/src/Learn/Auth.php" target="_blank"><code>ZealPHP\Learn\Auth</code></a> &mdash; already in your <code>vendor/</code> directory via the framework dependency. The API endpoint is a thin wrapper that delegates to it:
     </p>
     <pre><code class="language-php">// <a href="https://github.com/sibidharan/zealphp/blob/master/api/learn/register.php" class="lauth-srclink">api/learn/register.php</a> — thin endpoint
 $register = function () {
@@ -282,11 +281,12 @@ $delete = function() {
     if (!$this->requirePostAuth()) return;
 
     $user = \ZealPHP\Learn\Auth::currentUser();
-    // $g is the canonical per-coroutine request context. It works in BOTH
-    // App::superglobals(true) and (false) modes — raw $_POST is unsafe in
-    // coroutine mode (process-wide array races across requests).
     $g = \ZealPHP\G::instance();
-    Note::delete((int)$g->post['note_id'], $userId);
+    \ZealPHP\Learn\Notes::delete(
+        \ZealPHP\Learn\DB::open(),
+        $user['user_id'],
+        (int) $g->post['note_id']
+    );
     return ['ok' => true];
 };
 PHP,

--- a/template/pages/learn/auth.php
+++ b/template/pages/learn/auth.php
@@ -21,6 +21,43 @@ $active = $active ?? 'learn/auth';
     ]]); ?>
 
     <h2>The problem</h2>
+    <pre class="mermaid">sequenceDiagram
+    participant B as Browser
+    participant API as API endpoint
+    participant A as Auth.php
+    participant DB as SQLite
+    participant S as Session
+    rect rgb(255, 251, 235)
+    Note over B,S: Register
+    B->>API: POST username + password
+    API->>A: Auth::register(db, user, pass)
+    A->>A: password_hash(pass)
+    A->>DB: INSERT INTO users
+    DB-->>A: id = 7
+    A-->>API: user id 7
+    API->>S: session user_id = 7
+    API-->>B: redirect to notes
+    end
+    rect rgb(236, 253, 245)
+    Note over B,S: Login
+    B->>API: POST username + password
+    API->>A: Auth::login(db, user, pass)
+    A->>DB: SELECT password_hash
+    DB-->>A: stored hash
+    A->>A: password_verify() OK
+    A-->>API: user id 7
+    API->>S: session user_id = 7
+    API-->>B: redirect to notes
+    end
+    rect rgb(254, 242, 242)
+    Note over B,S: Auth guard (every protected page)
+    B->>API: GET /learn/notes
+    API->>S: session user_id?
+    S-->>API: 7
+    API->>DB: SELECT * FROM users WHERE id = 7
+    DB-->>API: user row
+    Note over API: user found, show content
+    end</pre>
     <p>
       Sessions remember <em>this browser</em>, but they don't know <em>who</em> is using it. Anyone
       who opens your app can see anyone else's data. You need real user accounts: a username, a password,

--- a/template/pages/learn/auth.php
+++ b/template/pages/learn/auth.php
@@ -112,7 +112,8 @@ if (!$user) {
     </p>
     <pre><code class="language-php">// <a href="https://github.com/sibidharan/zealphp/blob/master/api/learn/register.php" class="lauth-srclink">api/learn/register.php</a> — thin endpoint
 $register = function () {
-    $creds = Auth::readCredentials($this);
+    $g = \ZealPHP\G::instance();
+    $creds = Auth::readCredentials($g);
     $userId = Auth::register(DB::open(), $creds['username'], $creds['password']);
     // ... set session, redirect
 };</code></pre>
@@ -259,11 +260,10 @@ document.addEventListener('htmx:beforeSwap', (e) =&gt; {
       'code'  => <<<'PHP'
 <?php
 use ZealPHP\App;
-use App\Auth;          // the src/Auth.php class from Step 2
+use ZealPHP\Learn\Auth; // the src/Learn/Auth.php class from the tutorial
 
-App::authChecker(fn(): bool       => Auth::currentUserId() !== null);
-App::adminChecker(fn(): bool      => Auth::currentRole() === 'admin');
-App::usernameProvider(fn(): ?string => Auth::currentUsername());
+App::authChecker(fn(): bool        => Auth::currentUser() !== null);
+App::usernameProvider(fn(): ?string => Auth::currentUser()['username'] ?? null);
 
 $app = App::init('0.0.0.0', 8080);
 $app->run();
@@ -281,7 +281,7 @@ $delete = function() {
     // POST + authenticated guard. Emits 403 JSON and returns false on failure.
     if (!$this->requirePostAuth()) return;
 
-    $userId = \App\Auth::currentUserId();
+    $user = \ZealPHP\Learn\Auth::currentUser();
     // $g is the canonical per-coroutine request context. It works in BOTH
     // App::superglobals(true) and (false) modes — raw $_POST is unsafe in
     // coroutine mode (process-wide array races across requests).

--- a/template/pages/learn/chatroom.php
+++ b/template/pages/learn/chatroom.php
@@ -68,7 +68,7 @@ CREATE INDEX idx_chatroom_room_time ON chatroom_messages(room, created_at);</cod
     <h2 id="model">A small model class — three pure-PHP functions</h2>
     <p>
       Everything the chat does to SQLite collapses to three methods. This is
-      <code>src/Learn/Chatroom.php</code> shipped with the demo:
+      <code>ZealPHP\Learn\Chatroom</code> (already in <code>vendor/</code> via the framework):
     </p>
 <pre><code class="language-php">final class Chatroom
 {

--- a/template/pages/learn/htmx.php
+++ b/template/pages/learn/htmx.php
@@ -485,26 +485,24 @@ $app->route('/notes/{id}', function ($request, $response, $id) {
       11 HX-* response headers htmx reads after a swap — events, browser history,
       target/swap override, refresh, redirect. Fluent, chained:
     </p>
-    <pre><code class="language-php">$app->route('/api/notes', function ($request, $response) {
-    $note = Notes::create($request->getParsedBody());
+    <pre><code class="language-php">$app->route('/api/notes', function ($response) {
+    $g    = \ZealPHP\G::instance();
+    $note = Notes::create($g->post);
 
-    return $response->htmx()
+    $response->htmx()
         ->trigger('note-saved')                   // HX-Trigger: fire JS event
         ->triggerAfterSwap('focus-next-input')    // HX-Trigger-After-Swap
         ->pushUrl("/notes/{$note->id}")           // HX-Push-Url: browser history
-        ->reswap('beforeend')                     // HX-Reswap: override target swap
-        ->response()                              // → underlying Response
-        ->withHeader('Content-Type', 'text/html')
-        ->withBody(\GuzzleHttp\Psr7\Utils::streamFor(
-            App::renderToString('partials/note_card', ['note' => $note])
-        ));
+        ->reswap('beforeend');                    // HX-Reswap: override target swap
+
+    return App::renderToString('partials/note_card', ['note' => $note]);
 });</code></pre>
 
     <p class="lhx-note">
       Full surface: <code>trigger()</code>, <code>triggerAfterSwap()</code>, <code>triggerAfterSettle()</code>,
       <code>reswap()</code>, <code>retarget()</code>, <code>reselect()</code>,
       <code>refresh()</code>, <code>location()</code>, <code>pushUrl()</code>, <code>replaceUrl()</code>,
-      <code>redirect()</code>. Each returns the builder; <code>response()</code> hands you back the underlying <code>Response</code>.
+      <code>redirect()</code>. Each returns the builder &mdash; the HX-* headers are set on the underlying response automatically.
     </p>
 
     <h3 id="hx-oob">Out-of-band swaps — update multiple regions in one response</h3>
@@ -519,9 +517,8 @@ $body = App::renderToString('partials/note_card', ['note' => $note])         // 
       . HtmxResponse::oob('unread-badge', '&lt;span&gt;' . $unread . '&lt;/span&gt;')         // OOB: replace #unread-badge
       . HtmxResponse::oob('toast', '&lt;div&gt;Saved!&lt;/div&gt;', swap: 'beforeend'); // OOB: append to #toast
 
-return $response->htmx()->trigger('note-saved')->response()
-       ->withHeader('Content-Type', 'text/html')
-       ->withBody(\GuzzleHttp\Psr7\Utils::streamFor($body));</code></pre>
+$response->htmx()->trigger('note-saved');
+return $body;</code></pre>
 
     <h3 id="hx-compose">Putting it together: one template, two responses, one HX-Trigger</h3>
     <p>
@@ -544,16 +541,15 @@ return $response->htmx()->trigger('note-saved')->response()
 use ZealPHP\App;
 
 $app->route('/notes', function ($request, $response) {
-    if ($request->getMethod() === 'POST') {
-        Notes::create($request->getParsedBody());
+    $g = \ZealPHP\G::instance();
+    if ($g->server['REQUEST_METHOD'] === 'POST') {
+        Notes::create($g->post);
         // After save, return just the updated list AND fire the toast event.
-        $body = App::renderToString('pages/notes', [
+        $response->htmx()->trigger('note-saved');
+        return App::renderToString('pages/notes', [
             'notes'    => Notes::all(),
             'fragment' => 'note-list',
         ]);
-        return $response->htmx()->trigger('note-saved')->response()
-               ->withHeader('Content-Type', 'text/html')
-               ->withBody(\GuzzleHttp\Psr7\Utils::streamFor($body));
     }
     // GET — full page on plain nav, just #note-list on htmx swap.
     return App::render('_master', [

--- a/template/pages/learn/middleware.php
+++ b/template/pages/learn/middleware.php
@@ -62,6 +62,21 @@ $app-&gt;addMiddleware(new ETagMiddleware());
 $app-&gt;addMiddleware(new SessionStartMiddleware());</code></pre>
 
     <h2>Order is reversed at execution time</h2>
+    <pre class="mermaid">graph TB
+    REQ[Request arrives] --> C
+    subgraph C_wrap["C  (last registered = outermost)"]
+      C[C.process] --> B_in
+      subgraph B_wrap["B"]
+        B_in[B.process] --> A_in
+        subgraph A_wrap["A  (first registered = innermost)"]
+          A_in[A.process] --> RM["ResponseMiddleware<br/>match route + invoke handler"]
+        end
+      end
+    end
+    RM --> RES[Response emitted]
+    style C_wrap fill:#fffbeb,stroke:#f59e0b,stroke-width:2px
+    style A_wrap fill:#ecfdf5,stroke:#059669,stroke-width:2px
+    style RM fill:#ecfdf5,stroke:#059669</pre>
     <p>
       You register <code>A, B, C</code>. The stack ZealPHP builds is <code>C wraps B wraps A wraps
       ResponseMiddleware</code>. At request time, <strong>C runs first.</strong> The last middleware

--- a/template/pages/learn/middleware.php
+++ b/template/pages/learn/middleware.php
@@ -53,7 +53,11 @@
     <p>
       Register them in <code>app.php</code> before <code>$app-&gt;run()</code>:
     </p>
-    <pre><code class="language-php">$app-&gt;addMiddleware(new CorsMiddleware());
+    <pre><code class="language-php">use ZealPHP\Middleware\CorsMiddleware;
+use ZealPHP\Middleware\ETagMiddleware;
+use ZealPHP\Middleware\SessionStartMiddleware;
+
+$app-&gt;addMiddleware(new CorsMiddleware());
 $app-&gt;addMiddleware(new ETagMiddleware());
 $app-&gt;addMiddleware(new SessionStartMiddleware());</code></pre>
 

--- a/template/pages/learn/notes.php
+++ b/template/pages/learn/notes.php
@@ -30,21 +30,55 @@ $active = $active ?? 'learn/notes';
       Build this once, and you can build any data app — a todo list, a blog, an inventory system.
     </p>
 
+    <div class="callout info">
+      <strong>Build it yourself.</strong> The business logic classes (<code>Notes</code>, <code>Auth</code>,
+      <code>DB</code>, <code>WS</code>) ship with the framework library &mdash; they&rsquo;re already in
+      your <code>vendor/</code> directory after <code>composer create-project</code>. This lesson walks you
+      through creating the <strong>glue files</strong> that wire them into a working app:
+      <ol>
+        <li><code>api/learn/notes.php</code> &mdash; CRUD endpoint</li>
+        <li><code>route/learn.php</code> &mdash; path-param routes + WebSocket registration</li>
+        <li><code>template/components/_notes_widget.php</code> &mdash; the notes UI</li>
+        <li><code>template/components/_note_card.php</code> &mdash; individual note display</li>
+      </ol>
+      Create each file as you reach its section. Restart the server (<code>php app.php restart</code>) after
+      adding route files.
+    </div>
+
     <h2 id="step-components">2. Component extraction — the same widget, two places</h2>
     <p>
-      Before we wire anything up, look at the page structure. The note-creation form, the list of
-      notes below it, and the user bar at the top form a self-contained UI block. That block is
-      extracted into a reusable partial:
+      Before we wire anything up, let&rsquo;s build the UI. The note-creation form, the list of
+      notes below it, and the user bar at the top form a self-contained UI block. Create it as a
+      reusable partial:
     </p>
-    <pre><code class="language-php">// template/components/_notes_widget.php
-&lt;?php
+    <p><strong>Create <code>template/components/_notes_widget.php</code>:</strong></p>
+    <pre><code class="language-php">&lt;?php
 $user ??= null;
 if (!$user) return;
 ?&gt;
-&lt;div class="notes-user-bar"&gt;…&lt;/div&gt;
+&lt;div class="notes-user-bar"&gt;
+  &lt;span class="notes-user-avatar"&gt;&lt;?= strtoupper(substr($user['username'], 0, 1)) ?&gt;&lt;/span&gt;
+  &lt;span class="notes-user-name"&gt;&lt;?= htmlspecialchars($user['username']) ?&gt;&lt;/span&gt;
+  &lt;a href="/api/learn/logout" class="notes-user-logout"&gt;Log out&lt;/a&gt;
+&lt;/div&gt;
+
 &lt;section class="notes-app"&gt;
-  &lt;form class="note-form" hx-post="/api/learn/notes" …&gt;…&lt;/form&gt;
-  &lt;div id="notes-list" class="notes-list" hx-get="/api/learn/notes" hx-trigger="load"&gt;…&lt;/div&gt;
+  &lt;form class="note-form"
+        hx-post="/api/learn/notes"
+        hx-target="#notes-list"
+        hx-swap="afterbegin"
+        hx-on::after-request="this.reset()"&gt;
+    &lt;input type="text" name="title" placeholder="Note title" required maxlength="200"&gt;
+    &lt;textarea name="body" placeholder="What's on your mind?" maxlength="4096"&gt;&lt;/textarea&gt;
+    &lt;button type="submit"&gt;Add note&lt;/button&gt;
+  &lt;/form&gt;
+
+  &lt;div id="notes-list" class="notes-list"
+       hx-get="/api/learn/notes"
+       hx-trigger="load"
+       hx-swap="innerHTML"&gt;
+    &lt;p class="notes-empty"&gt;Loading&amp;hellip;&lt;/p&gt;
+  &lt;/div&gt;
 &lt;/section&gt;</code></pre>
     <p>
       The partial renders identical HTML in two consumers — and that&rsquo;s the lesson:
@@ -117,14 +151,14 @@ if (!$user) return;
     H-->>B: afterbegin swap (green glow)</pre>
     <p>Three layers, each with one job:</p>
     <ol>
-      <li><strong><a href="https://github.com/sibidharan/zealphp/blob/master/src/Learn/Notes.php" target="_blank"><code>src/Learn/Notes.php</code></a></strong> — Business logic. SQL queries scoped by <code>user_id</code>.</li>
-      <li><strong><a href="https://github.com/sibidharan/zealphp/blob/master/api/learn/notes.php" target="_blank"><code>api/learn/notes.php</code></a></strong> — Endpoint. Reads the request, calls the class, returns HTML.</li>
-      <li><strong>Template + htmx</strong> — UI. The form and list, wired with four htmx attributes.</li>
+      <li><strong><code>ZealPHP\Learn\Notes</code></strong> — Business logic (already in <code>vendor/</code> via the framework). SQL queries scoped by <code>user_id</code>.</li>
+      <li><strong><code>api/learn/notes.php</code></strong> — Endpoint you&rsquo;ll create. Reads the request, calls the class, returns HTML.</li>
+      <li><strong>Template + htmx</strong> — UI you created in step 2, wired with four htmx attributes.</li>
     </ol>
 
-    <h3>The data layer</h3>
-    <p>Every method takes a <code>$userId</code> parameter. The user can never read or modify another user's notes:</p>
-    <pre><code class="language-php">// <a href="https://github.com/sibidharan/zealphp/blob/master/src/Learn/Notes.php" class="lnotes-srclink">src/Learn/Notes.php</a>
+    <h3>The data layer (already in vendor)</h3>
+    <p>The <code>ZealPHP\Learn\Notes</code> class ships with the framework &mdash; you don&rsquo;t need to create it. Every method takes a <code>$userId</code> parameter. The user can never read or modify another user&rsquo;s notes:</p>
+    <pre><code class="language-php">// vendor/sibidharan/zealphp/src/Learn/Notes.php — already installed
 class Notes
 {
     public static function create(\PDO $db, int $userId, string $title, string $body): ?int
@@ -155,11 +189,50 @@ class Notes
       <em>response body</em>. You need the HTML as a string, not echoed to the page. That's
       <code>App::renderToString()</code>:
     </p>
-    <pre><code class="language-php">// <a href="https://github.com/sibidharan/zealphp/blob/master/api/learn/notes.php" class="lnotes-srclink">api/learn/notes.php</a> — return the rendered note card
-$note = Notes::read($db, $userId, $id);
-$html = App::renderToString('/components/_note_card', $note);
-$this->response($html, 200);</code></pre>
-    <p>Same component, same template file — but now you get the HTML as a string to return from your API.</p>
+    <p><strong>Create <code>api/learn/notes.php</code></strong> &mdash; this is the endpoint htmx talks to:</p>
+    <pre><code class="language-php">&lt;?php
+use ZealPHP\App;
+use ZealPHP\G;
+use ZealPHP\Learn\DB;
+use ZealPHP\Learn\Auth;
+use ZealPHP\Learn\Notes;
+use ZealPHP\Learn\WS;
+
+${basename(__FILE__, '.php')} = function () {
+    $u = Auth::currentUser();
+    if (!$u) { $this->response($this->json(['error' => 'auth_required']), 401); return; }
+    $g = G::instance();
+    $method = strtoupper($g->server['REQUEST_METHOD'] ?? 'GET');
+    $db = DB::open();
+    $wantsJson = stripos($g->server['HTTP_ACCEPT'] ?? '', 'application/json') !== false;
+
+    if ($method === 'POST') {
+        $body = $g->post;
+        $title    = (string) ($body['title'] ?? '');
+        $bodyText = (string) ($body['body'] ?? '');
+        $id = Notes::create($db, $u['user_id'], $title, $bodyText);
+        if ($id === null) { $this->response($this->json(['error' => 'validation_failed']), 422); return; }
+        WS::broadcast($u['user_id'], ['type' => 'note_changed', 'op' => 'create', 'id' => $id]);
+        $note = Notes::read($db, $u['user_id'], $id);
+        header('Content-Type: text/html; charset=utf-8');
+        $this->response(App::renderToString('/components/_note_card', $note), 200);
+        return;
+    }
+
+    // GET — list notes
+    $notesList = Notes::list($db, $u['user_id']);
+    header('Content-Type: text/html; charset=utf-8');
+    if (empty($notesList)) {
+        $this->response('&lt;p class="notes-empty"&gt;No notes yet. Add one above.&lt;/p&gt;', 200);
+        return;
+    }
+    $html = '';
+    foreach ($notesList as $n) {
+        $html .= App::renderToString('/components/_note_card', $n);
+    }
+    $this->response($html, 200);
+};</code></pre>
+    <p>The key line: <code>App::renderToString('/components/_note_card', $note)</code> renders the card you created above and returns it as a string &mdash; exactly what htmx expects as the response body.</p>
 
     <?php App::render('/components/_callout', [
       'variant' => 'info',
@@ -186,10 +259,30 @@ $this->response($html, 200);</code></pre>
         hx-confirm="Delete this note?"&gt;Delete&lt;/button&gt;</code></pre>
     <p><code>hx-swap="outerHTML"</code> replaces the entire note card with the empty response — effectively removing it.</p>
 
-    <h3>Component reuse</h3>
+    <h3>Create the note card component</h3>
     <p>
-      The <a href="https://github.com/sibidharan/zealphp/blob/master/template/components/_note_card.php" target="_blank"><code>_note_card</code></a> component is used in three places: the notes list (GET), the create response (POST), and the chat history bubbles (<a href="/learn/ai-chat">Lesson 20, AI Chat</a>). Same file, three consumers. <code>_notes_widget</code> from step&nbsp;2 takes the same idea one level up — it&rsquo;s the whole notes panel, also used in two places (this lesson + the popup viewer).
+      Each note renders as a card. This component is used in three places: the notes list (GET), the create response (POST), and the chat history bubbles (<a href="/learn/ai-chat">Lesson 20, AI Chat</a>). Same file, three consumers.
     </p>
+    <p><strong>Create <code>template/components/_note_card.php</code>:</strong></p>
+    <pre><code class="language-php">&lt;?php
+$id    = (int)($id ?? 0);
+$title = (string)($title ?? '');
+$body  = (string)($body ?? '');
+$ts    = (int)($updated_at ?? time());
+?&gt;
+&lt;article class="note" id="note-&lt;?= $id ?&gt;" data-id="&lt;?= $id ?&gt;"&gt;
+  &lt;details&gt;
+    &lt;summary class="note-title"&gt;&lt;?= htmlspecialchars($title) ?&gt;&lt;/summary&gt;
+    &lt;p class="note-body"&gt;&lt;?= nl2br(htmlspecialchars($body)) ?&gt;&lt;/p&gt;
+  &lt;/details&gt;
+  &lt;div class="note-meta"&gt;
+    &lt;span&gt;Updated &lt;?= date('Y-m-d H:i', $ts) ?&gt;&lt;/span&gt;
+    &lt;button hx-delete="/api/learn/notes/&lt;?= $id ?&gt;"
+            hx-target="#note-&lt;?= $id ?&gt;"
+            hx-swap="outerHTML"
+            hx-confirm="Delete this note?"&gt;Delete&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/article&gt;</code></pre>
 
     <h2 id="step-sync">5. Live sync — cross-tab via WebSocket</h2>
     <p>

--- a/template/pages/learn/project-structure.php
+++ b/template/pages/learn/project-structure.php
@@ -142,14 +142,14 @@ $app->run();</code></pre>
 {
   "autoload": {
     "psr-4": {
-      "App\\": "src/"
+      "MyProject\\": "src/"
     }
   }
 }</code></pre>
     <p>
-      With that, <code>src/Auth.php</code> defining <code>App\Auth</code> is reachable from anywhere
-      as <code>new \App\Auth()</code>. Run <code>composer dump-autoload</code> after adding new
-      classes for the first time.
+      The scaffold already has this configured. With it, <code>src/Auth.php</code> defining
+      <code>MyProject\Auth</code> is reachable from anywhere as <code>new \MyProject\Auth()</code>.
+      Run <code>composer dump-autoload</code> after adding new classes for the first time.
     </p>
 
     <h3><code>app.php</code> — bootstrap, nothing else</h3>

--- a/template/pages/learn/sessions.php
+++ b/template/pages/learn/sessions.php
@@ -39,6 +39,22 @@
     ]); ?>
 
     <h2>Step 1 — HTTP doesn't remember anything</h2>
+    <pre class="mermaid">sequenceDiagram
+    participant B as Browser
+    participant SW as ZealPHP
+    participant FS as Session file on disk
+    Note over B: First visit, no cookie
+    B->>SW: GET /page
+    SW->>SW: session_start(), mint new id
+    SW->>FS: create sess_abc123
+    SW-->>B: response + Set-Cookie PHPSESSID
+    Note over B: Second visit, cookie present
+    B->>SW: GET /page + Cookie PHPSESSID
+    SW->>FS: read sess_abc123
+    FS-->>SW: lesson_counter = 5
+    SW->>SW: handler increments to 6
+    SW->>FS: write sess_abc123
+    SW-->>B: response (counter shows 6)</pre>
     <p>
       Each HTTP request stands alone. The server doesn&rsquo;t know that <em>you</em> are the same
       visitor who reloaded the page two seconds ago — it just sees a new request. So how does the

--- a/template/pages/learn/store.php
+++ b/template/pages/learn/store.php
@@ -18,6 +18,22 @@
     ]]); ?>
 
     <h2>The workers don’t share a heap</h2>
+    <pre class="mermaid">graph TD
+    M[Master process] -->|fork| W1[Worker 1<br/>own PHP heap]
+    M -->|fork| W2[Worker 2<br/>own PHP heap]
+    M -->|fork| W3[Worker N<br/>own PHP heap]
+    M -->|allocate before fork| SHM[Store shared memory<br/>all workers read and write]
+    W1 -->|set / get / incr| SHM
+    W2 -->|set / get / incr| SHM
+    W3 -->|set / get / incr| SHM
+    SHM -.->|read| W1
+    SHM -.->|read| W2
+    SHM -.->|read| W3
+    style SHM fill:#fffbeb,stroke:#f59e0b,stroke-width:2px
+    style M fill:#ecfdf5,stroke:#059669,stroke-width:2px
+    style W1 fill:#fef2f2,stroke:#f87171
+    style W2 fill:#fef2f2,stroke:#f87171
+    style W3 fill:#fef2f2,stroke:#f87171</pre>
     <p>
       ZealPHP runs N worker processes (default: number of CPU cores). Each worker is a separate
       OS process with its own PHP heap. A static class property in one worker is invisible to the

--- a/template/pages/learn/tictactoe.php
+++ b/template/pages/learn/tictactoe.php
@@ -21,6 +21,15 @@ $active = $active ?? 'learn/tictactoe';
       'Handle disconnects, reconnects, and an alternating starter across rounds',
     ]]); ?>
 
+    <div class="callout info">
+      <strong>Build it yourself.</strong> The game logic and state management are in
+      <code>route/learn.php</code> (already loaded if you completed Lesson 18). The game state lives
+      in <code>Store</code> tables, and moves broadcast over WebSocket. All the server-side classes
+      (<code>Auth</code>, <code>DB</code>, <code>Store</code>, <code>Counter</code>) are already
+      in your <code>vendor/</code> directory. This lesson shows the route code you&rsquo;ll add
+      to your existing route file.
+    </div>
+
     <h2 id="step-setup">1. Setup — what you&rsquo;re building</h2>
     <p>
       A multiplayer tic-tac-toe game where two players in the same browser, in different browsers, or

--- a/template/pages/learn/websocket.php
+++ b/template/pages/learn/websocket.php
@@ -57,6 +57,23 @@
     </p>
 
     <h3>The four callbacks</h3>
+    <pre class="mermaid">sequenceDiagram
+    participant B as Browser
+    participant SW as OpenSwoole<br/>Server
+    participant H as Your callbacks
+    participant ST as Store<br/>ws_clients table
+    B->>SW: HTTP Upgrade request
+    SW->>H: onOpen(server, request)
+    H->>ST: Store fd
+    H-->>B: push(fd, current value)
+    Note over B,SW: Connection is now open,<br/>bidirectional channel
+    B->>SW: ws.send(ping)
+    SW->>H: onMessage(server, frame)
+    H-->>B: push(fd, pong)
+    Note over B: ... time passes ...
+    B->>SW: close / disconnect
+    SW->>H: onClose(server, fd)
+    H->>ST: Delete fd</pre>
     <p>
       One call to <code>$app-&gt;ws()</code>, three callbacks. The callbacks handle the connection
       lifecycle:

--- a/template/pages/learn/websocket.php
+++ b/template/pages/learn/websocket.php
@@ -20,10 +20,20 @@
     <h2 id="step-overview">1. Overview — what you&rsquo;re building</h2>
     <p>
       A counter that <strong>updates in every open tab the moment any tab clicks +1</strong>. No
-      reloads, no polling, no Redis on a single server (cross-server deploys use the Redis-backed federated routing the framework ships — see /websocket#cross-server). The server holds a list of open WebSocket connections; the
+      reloads, no polling, no Redis on a single server (cross-server deploys use the Redis-backed federated routing the framework ships &mdash; see /websocket#cross-server). The server holds a list of open WebSocket connections; the
       <code>+1</code> button hits a normal HTTP endpoint; that endpoint broadcasts the new value
-      back over WebSocket to every connected tab. Try it now — open this URL in another tab first.
+      back over WebSocket to every connected tab. Try it now &mdash; open this URL in another tab first.
     </p>
+
+    <div class="callout info">
+      <strong>Build it yourself.</strong> This lesson adds WebSocket to your scaffold project.
+      You&rsquo;ll create one file:
+      <ol>
+        <li><code>route/ws-counter.php</code> &mdash; WebSocket endpoint + broadcast helper + HTTP bump route</li>
+      </ol>
+      The <code>Store</code> and <code>Counter</code> classes are already available via the framework.
+      Restart the server after creating the route file.
+    </div>
 
     <?php App::render('/components/_ws_counter_widget'); ?>
 


### PR DESCRIPTION
## Summary

- **setup.sh**: Replace 17 internal `sudo` calls with `$SUDO` variable (Docker containers don't have sudo when already root); add `php-intl` to deps (Composer crashes without it)
- **home.php**: middleware count 18 → 28
- **coroutines.php**: remove false PDO hooking claim (2 places)
- **Lesson 15 (htmx)**: replace broken PSR-7 chains with correct ZealPHP API
- **Lesson 17 (auth)**: fix namespace `App\Auth` → `ZealPHP\Learn\Auth`, nonexistent methods → real `currentUser()`
- **Lessons 18/19/20**: add "Build it yourself" callouts with file creation steps, reframe from demo-app tours to scaffold-buildable instructions

## Test plan

- [x] PHPStan level 10: zero errors
- [x] PHPUnit: 2961 tests pass
- [x] Fresh Ubuntu 24.04 Docker container: `setup.sh` → `composer create-project` → `php app.php` → 200 OK
- [x] Lesson 3 (first page): `public/greeting.php` works with query params
- [x] 50 live demo endpoints verified working
- [x] No broken GitHub links in modified files