### PR TITLE
fix: setcookie array options, session_destroy, die() on PHP 8.4

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -6454,7 +6454,9 @@ HELP;
                 }
                 access_log($serverResponse->getStatusCode(), 0);
             } catch (\Throwable|\OpenSwoole\ExitException $e) {
-                if ($e instanceof \OpenSwoole\ExitException) {
+                if ($e instanceof \OpenSwoole\ExitException
+                    || ($e::class === 'ExitException' && method_exists($e, 'getStatus'))
+                ) {
                     $exitStatus = $e->getStatus();
                     $body = is_string($exitStatus) ? $exitStatus : '';
                     $code = (is_int($exitStatus) && $exitStatus >= 100 && $exitStatus <= 599) ? $exitStatus : ($g->status ?? 200);
@@ -6761,7 +6763,9 @@ class ResponseMiddleware implements MiddlewareInterface
             }
             return (new Response($body, $status));
         } catch (\Throwable|\OpenSwoole\ExitException $e) {
-            if($e instanceof \OpenSwoole\ExitException){
+            if ($e instanceof \OpenSwoole\ExitException
+                || ($e::class === 'ExitException' && method_exists($e, 'getStatus'))
+            ) {
                 $exitStatus = $e->getStatus();
                 if ($exitStatus === 0 || $exitStatus === null) {
                     return (new Response(''))->withStatus($g->status ?? 200);
@@ -6935,7 +6939,9 @@ class ResponseMiddleware implements MiddlewareInterface
             }
             return (new Response($buffer, $status));
         } catch (\Throwable|\OpenSwoole\ExitException $e) {
-            if($e instanceof \OpenSwoole\ExitException){
+            if ($e instanceof \OpenSwoole\ExitException
+                || ($e::class === 'ExitException' && method_exists($e, 'getStatus'))
+            ) {
                 $exitStatus = $e->getStatus();
                 $buffered = (string)ob_get_clean();
                 if ($exitStatus === 0 || $exitStatus === null) {

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -424,6 +424,8 @@ function zeal_session_destroy(): bool
     assert(is_string($session_name));
     unset($g->cookie[$session_name]);
 
+    $g->_session_started = false;
+
     return true;
 }
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -736,9 +736,27 @@ function response_headers_list(): array
  * @param bool   $httponly
  * @param string $samesite
  */
-function setcookie($name, $value = "", $expire = 0, $path = "", $domain = "", $secure = false, $httponly = false, $samesite = ''): bool {
-    // Cookie name char rules match PHP native setcookie: reject `=,; \t\r\n\013\014\0`.
-    // Reject CR/LF/NUL in value/path/domain to prevent Set-Cookie header injection.
+/**
+ * @param string $name
+ * @param string $value
+ * @param int|array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool, samesite?: string} $expire_or_options
+ * @param string $path
+ * @param string $domain
+ * @param bool $secure
+ * @param bool $httponly
+ * @param string $samesite
+ */
+function setcookie($name, $value = "", int|array $expire_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false, $samesite = ''): bool {
+    if (is_array($expire_or_options)) {
+        $expire   = (int) ($expire_or_options['expires'] ?? 0);
+        $path     = (string) ($expire_or_options['path'] ?? '');
+        $domain   = (string) ($expire_or_options['domain'] ?? '');
+        $secure   = (bool) ($expire_or_options['secure'] ?? false);
+        $httponly  = (bool) ($expire_or_options['httponly'] ?? false);
+        $samesite = (string) ($expire_or_options['samesite'] ?? '');
+    } else {
+        $expire = $expire_or_options;
+    }
     if (strpbrk((string)$name, "=,; \t\r\n\013\014\0") !== false) {
         trigger_error("Cookie names cannot contain any of the following '=,; \\t\\r\\n\\013\\014'", E_USER_WARNING);
         return false;
@@ -757,32 +775,24 @@ function setcookie($name, $value = "", $expire = 0, $path = "", $domain = "", $s
 }
 
 /**
- * Set a raw cookie.
- *
- * @param string $name The name of the cookie.
- * @param string $value The value of the cookie. Default is an empty string.
- * @param int $expire The time the cookie expires. This is a Unix timestamp so is in number of seconds since the epoch. Default is 0.
- * @param string $path The path on the server in which the cookie will be available on. Default is an empty string.
- * @param string $domain The (sub)domain that the cookie is available to. Default is an empty string.
- * @param bool $secure Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client. Default is false.
- * @param bool $httponly When true the cookie will be made accessible only through the HTTP protocol. Default is false.
- */
-/**
  * @param string $name
  * @param string $value
- * @param int    $expire
+ * @param int|array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool} $expire_or_options
  * @param string $path
  * @param string $domain
  * @param bool   $secure
  * @param bool   $httponly
  */
-function setrawcookie($name, $value = "", $expire = 0, $path = "", $domain = "", $secure = false, $httponly = false): bool {
-    // setrawcookie() skips URL-encoding on $value, which is the whole point —
-    // it's "raw" so callers can pass already-encoded values verbatim. Match
-    // PHP native behavior: reject the name char-class, but only reject
-    // CRLF/NUL in the value/path/domain (the response-splitting vector).
-    // Do NOT reject space/comma/semicolon in the value — PHP allows them
-    // (test fixture: setrawcookie('rawck', 'a b+c/d')).
+function setrawcookie($name, $value = "", int|array $expire_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false): bool {
+    if (is_array($expire_or_options)) {
+        $expire   = (int) ($expire_or_options['expires'] ?? 0);
+        $path     = (string) ($expire_or_options['path'] ?? '');
+        $domain   = (string) ($expire_or_options['domain'] ?? '');
+        $secure   = (bool) ($expire_or_options['secure'] ?? false);
+        $httponly  = (bool) ($expire_or_options['httponly'] ?? false);
+    } else {
+        $expire = $expire_or_options;
+    }
     if (strpbrk((string)$name, "=,; \t\r\n\013\014\0") !== false) {
         trigger_error("Cookie names cannot contain any of the following '=,; \\t\\r\\n\\013\\014'", E_USER_WARNING);
         return false;

--- a/template/pages/learn/first-page.php
+++ b/template/pages/learn/first-page.php
@@ -60,11 +60,11 @@ echo "&lt;h1&gt;Hello, {$name}!&lt;/h1&gt;";
 echo "&lt;p&gt;The time is " . date('H:i:s') . "&lt;/p&gt;";</code></pre>
     <p>Visit <code>/greeting?name=Alice</code> and the page greets Alice by name.</p>
     <p>
-      <strong>Why <code>$g-&gt;get</code> instead of <code>$_GET</code>?</strong> &nbsp;ZealPHP handles
-      many requests at once inside one process. <code>$_GET</code> is a single global array &mdash; if two
-      requests touch it simultaneously, they&rsquo;d overwrite each other. <code>$g</code> is scoped to
-      <em>your</em> request, so it&rsquo;s always safe.
-      <a href="/learn/mental-model">Lesson&nbsp;4</a> has the full picture.
+      <strong>Why <code>$g-&gt;get</code> instead of <code>$_GET</code>?</strong> &nbsp;<code>$g-&gt;get</code>
+      works in every mode ZealPHP supports &mdash; it&rsquo;s always scoped to <em>your</em> request.
+      <code>$_GET</code> also works if you have ext-zealphp installed (it makes superglobals
+      per-request safe), but <code>$g-&gt;get</code> is the recommended convention.
+      <a href="/learn/mental-model">Lesson&nbsp;4</a> explains the difference.
     </p>
 
     <?php App::render('/components/_tryit', [
@@ -112,7 +112,7 @@ App::render('/_master', [
     <?php App::render('/components/_keytakeaways', ['items' => [
       'Files in <code>public/</code> automatically become URLs — no routing config needed',
       'The URL mirrors the file path: <code>public/blog/post.php</code> → <code>/blog/post</code>',
-      'Use <code>$_GET</code> for query parameters, standard PHP for dynamic content',
+      'Use <code>$g-&gt;get</code> for query parameters — works in every mode, always safe',
       '<code>.php</code> extensions are stripped — clean URLs by default',
     ]]); ?>
 


### PR DESCRIPTION
## Summary
Three bugs found during traditional PHP compatibility testing:

1. **setcookie() array options** — `setcookie('name', 'val', ['samesite' => 'Lax'])` threw TypeError. Now supports the PHP 7.3+ array form.
2. **session_destroy()** — framework cleanup called `session_write_close()` after destroy, potentially re-creating the session. Now sets `_session_started = false`.
3. **die("msg") returns 500** — dispatch-level catch blocks only checked `\OpenSwoole\ExitException`, missing PHP 8.4's native `\ExitException`. Now checks both.

## Test plan
- [ ] `setcookie('x', 'v', ['expires' => time()+3600, 'samesite' => 'Lax'])` returns 200
- [ ] `session_destroy()` + re-read with same PHPSESSID returns empty session
- [ ] `die("hello")` returns 200 with body "hello" on PHP 8.4+
- [ ] PHPStan level 10 clean
- [ ] All unit tests pass