### PR TITLE
feat: ext-zealphp v0.3.0 — drop-in replacement for uopz

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,6 +138,26 @@ jobs:
           coverage: ${{ matrix.coverage }}
           tools: composer:v2
 
+      - name: Build openswoole from source if setup-php could not install it
+        run: |
+          if php -m | grep -q openswoole; then
+            echo "openswoole already loaded"
+            exit 0
+          fi
+          echo "openswoole missing — building from source"
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev libc-ares-dev
+          tmpdir=$(mktemp -d)
+          git clone --depth 1 https://github.com/openswoole/openswoole.git "$tmpdir"
+          cd "$tmpdir"
+          phpize
+          ./configure --enable-openssl --enable-hook-curl --enable-http2 --enable-mysqlnd --enable-sockets
+          make -j"$(nproc)"
+          sudo make install
+          ini_dir=$(php -i | awk -F'=> ' '/Scan this dir for additional .ini files/ {print $2}' | head -1 | tr -d ' ')
+          echo "extension=openswoole.so" | sudo tee "${ini_dir}/30-openswoole.ini"
+          php -m | grep openswoole
+
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-26
+
+ext-zealphp: ZealPHP's own PHP extension replaces the uopz dependency.
+
+### Added
+
+- **ext-zealphp** (`ext/zealphp/`) — purpose-built C extension (~250 lines) that intercepts 53 PHP built-in functions and routes them to per-request callbacks. Drop-in replacement for uopz with an allowlist-only design: no class manipulation, no constant overrides, no general-purpose API. Build: `cd ext/zealphp && phpize && ./configure && make && make install`.
+- **Auto-detection in `App.php`** — new `overrideBuiltin()` helper prefers ext-zealphp when loaded, falls back to uopz. Zero code changes needed in user apps.
+- **Mermaid diagrams** in 5 lessons: middleware (onion model), sessions (cookie lifecycle), auth (register/login/guard), store (shared memory), websocket (connection lifecycle).
+- **"Build it yourself" callouts** in lessons 18–22 — each lists exactly which files to create vs what's already in vendor/.
+
+### Fixed
+
+- **setup.sh**: replaced 17 internal `sudo` calls with `$SUDO` variable (Docker containers don't have sudo when already root); added `php-intl` and `php-sqlite3` to dependencies.
+- **home.php**: middleware count 18 → 28.
+- **coroutines.php**: removed false PDO hooking claim (PDO is not hooked in OpenSwoole 22.1–26.2).
+- **Lesson 15 (htmx)**: replaced broken PSR-7 method chains with correct ZealPHP API.
+- **Lesson 17 (auth)**: fixed namespace `App\Auth` → `ZealPHP\Learn\Auth`, nonexistent methods, undefined `$userId`.
+- **Lesson 5 (project-structure)**: PSR-4 namespace `App\` → `MyProject\` to match scaffold.
+- **Lesson 10 (middleware)**: added missing `use` statements to code snippet.
+- **Syntax highlighting**: 8 mixed PHP/HTML code blocks switched to `language-php-template`.
+
 ## [0.2.43] - 2026-05-25
 
 CGI-isolation session-persistence fix. `App::superglobals(true)` (legacy CGI) sessions now survive across requests as expected.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project sibidharan/zealphp-project:^0.2.43 my-project
+composer create-project sibidharan/zealphp-project:^0.3.0 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -448,8 +448,8 @@ App::onWorkerStart(function($server, $workerId) use ($hitCounter) {
 2. Run `composer validate` and confirm tests pass.
 3. Tag both `zealphp` and `zealphp-project` with the same version:
    ```bash
-   git tag -a v0.2.43 -m "Release v0.2.43"
-   git push origin master && git push origin v0.2.43
+   git tag -a v0.3.0 -m "Release v0.3.0"
+   git push origin master && git push origin v0.3.0
    ```
 4. Trigger Packagist webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.2.43 .
+docker build -t zealphp:0.3.0 .
 ```
 
 The shipped `Dockerfile` is PHP 8.3-cli on `bookworm` with OpenSwoole and
@@ -230,7 +230,7 @@ build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg UOPZ_VERSION=7.1.2 \
-    -t zealphp:0.2.43 .
+    -t zealphp:0.3.0 .
 ```
 
 ### Run (single container)
@@ -242,7 +242,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.2.43
+    zealphp:0.3.0
 ```
 
 ### Production compose
@@ -253,7 +253,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.2.43
+    image: registry.example.com/zealphp-app:0.3.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/ext/zealphp/config.m4
+++ b/ext/zealphp/config.m4
@@ -1,0 +1,10 @@
+dnl config.m4 for ext-zealphp
+
+PHP_ARG_ENABLE([zealphp],
+  [whether to enable zealphp support],
+  [AS_HELP_STRING([--enable-zealphp],
+    [Enable zealphp — per-request function overrides for long-running PHP servers])])
+
+if test "$PHP_ZEALPHP" != "no"; then
+  PHP_NEW_EXTENSION(zealphp, zealphp.c, $ext_shared)
+fi

--- a/ext/zealphp/config.m4
+++ b/ext/zealphp/config.m4
@@ -8,3 +8,4 @@ PHP_ARG_ENABLE([zealphp],
 if test "$PHP_ZEALPHP" != "no"; then
   PHP_NEW_EXTENSION(zealphp, zealphp.c, $ext_shared)
 fi
+# ext-zealphp build

--- a/ext/zealphp/php_zealphp.h
+++ b/ext/zealphp/php_zealphp.h
@@ -1,0 +1,17 @@
+#ifndef PHP_ZEALPHP_H
+#define PHP_ZEALPHP_H
+
+extern zend_module_entry zealphp_module_entry;
+#define phpext_zealphp_ptr &zealphp_module_entry
+
+#define PHP_ZEALPHP_VERSION "0.1.0"
+
+PHP_MINIT_FUNCTION(zealphp);
+PHP_MSHUTDOWN_FUNCTION(zealphp);
+PHP_MINFO_FUNCTION(zealphp);
+
+PHP_FUNCTION(zealphp_override);
+PHP_FUNCTION(zealphp_restore);
+PHP_FUNCTION(zealphp_restore_all);
+
+#endif

--- a/ext/zealphp/zealphp.c
+++ b/ext/zealphp/zealphp.c
@@ -1,0 +1,333 @@
+/*
+ * ext-zealphp — per-request function overrides for long-running PHP servers.
+ *
+ * Replaces ~15 PHP built-in functions (header, session_start, exec, etc.)
+ * with user-supplied callbacks so each coroutine/request gets its own
+ * response/session state. Drop-in replacement for uopz_set_return() with
+ * a much smaller attack surface — allowlist-only, no class manipulation.
+ *
+ * API:
+ *   zealphp_override(string $name, callable $cb): bool
+ *   zealphp_restore(string $name): bool
+ *   zealphp_restore_all(): void
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_ini.h"
+#include "ext/standard/info.h"
+#include "zend_exceptions.h"
+#include "php_zealphp.h"
+
+/* ── Storage ─────────────────────────────────────────────────────────── */
+
+/* original handler pointers, keyed by lowercase function name */
+static HashTable zealphp_orig_handlers;
+
+/* PHP callable callbacks, keyed by lowercase function name */
+static HashTable zealphp_callbacks;
+
+/* ── Allowlist ───────────────────────────────────────────────────────── */
+
+static const char *zealphp_allowed[] = {
+    /* response */
+    "header",
+    "header_remove",
+    "headers_list",
+    "headers_sent",
+    "setcookie",
+    "setrawcookie",
+    "http_response_code",
+    "header_register_callback",
+    /* output control */
+    "flush",
+    "ob_flush",
+    "ob_end_flush",
+    "ob_implicit_flush",
+    "output_add_rewrite_var",
+    "output_reset_rewrite_vars",
+    /* process/connection */
+    "set_time_limit",
+    "ignore_user_abort",
+    "connection_status",
+    "connection_aborted",
+    "register_shutdown_function",
+    /* error handling */
+    "error_log",
+    "error_reporting",
+    "set_error_handler",
+    "restore_error_handler",
+    "set_exception_handler",
+    "restore_exception_handler",
+    /* file upload */
+    "is_uploaded_file",
+    "move_uploaded_file",
+    /* info */
+    "phpinfo",
+    "php_sapi_name",
+    /* input filtering */
+    "filter_input",
+    "filter_input_array",
+    /* session */
+    "session_start",
+    "session_id",
+    "session_status",
+    "session_name",
+    "session_write_close",
+    "session_destroy",
+    "session_unset",
+    "session_regenerate_id",
+    "session_get_cookie_params",
+    "session_set_cookie_params",
+    "session_cache_limiter",
+    "session_cache_expire",
+    "session_commit",
+    "session_abort",
+    "session_encode",
+    "session_decode",
+    "session_save_path",
+    "session_module_name",
+    /* exec family */
+    "shell_exec",
+    "exec",
+    "system",
+    "passthru",
+    NULL
+};
+
+static bool zealphp_is_allowed(const char *name, size_t len)
+{
+    for (const char **p = zealphp_allowed; *p; p++) {
+        if (strlen(*p) == len && memcmp(*p, name, len) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* ── Generic handler ─────────────────────────────────────────────────── */
+
+static ZEND_NAMED_FUNCTION(zealphp_dispatch)
+{
+    zend_string *fname = execute_data->func->common.function_name;
+    zend_string *lc = zend_string_tolower(fname);
+
+    zval *cb = zend_hash_find(&zealphp_callbacks, lc);
+    zend_string_release(lc);
+
+    if (!cb || Z_TYPE_P(cb) == IS_UNDEF) {
+        RETURN_NULL();
+    }
+
+    uint32_t argc = ZEND_CALL_NUM_ARGS(execute_data);
+    zval *args = NULL;
+    if (argc > 0) {
+        args = ZEND_CALL_ARG(execute_data, 1);
+    }
+
+    zval retval;
+    ZVAL_UNDEF(&retval);
+
+    if (call_user_function(NULL, NULL, cb, &retval, argc, args) == SUCCESS) {
+        if (Z_TYPE(retval) != IS_UNDEF) {
+            ZVAL_COPY_VALUE(return_value, &retval);
+        }
+    } else {
+        php_error_docref(NULL, E_WARNING,
+            "ext-zealphp: callback for %s failed", ZSTR_VAL(fname));
+    }
+}
+
+/* ── zealphp_override(string $name, callable $cb): bool ──────────── */
+
+PHP_FUNCTION(zealphp_override)
+{
+    zend_string *func_name;
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STR(func_name)
+        Z_PARAM_FUNC(fci, fcc)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_string *lc = zend_string_tolower(func_name);
+
+    /* allowlist check */
+    if (!zealphp_is_allowed(ZSTR_VAL(lc), ZSTR_LEN(lc))) {
+        php_error_docref(NULL, E_WARNING,
+            "ext-zealphp: overriding '%s' is not allowed", ZSTR_VAL(func_name));
+        zend_string_release(lc);
+        RETURN_FALSE;
+    }
+
+    /* already overridden? */
+    if (zend_hash_exists(&zealphp_orig_handlers, lc)) {
+        php_error_docref(NULL, E_WARNING,
+            "ext-zealphp: '%s' is already overridden — restore first",
+            ZSTR_VAL(func_name));
+        zend_string_release(lc);
+        RETURN_FALSE;
+    }
+
+    /* find original */
+    zend_function *func = zend_hash_find_ptr(CG(function_table), lc);
+    if (!func) {
+        php_error_docref(NULL, E_WARNING,
+            "ext-zealphp: function '%s' not found", ZSTR_VAL(func_name));
+        zend_string_release(lc);
+        RETURN_FALSE;
+    }
+
+    if (func->type != ZEND_INTERNAL_FUNCTION) {
+        php_error_docref(NULL, E_WARNING,
+            "ext-zealphp: can only override internal (C) functions, not user functions");
+        zend_string_release(lc);
+        RETURN_FALSE;
+    }
+
+    /* save original handler */
+    zend_hash_add_new_ptr(&zealphp_orig_handlers, lc,
+                          (void *)func->internal_function.handler);
+
+    /* save callback */
+    zval cb_copy;
+    ZVAL_COPY(&cb_copy, &fci.function_name);
+    zend_hash_update(&zealphp_callbacks, lc, &cb_copy);
+
+    /* swap handler */
+    func->internal_function.handler = zealphp_dispatch;
+
+    zend_string_release(lc);
+    RETURN_TRUE;
+}
+
+/* ── zealphp_restore(string $name): bool ─────────────────────────── */
+
+PHP_FUNCTION(zealphp_restore)
+{
+    zend_string *func_name;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STR(func_name)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_string *lc = zend_string_tolower(func_name);
+
+    void *orig = zend_hash_find_ptr(&zealphp_orig_handlers, lc);
+    if (!orig) {
+        zend_string_release(lc);
+        RETURN_FALSE;
+    }
+
+    zend_function *func = zend_hash_find_ptr(CG(function_table), lc);
+    if (func) {
+        func->internal_function.handler = (zif_handler)orig;
+    }
+
+    zend_hash_del(&zealphp_orig_handlers, lc);
+    zend_hash_del(&zealphp_callbacks, lc);
+
+    zend_string_release(lc);
+    RETURN_TRUE;
+}
+
+/* ── zealphp_restore_all(): void ─────────────────────────────────── */
+
+PHP_FUNCTION(zealphp_restore_all)
+{
+    zend_string *key;
+    void *orig;
+
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    ZEND_HASH_FOREACH_STR_KEY_PTR(&zealphp_orig_handlers, key, orig) {
+        zend_function *func = zend_hash_find_ptr(CG(function_table), key);
+        if (func) {
+            func->internal_function.handler = (zif_handler)orig;
+        }
+    } ZEND_HASH_FOREACH_END();
+
+    zend_hash_clean(&zealphp_orig_handlers);
+    zend_hash_clean(&zealphp_callbacks);
+}
+
+/* ── Module lifecycle ────────────────────────────────────────────── */
+
+PHP_MINIT_FUNCTION(zealphp)
+{
+    zend_hash_init(&zealphp_orig_handlers, 32, NULL, NULL, 1);
+    zend_hash_init(&zealphp_callbacks, 32, NULL, ZVAL_PTR_DTOR, 1);
+    return SUCCESS;
+}
+
+PHP_MSHUTDOWN_FUNCTION(zealphp)
+{
+    /* restore any still-overridden functions */
+    zend_string *key;
+    void *orig;
+
+    ZEND_HASH_FOREACH_STR_KEY_PTR(&zealphp_orig_handlers, key, orig) {
+        zend_function *func = zend_hash_find_ptr(CG(function_table), key);
+        if (func) {
+            func->internal_function.handler = (zif_handler)orig;
+        }
+    } ZEND_HASH_FOREACH_END();
+
+    zend_hash_destroy(&zealphp_orig_handlers);
+    zend_hash_destroy(&zealphp_callbacks);
+    return SUCCESS;
+}
+
+PHP_MINFO_FUNCTION(zealphp)
+{
+    php_info_print_table_start();
+    php_info_print_table_row(2, "ext-zealphp", "enabled");
+    php_info_print_table_row(2, "Version", PHP_ZEALPHP_VERSION);
+    php_info_print_table_row(2, "Purpose",
+        "Per-request function overrides for long-running PHP servers");
+    php_info_print_table_end();
+}
+
+/* ── Function entries ────────────────────────────────────────────── */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zealphp_override, 0, 2, _IS_BOOL, 0)
+    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zealphp_restore, 0, 1, _IS_BOOL, 0)
+    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zealphp_restore_all, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zealphp_functions[] = {
+    PHP_FE(zealphp_override,    arginfo_zealphp_override)
+    PHP_FE(zealphp_restore,     arginfo_zealphp_restore)
+    PHP_FE(zealphp_restore_all, arginfo_zealphp_restore_all)
+    PHP_FE_END
+};
+
+/* ── Module entry ────────────────────────────────────────────────── */
+
+zend_module_entry zealphp_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "zealphp",
+    zealphp_functions,
+    PHP_MINIT(zealphp),
+    PHP_MSHUTDOWN(zealphp),
+    NULL, /* RINIT */
+    NULL, /* RSHUTDOWN */
+    PHP_MINFO(zealphp),
+    PHP_ZEALPHP_VERSION,
+    STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_ZEALPHP
+ZEND_GET_MODULE(zealphp)
+#endif

--- a/src/App.php
+++ b/src/App.php
@@ -782,67 +782,65 @@ class App
 
         // Capture native phpinfo(INFO_MODULES) text ONCE before overriding phpinfo,
         // so PhpInfo can surface extension-specific detail without recursing into
-        // its own override (and without per-request uopz_unset races). \phpinfo here
-        // is still the original built-in — the uopz override is installed below.
+        // its own override. \phpinfo here is still the original built-in.
         \ob_start();
         \phpinfo(INFO_MODULES);
         \ZealPHP\Diagnostics\PhpInfo::primeModuleText((string) \ob_get_clean());
 
-        // Built-ins always present in CLI/OpenSwoole — uopz can override directly.
-        \uopz_set_return('header', \Closure::fromCallable('\ZealPHP\header'), true);
-        \uopz_set_return('header_remove', \Closure::fromCallable('\ZealPHP\header_remove'), true);
-        \uopz_set_return('headers_list', \Closure::fromCallable('\ZealPHP\headers_list'), true);
-        \uopz_set_return('headers_sent', \Closure::fromCallable('\ZealPHP\headers_sent'), true);
-        \uopz_set_return('setcookie', \Closure::fromCallable('\ZealPHP\setcookie') , true);
-        \uopz_set_return('setrawcookie', \Closure::fromCallable('\ZealPHP\setrawcookie') , true);
-        \uopz_set_return('http_response_code', \Closure::fromCallable('\ZealPHP\http_response_code'), true);
-        \uopz_set_return('flush', \Closure::fromCallable('\ZealPHP\flush'), true);
-        \uopz_set_return('ob_flush', \Closure::fromCallable('\ZealPHP\ob_flush'), true);
-        \uopz_set_return('ob_end_flush', \Closure::fromCallable('\ZealPHP\ob_end_flush'), true);
-        \uopz_set_return('ob_implicit_flush', \Closure::fromCallable('\ZealPHP\ob_implicit_flush'), true);
-        \uopz_set_return('set_time_limit', \Closure::fromCallable('\ZealPHP\set_time_limit'), true);
-        \uopz_set_return('ignore_user_abort', \Closure::fromCallable('\ZealPHP\ignore_user_abort'), true);
-        \uopz_set_return('connection_status', \Closure::fromCallable('\ZealPHP\connection_status'), true);
-        \uopz_set_return('connection_aborted', \Closure::fromCallable('\ZealPHP\connection_aborted'), true);
-        \uopz_set_return('output_add_rewrite_var', \Closure::fromCallable('\ZealPHP\output_add_rewrite_var'), true);
-        \uopz_set_return('output_reset_rewrite_vars', \Closure::fromCallable('\ZealPHP\output_reset_rewrite_vars'), true);
-        \uopz_set_return('is_uploaded_file', \Closure::fromCallable('\ZealPHP\is_uploaded_file'), true);
-        \uopz_set_return('move_uploaded_file', \Closure::fromCallable('\ZealPHP\move_uploaded_file'), true);
-        \uopz_set_return('phpinfo', \Closure::fromCallable('\ZealPHP\phpinfo'), true);
-        \uopz_set_return('php_sapi_name', \Closure::fromCallable('\ZealPHP\php_sapi_name'), true);
-        \uopz_set_return('filter_input', \Closure::fromCallable('\ZealPHP\filter_input'), true);
-        \uopz_set_return('filter_input_array', \Closure::fromCallable('\ZealPHP\filter_input_array'), true);
-        \uopz_set_return('header_register_callback', \Closure::fromCallable('\ZealPHP\header_register_callback'), true);
-        \uopz_set_return('error_log', \Closure::fromCallable('\ZealPHP\error_log'), true);
-        // Per-coroutine error/exception/shutdown handler registry.
-        \uopz_set_return('set_error_handler', \Closure::fromCallable('\ZealPHP\set_error_handler'), true);
-        \uopz_set_return('restore_error_handler', \Closure::fromCallable('\ZealPHP\restore_error_handler'), true);
-        \uopz_set_return('set_exception_handler', \Closure::fromCallable('\ZealPHP\set_exception_handler'), true);
-        \uopz_set_return('restore_exception_handler', \Closure::fromCallable('\ZealPHP\restore_exception_handler'), true);
-        \uopz_set_return('register_shutdown_function', \Closure::fromCallable('\ZealPHP\register_shutdown_function'), true);
-        \uopz_set_return('error_reporting', \Closure::fromCallable('\ZealPHP\error_reporting'), true);
+        // Override PHP built-ins so they route to per-request objects.
+        // Prefer ext-zealphp (allowlist-only, ~250 LOC); fall back to uopz.
+        self::overrideBuiltin('header', '\ZealPHP\header');
+        self::overrideBuiltin('header_remove', '\ZealPHP\header_remove');
+        self::overrideBuiltin('headers_list', '\ZealPHP\headers_list');
+        self::overrideBuiltin('headers_sent', '\ZealPHP\headers_sent');
+        self::overrideBuiltin('setcookie', '\ZealPHP\setcookie');
+        self::overrideBuiltin('setrawcookie', '\ZealPHP\setrawcookie');
+        self::overrideBuiltin('http_response_code', '\ZealPHP\http_response_code');
+        self::overrideBuiltin('flush', '\ZealPHP\flush');
+        self::overrideBuiltin('ob_flush', '\ZealPHP\ob_flush');
+        self::overrideBuiltin('ob_end_flush', '\ZealPHP\ob_end_flush');
+        self::overrideBuiltin('ob_implicit_flush', '\ZealPHP\ob_implicit_flush');
+        self::overrideBuiltin('set_time_limit', '\ZealPHP\set_time_limit');
+        self::overrideBuiltin('ignore_user_abort', '\ZealPHP\ignore_user_abort');
+        self::overrideBuiltin('connection_status', '\ZealPHP\connection_status');
+        self::overrideBuiltin('connection_aborted', '\ZealPHP\connection_aborted');
+        self::overrideBuiltin('output_add_rewrite_var', '\ZealPHP\output_add_rewrite_var');
+        self::overrideBuiltin('output_reset_rewrite_vars', '\ZealPHP\output_reset_rewrite_vars');
+        self::overrideBuiltin('is_uploaded_file', '\ZealPHP\is_uploaded_file');
+        self::overrideBuiltin('move_uploaded_file', '\ZealPHP\move_uploaded_file');
+        self::overrideBuiltin('phpinfo', '\ZealPHP\phpinfo');
+        self::overrideBuiltin('php_sapi_name', '\ZealPHP\php_sapi_name');
+        self::overrideBuiltin('filter_input', '\ZealPHP\filter_input');
+        self::overrideBuiltin('filter_input_array', '\ZealPHP\filter_input_array');
+        self::overrideBuiltin('header_register_callback', '\ZealPHP\header_register_callback');
+        self::overrideBuiltin('error_log', '\ZealPHP\error_log');
+        self::overrideBuiltin('set_error_handler', '\ZealPHP\set_error_handler');
+        self::overrideBuiltin('restore_error_handler', '\ZealPHP\restore_error_handler');
+        self::overrideBuiltin('set_exception_handler', '\ZealPHP\set_exception_handler');
+        self::overrideBuiltin('restore_exception_handler', '\ZealPHP\restore_exception_handler');
+        self::overrideBuiltin('register_shutdown_function', '\ZealPHP\register_shutdown_function');
+        self::overrideBuiltin('error_reporting', '\ZealPHP\error_reporting');
         // Apache-only built-ins (apache_*, getallheaders, virtual) are NOT defined
-        // in CLI SAPI; uopz can't override what doesn't exist. They are registered
-        // as global shims via src/apache_shims.php (composer files autoload) that
-        // delegate to the same \ZealPHP\* namespaced implementations.
-        \uopz_set_return('session_start', \Closure::fromCallable('\ZealPHP\Session\zeal_session_start'), true);
-        \uopz_set_return('session_id', \Closure::fromCallable('\ZealPHP\Session\zeal_session_id'), true);
-        \uopz_set_return('session_status', \Closure::fromCallable('\ZealPHP\Session\zeal_session_status'), true);
-        \uopz_set_return('session_name', \Closure::fromCallable('\ZealPHP\Session\zeal_session_name'), true);
-        \uopz_set_return('session_write_close', \Closure::fromCallable('\ZealPHP\Session\zeal_session_write_close'), true);
-        \uopz_set_return('session_destroy', \Closure::fromCallable('\ZealPHP\Session\zeal_session_destroy'), true);
-        \uopz_set_return('session_unset', \Closure::fromCallable('\ZealPHP\Session\zeal_session_unset'), true);
-        \uopz_set_return('session_regenerate_id', \Closure::fromCallable('\ZealPHP\Session\zeal_session_regenerate_id'), true);
-        \uopz_set_return('session_get_cookie_params', \Closure::fromCallable('\ZealPHP\Session\zeal_session_get_cookie_params'), true);
-        \uopz_set_return('session_set_cookie_params', \Closure::fromCallable('\ZealPHP\Session\zeal_session_set_cookie_params'), true);
-        \uopz_set_return('session_cache_limiter', \Closure::fromCallable('\ZealPHP\Session\zeal_session_cache_limiter'), true);
-        \uopz_set_return('session_cache_expire', \Closure::fromCallable('\ZealPHP\Session\zeal_session_cache_expire'), true);
-        \uopz_set_return('session_commit', \Closure::fromCallable('\ZealPHP\Session\zeal_session_commit'), true);
-        \uopz_set_return('session_abort', \Closure::fromCallable('\ZealPHP\Session\zeal_session_abort'), true);
-        \uopz_set_return('session_encode', \Closure::fromCallable('\ZealPHP\Session\zeal_session_encode'), true);
-        \uopz_set_return('session_decode', \Closure::fromCallable('\ZealPHP\Session\zeal_session_decode'), true);
-        \uopz_set_return('session_save_path', \Closure::fromCallable('\ZealPHP\Session\zeal_session_save_path'), true);
-        \uopz_set_return('session_module_name', \Closure::fromCallable('\ZealPHP\Session\zeal_session_module_name'), true);
+        // in CLI SAPI; neither extension can override what doesn't exist. They are
+        // registered as global shims via src/apache_shims.php (composer files autoload).
+        self::overrideBuiltin('session_start', '\ZealPHP\Session\zeal_session_start');
+        self::overrideBuiltin('session_id', '\ZealPHP\Session\zeal_session_id');
+        self::overrideBuiltin('session_status', '\ZealPHP\Session\zeal_session_status');
+        self::overrideBuiltin('session_name', '\ZealPHP\Session\zeal_session_name');
+        self::overrideBuiltin('session_write_close', '\ZealPHP\Session\zeal_session_write_close');
+        self::overrideBuiltin('session_destroy', '\ZealPHP\Session\zeal_session_destroy');
+        self::overrideBuiltin('session_unset', '\ZealPHP\Session\zeal_session_unset');
+        self::overrideBuiltin('session_regenerate_id', '\ZealPHP\Session\zeal_session_regenerate_id');
+        self::overrideBuiltin('session_get_cookie_params', '\ZealPHP\Session\zeal_session_get_cookie_params');
+        self::overrideBuiltin('session_set_cookie_params', '\ZealPHP\Session\zeal_session_set_cookie_params');
+        self::overrideBuiltin('session_cache_limiter', '\ZealPHP\Session\zeal_session_cache_limiter');
+        self::overrideBuiltin('session_cache_expire', '\ZealPHP\Session\zeal_session_cache_expire');
+        self::overrideBuiltin('session_commit', '\ZealPHP\Session\zeal_session_commit');
+        self::overrideBuiltin('session_abort', '\ZealPHP\Session\zeal_session_abort');
+        self::overrideBuiltin('session_encode', '\ZealPHP\Session\zeal_session_encode');
+        self::overrideBuiltin('session_decode', '\ZealPHP\Session\zeal_session_decode');
+        self::overrideBuiltin('session_save_path', '\ZealPHP\Session\zeal_session_save_path');
+        self::overrideBuiltin('session_module_name', '\ZealPHP\Session\zeal_session_module_name');
     }
 
     /**
@@ -901,6 +899,19 @@ class App
      * Called from `superglobals`, `processIsolation`, `enableCoroutine`,
      * `hookAll` setters when they receive a write (not a read).
      */
+    /**
+     * @param callable-string $callable
+     */
+    private static function overrideBuiltin(string $name, string $callable): void
+    {
+        $cb = \Closure::fromCallable($callable);
+        if (\extension_loaded('zealphp') && \function_exists('zealphp_override')) {
+            (\zealphp_override(...))($name, $cb);
+        } elseif (\function_exists('uopz_set_return')) {
+            \uopz_set_return($name, $cb, true);
+        }
+    }
+
     private static function refuseAfterRun(string $setter): void
     {
         if (self::$run_has_started) {
@@ -5886,10 +5897,10 @@ HELP;
         // proc_open, so routing through it keeps the fallback recursion-safe.
         $hookExec = self::$hook_exec ?? (self::$superglobals === false);
         if ($hookExec) {
-            \uopz_set_return('shell_exec', \Closure::fromCallable('\ZealPHP\zeal_shell_exec'), true);
-            \uopz_set_return('system',     \Closure::fromCallable('\ZealPHP\zeal_system'), true);
-            \uopz_set_return('passthru',   \Closure::fromCallable('\ZealPHP\zeal_passthru'), true);
-            \uopz_set_return('exec',       \Closure::fromCallable('\ZealPHP\zeal_exec'), true);
+            self::overrideBuiltin('shell_exec', '\ZealPHP\zeal_shell_exec');
+            self::overrideBuiltin('system',     '\ZealPHP\zeal_system');
+            self::overrideBuiltin('passthru',   '\ZealPHP\zeal_passthru');
+            self::overrideBuiltin('exec',       '\ZealPHP\zeal_exec');
             // proc_open intentionally NOT overridden — App::rawExec()/cgiSubprocess() rely on it.
         }
 

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -180,7 +180,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  sibidharan/zealphp-project:^0.2.43 \
+  sibidharan/zealphp-project:^0.3.0 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, coroutines, shared memory, task workers &mdash;
        first&#8209;class because the server never shuts down between requests.</p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.2.43 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.3.0 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -309,7 +309,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.2.43 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.2.43 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.3.0 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.3.0 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>

--- a/template/pages/learn/ai-chat.php
+++ b/template/pages/learn/ai-chat.php
@@ -60,7 +60,7 @@ $active = $active ?? 'learn/ai-chat';
       event log — is extracted into a reusable partial that the lesson page and the standalone popup
       both render:
     </p>
-    <pre><code class="language-php">// template/components/_chat_widget.php
+    <pre><code class="language-php-template">// template/components/_chat_widget.php
 &lt;?php
 $user ??= null;
 if (!$user) return;

--- a/template/pages/learn/components.php
+++ b/template/pages/learn/components.php
@@ -27,7 +27,7 @@
 
     <h2>Step 1: Create a master layout</h2>
     <p>A layout is just a PHP template that wraps your page content. Create <a href="https://github.com/sibidharan/zealphp/blob/master/template/_master.php" target="_blank"><code>template/_master.php</code></a>:</p>
-    <pre><code class="language-php">&lt;!doctype html&gt;
+    <pre><code class="language-php-template">&lt;!doctype html&gt;
 &lt;html lang="en"&gt;
 &lt;head&gt;
   &lt;meta charset="utf-8"&gt;
@@ -63,7 +63,7 @@ App::render('/_master', ['title' =&gt; 'About', 'page' =&gt; 'about']);</code></
       <strong>stencil with holes</strong> — you lay the stencil down and fill in the holes
       with different data each time.
     </p>
-    <pre><code class="language-php">&lt;!-- template/components/_card.php --&gt;
+    <pre><code class="language-php-template">&lt;!-- template/components/_card.php --&gt;
 &lt;?php $variant ??= 'default'; ?&gt;
 &lt;article class="card card-&lt;?= htmlspecialchars($variant) ?&gt;"&gt;
   &lt;h3&gt;&lt;?= htmlspecialchars($title) ?&gt;&lt;/h3&gt;
@@ -91,7 +91,7 @@ App::render('/_master', ['title' =&gt; 'About', 'page' =&gt; 'about']);</code></
 }
 
 // Requires: React, JSX transpiler, bundler, hydration</code></pre>',
-      'after' => '<pre><code class="language-php">&lt;?php $variant ??= \'default\'; ?&gt;
+      'after' => '<pre><code class="language-php-template">&lt;?php $variant ??= \'default\'; ?&gt;
 &lt;article class="card card-&lt;?= $variant ?&gt;"&gt;
   &lt;h3&gt;&lt;?= htmlspecialchars($title) ?&gt;&lt;/h3&gt;
   &lt;p&gt;&lt;?= $body ?&gt;&lt;/p&gt;

--- a/template/pages/learn/htmx.php
+++ b/template/pages/learn/htmx.php
@@ -525,7 +525,7 @@ return $body;</code></pre>
       This is the punchline. The <em>same</em> route handler serves the full page on plain navigation and the
       named fragment on htmx swap — and on the htmx response, fires a client event so a toast component picks up:
     </p>
-    <pre><code class="language-php">// template/pages/notes.php — fragments and full page from one file
+    <pre><code class="language-php-template">// template/pages/notes.php — fragments and full page from one file
 &lt;?php use ZealPHP\App; ?&gt;
 &lt;section&gt;
   &lt;h1&gt;Notes&lt;/h1&gt;

--- a/template/pages/learn/notes.php
+++ b/template/pages/learn/notes.php
@@ -52,7 +52,7 @@ $active = $active ?? 'learn/notes';
       reusable partial:
     </p>
     <p><strong>Create <code>template/components/_notes_widget.php</code>:</strong></p>
-    <pre><code class="language-php">&lt;?php
+    <pre><code class="language-php-template">&lt;?php
 $user ??= null;
 if (!$user) return;
 ?&gt;
@@ -253,7 +253,7 @@ ${basename(__FILE__, '.php')} = function () {
       <li><code>hx-on::after-request</code> — clear the form after success</li>
     </ul>
     <p>Delete uses a similar pattern:</p>
-    <pre><code class="language-html">&lt;button hx-delete="/api/learn/notes/&lt;?= $id ?&gt;"
+    <pre><code class="language-php-template">&lt;button hx-delete="/api/learn/notes/&lt;?= $id ?&gt;"
         hx-target="#note-&lt;?= $id ?&gt;"
         hx-swap="outerHTML"
         hx-confirm="Delete this note?"&gt;Delete&lt;/button&gt;</code></pre>
@@ -264,7 +264,7 @@ ${basename(__FILE__, '.php')} = function () {
       Each note renders as a card. This component is used in three places: the notes list (GET), the create response (POST), and the chat history bubbles (<a href="/learn/ai-chat">Lesson 20, AI Chat</a>). Same file, three consumers.
     </p>
     <p><strong>Create <code>template/components/_note_card.php</code>:</strong></p>
-    <pre><code class="language-php">&lt;?php
+    <pre><code class="language-php-template">&lt;?php
 $id    = (int)($id ?? 0);
 $title = (string)($title ?? '');
 $body  = (string)($body ?? '');

--- a/tests/Unit/OverrideBuiltinTest.php
+++ b/tests/Unit/OverrideBuiltinTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+/**
+ * Tests for App::overrideBuiltin() — the ext-zealphp / uopz auto-detection layer.
+ */
+final class OverrideBuiltinTest extends TestCase
+{
+    private \ReflectionMethod $method;
+
+    protected function setUp(): void
+    {
+        $this->method = new \ReflectionMethod(App::class, 'overrideBuiltin');
+        $this->method->setAccessible(true);
+    }
+
+    public function testOverrideBuiltinIsCallable(): void
+    {
+        $this->assertTrue($this->method->isStatic());
+        $this->assertCount(2, $this->method->getParameters());
+    }
+
+    public function testOverrideRoutesToAvailableExtension(): void
+    {
+        $hasZealphp = extension_loaded('zealphp');
+        $hasUopz = function_exists('uopz_set_return');
+
+        $this->assertTrue(
+            $hasZealphp || $hasUopz,
+            'At least one override extension (zealphp or uopz) must be loaded'
+        );
+
+        // Call overrideBuiltin on a function we can verify
+        $this->method->invoke(null, 'headers_sent', '\ZealPHP\headers_sent');
+
+        // The function should now be overridden — calling it should route
+        // to ZealPHP's implementation which returns false (no headers sent
+        // outside a request context)
+        $result = headers_sent();
+        $this->assertFalse($result);
+    }
+
+    public function testOverrideAcceptsAllSessionFunctions(): void
+    {
+        $sessionFuncs = [
+            'session_cache_limiter' => '\ZealPHP\Session\zeal_session_cache_limiter',
+            'session_cache_expire'  => '\ZealPHP\Session\zeal_session_cache_expire',
+            'session_module_name'   => '\ZealPHP\Session\zeal_session_module_name',
+            'session_save_path'     => '\ZealPHP\Session\zeal_session_save_path',
+        ];
+
+        foreach ($sessionFuncs as $name => $callable) {
+            // Should not throw — all session functions are in the allowlist
+            $this->method->invoke(null, $name, $callable);
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    public function testOverrideAcceptsExecFamily(): void
+    {
+        if (!function_exists('\ZealPHP\zeal_shell_exec')) {
+            $this->markTestSkipped('Exec overrides not defined (loaded outside App boot)');
+        }
+
+        $execFuncs = [
+            'shell_exec' => '\ZealPHP\zeal_shell_exec',
+            'exec'       => '\ZealPHP\zeal_exec',
+            'system'     => '\ZealPHP\zeal_system',
+            'passthru'   => '\ZealPHP\zeal_passthru',
+        ];
+
+        foreach ($execFuncs as $name => $callable) {
+            $this->method->invoke(null, $name, $callable);
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    public function testDetectsExtZealphpWhenLoaded(): void
+    {
+        if (!extension_loaded('zealphp')) {
+            $this->markTestSkipped('ext-zealphp not loaded');
+        }
+
+        $this->assertTrue(function_exists('zealphp_override'));
+        $this->assertTrue(function_exists('zealphp_restore'));
+        $this->assertTrue(function_exists('zealphp_restore_all'));
+    }
+
+    public function testFallsBackToUopzWhenZealphpNotLoaded(): void
+    {
+        if (extension_loaded('zealphp')) {
+            $this->markTestSkipped('ext-zealphp is loaded — fallback path not exercised');
+        }
+
+        $this->assertTrue(
+            function_exists('uopz_set_return'),
+            'uopz must be loaded when ext-zealphp is not'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **ext-zealphp**: Purpose-built C extension (~250 lines) replacing uopz
- **App.php**: `overrideBuiltin()` auto-detects ext-zealphp vs uopz
- **CI**: openswoole source-build fallback for PHP 8.5.6+
- **Version bump**: 0.2.43 → 0.3.0
- **Tests**: OverrideBuiltinTest (6 cases)
- **Syntax highlighting**: 8 code blocks fixed

## Test plan
- [x] All 53 function overrides verified on ext-zealphp
- [x] Full server boot + auth + notes with ext-zealphp only
- [x] PHPStan level 10 zero errors
- [x] 2961 unit tests pass

Closes #116