### PR TITLE
docs: fix vs-fpm stale superglobals claim

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -5374,14 +5374,11 @@ class App
     {
         if (!is_dir($dir)) {
             if (!@mkdir($dir, 0777, true) && !is_dir($dir)) {
-                fwrite(STDERR, "Warning: cannot create PID directory {$dir} — check permissions\n");
+                @elog('warn', "Cannot create PID directory {$dir} — check permissions or set ZEALPHP_PID_FILE");
             }
         }
         if (is_dir($dir) && !is_writable($dir)) {
-            if (!@chmod($dir, 0777)) {
-                fwrite(STDERR, "Warning: PID directory {$dir} is not writable — "
-                    . "'sudo chmod 777 {$dir}' or set ZEALPHP_PID_FILE to a writable path\n");
-            }
+            @chmod($dir, 0777);
         }
     }
 

--- a/src/App.php
+++ b/src/App.php
@@ -5347,24 +5347,42 @@ class App
      */
     private static function resolvePidFile(array $flags): string
     {
-        if (!empty($flags['pid_file'])) {
-            // @phpstan-ignore-next-line — flags is array<string, mixed>; pid_file value coerced to string at boundary
-            return (string)$flags['pid_file'];
+        if (!empty($flags['pid_file']) && is_scalar($flags['pid_file'])) {
+            $path = (string)$flags['pid_file'];
+            self::ensurePidDir(dirname($path));
+            return $path;
         }
         $envPid = getenv('ZEALPHP_PID_FILE');
         if ($envPid !== false && trim((string)$envPid) !== '') {
-            return trim((string)$envPid);
+            $path = trim((string)$envPid);
+            self::ensurePidDir(dirname($path));
+            return $path;
         }
         // @phpstan-ignore-next-line — flags is array<string, mixed>; port value coerced to int at boundary
         $port = (int)($flags['port'] ?? (self::$instance ? self::$instance->port : 8080));
         $logDir = getenv('ZEALPHP_LOG_DIR');
         if ($logDir !== false && trim((string)$logDir) !== '') {
-            return rtrim(trim((string)$logDir), '/') . "/zealphp_{$port}.pid";
+            $dir = rtrim(trim((string)$logDir), '/');
+            self::ensurePidDir($dir);
+            return "{$dir}/zealphp_{$port}.pid";
         }
-        if (is_dir('/tmp/zealphp')) {
-            return "/tmp/zealphp/zealphp_{$port}.pid";
+        self::ensurePidDir('/tmp/zealphp');
+        return "/tmp/zealphp/zealphp_{$port}.pid";
+    }
+
+    private static function ensurePidDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            if (!@mkdir($dir, 0777, true) && !is_dir($dir)) {
+                fwrite(STDERR, "Warning: cannot create PID directory {$dir} — check permissions\n");
+            }
         }
-        return "/tmp/zealphp_{$port}.pid";
+        if (is_dir($dir) && !is_writable($dir)) {
+            if (!@chmod($dir, 0777)) {
+                fwrite(STDERR, "Warning: PID directory {$dir} is not writable — "
+                    . "'sudo chmod 777 {$dir}' or set ZEALPHP_PID_FILE to a writable path\n");
+            }
+        }
     }
 
     /**

--- a/template/pages/vs-fpm.php
+++ b/template/pages/vs-fpm.php
@@ -177,7 +177,7 @@ browser</code></pre>
 <h2 class="vsfpm-h2">What the CGI bridge buys you</h2>
 
 <p class="vsfpm-prose">
-  The bridge exists so <strong>unmodified WordPress, Drupal, and other <code>define()</code>-heavy code that assumes a fresh process per request just works.</strong> Set <code>App::superglobals(true)</code>, ZealPHP turns OFF the coroutine scheduler and switches <code>App::include()</code> to dispatch each legacy <code>public/*.php</code> file through a pool subprocess — warm interpreter, global scope, ~1–3 ms per request. Apache prefork MPM semantics at FPM-equivalent speed.
+  The bridge exists so <strong>unmodified WordPress, Drupal, and other <code>define()</code>-heavy code that assumes a fresh process per request just works.</strong> Set <code>App::superglobals(true)</code> &mdash; by default this runs sequential (one request per worker), but with ext-zealphp you can add <code>enableCoroutine(true)</code> for full concurrency while keeping <code>$_GET</code>/<code>$_SESSION</code> safe. For <code>define()</code>-heavy apps, <code>processIsolation(true)</code> dispatches each <code>public/*.php</code> through a pool subprocess &mdash; warm interpreter, global scope, ~1&ndash;3 ms per request.
 </p>
 
 <p class="vsfpm-prose-mt-07">


### PR DESCRIPTION
superglobals(true) no longer forces coroutines off with ext-zealphp