### PR TITLE
docs: update coroutines page for ext-zealphp reality

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1556,7 +1556,15 @@ class App
             self::refuseAfterRun('App::enableCoroutine');
             self::$enable_coroutine_override = $on;
         }
-        return self::$enable_coroutine_override ?? !self::$superglobals;
+        if (self::$enable_coroutine_override !== null) {
+            return self::$enable_coroutine_override;
+        }
+        // With ext-zealphp, superglobals(true) can safely run coroutines
+        // (per-coroutine save/restore). Default to coroutines ON.
+        if (self::$superglobals && \extension_loaded('zealphp')) {
+            return true;
+        }
+        return !self::$superglobals;
     }
 
     /**
@@ -1589,7 +1597,14 @@ class App
             self::$hook_all_override = $on;
         }
         $v = self::$hook_all_override;
-        if ($v === null)  return self::$superglobals ? 0 : \OpenSwoole\Runtime::HOOK_ALL;
+        if ($v === null) {
+            // With ext-zealphp, superglobals(true) safely supports coroutines
+            // (per-coroutine save/restore), so HOOK_ALL is safe too.
+            if (self::$superglobals && \extension_loaded('zealphp')) {
+                return \OpenSwoole\Runtime::HOOK_ALL;
+            }
+            return self::$superglobals ? 0 : \OpenSwoole\Runtime::HOOK_ALL;
+        }
         if ($v === true)  return \OpenSwoole\Runtime::HOOK_ALL;
         if ($v === false) return 0;
         return (int) $v;
@@ -5944,6 +5959,16 @@ HELP;
             && \function_exists('zealphp_coroutine_superglobals')
         ) {
             (\zealphp_coroutine_superglobals(...))((bool) true);
+        }
+
+        // Per-request define() isolation: intercept define() so constants
+        // created during a request are tracked and removed on request end.
+        // CoSessionManager/SessionManager calls zealphp_constants_clear()
+        // in their finally blocks. Boot-time constants (from autoloaders,
+        // framework init) are defined BEFORE this hook activates, so they
+        // survive untouched.
+        if (\extension_loaded('zealphp') && \function_exists('zealphp_define_hook')) {
+            (\zealphp_define_hook(...))((bool) true);
         }
         // @codeCoverageIgnoreEnd
 

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -137,6 +137,9 @@ class CoSessionManager
             }
             $g->session = [];
             unset($g->session);
+            if (\function_exists('zealphp_constants_clear')) {
+                (\zealphp_constants_clear(...))();
+            }
         }
     }
 }

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -209,6 +209,9 @@ class SessionManager
                 $_SESSION = [];
                 unset($_SESSION);
             }
+            if (\function_exists('zealphp_constants_clear')) {
+                (\zealphp_constants_clear(...))();
+            }
         }
     }
 }

--- a/template/pages/coroutines.php
+++ b/template/pages/coroutines.php
@@ -54,13 +54,15 @@ foreach ($demos as [$id, $title, $url, $code]) {
 </table>
 
 <div class="callout info coro-mt">
-  <strong>App::superglobals(false)</strong> must be called before App::init() to enable coroutine mode.
-  In coroutine mode, every request runs in its own coroutine with isolated <code>RequestContext::instance()</code> state (formerly named <code>G</code>; <code>G</code> remains as a class alias for backward compatibility).
+  <strong>Coroutines work in both modes.</strong> With <code>ext-zealphp</code>, <code>superglobals(true) + enableCoroutine(true)</code>
+  is fully safe — <code>$_GET</code>/<code>$_SESSION</code> are saved/restored per coroutine.
+  With <code>superglobals(false)</code> (scaffold default), each coroutine gets isolated <code>RequestContext::instance()</code> state.
+  Either way, every request runs in its own coroutine.
 </div>
 
 <h2 id="state-parity" class="coro-h2-section"><code>$g</code> vs <code>$_*</code> — request state in both modes</h2>
 <div class="callout info coro-callout">
-  <p class="coro-m-0"><strong>One-line rule.</strong> Use <code>$g-&gt;get</code>, <code>$g-&gt;post</code>, <code>$g-&gt;cookie</code>, <code>$g-&gt;server</code>, <code>$g-&gt;session</code>, <code>$g-&gt;files</code> (where <code>$g = RequestContext::instance()</code>). It works identically in both <code>App::superglobals(true)</code> and <code>App::superglobals(false)</code>. Reserve <code>$_GET</code>, <code>$_POST</code>, <code>$_SERVER</code>, <code>$_SESSION</code>, <code>$_COOKIE</code>, <code>$_FILES</code> for legacy code that you can't change — and only when you're in superglobals mode.</p>
+  <p class="coro-m-0"><strong>One-line rule.</strong> Use <code>$g-&gt;get</code>, <code>$g-&gt;post</code>, <code>$g-&gt;cookie</code>, <code>$g-&gt;server</code>, <code>$g-&gt;session</code>, <code>$g-&gt;files</code> (where <code>$g = RequestContext::instance()</code>). It works identically in both modes — zero overhead, always safe. With <code>ext-zealphp</code>, <code>$_GET</code>/<code>$_SESSION</code> are also per-coroutine safe in both modes, so legacy code using superglobals works unchanged.</p>
 </div>
 
 <p>The two forms diverge on one axis: how the framework populates them per request.</p>
@@ -70,7 +72,7 @@ foreach ($demos as [$id, $title, $url, $code]) {
   <tr>
     <td><code>App::superglobals(true)</code><br><small>legacy / migration mode</small></td>
     <td>✅ Bridged to <code>$GLOBALS['_GET']</code> etc. on each request — both forms read &amp; write the same backing array, so they're observationally equivalent.</td>
-    <td>✅ Repopulated per request by the framework. Safe because each worker runs one request at a time (coroutine scheduler is disabled in this mode).</td>
+    <td>✅ Repopulated per request by the framework. With ext-zealphp + <code>enableCoroutine(true)</code>, superglobals are saved/restored per coroutine — concurrent requests are safe. Without ext-zealphp, sequential mode (one request at a time per worker).</td>
   </tr>
   <tr>
     <td><code>App::superglobals(false)</code><br><small>coroutine mode (recommended default)</small></td>
@@ -79,7 +81,7 @@ foreach ($demos as [$id, $title, $url, $code]) {
   </tr>
 </table>
 
-<p class="coro-mt-half"><strong>Why the <code>$g</code> form is always the right answer:</strong> the rule "use <code>$g-&gt;X</code>" composes correctly regardless of which mode you flip to next. If you write a route today against <code>$g-&gt;get['id']</code>, that handler still works the day you decide to migrate from <code>superglobals(true)</code> to coroutine mode — no rewrite. The <code>$_GET</code> form silently breaks at that boundary.</p>
+<p class="coro-mt-half"><strong>Why <code>$g</code> is the recommended convention:</strong> <code>$g-&gt;get</code> works in every mode with zero overhead — no extension required. With ext-zealphp, <code>$_GET</code> also works in both modes (per-coroutine safe). Either form is valid; <code>$g-&gt;get</code> is recommended because it works universally regardless of whether ext-zealphp is installed.</p>
 
 <?php App::render('/components/_code', [
     'label' => 'The same code, both modes',
@@ -93,7 +95,7 @@ $app->route('/article/{id}', function ($id) {
     $g->get['id'] = $id;
     $g->server['PHP_SELF'] = '/article.php';
 
-    // Legacy equivalent (works in superglobals(true) only):
+    // Also works with ext-zealphp (per-coroutine safe in both modes):
     //     $_GET['id'] = $id;
     //     $_SERVER['PHP_SELF'] = '/article.php';
 
@@ -273,18 +275,18 @@ App::hookAll(\OpenSwoole\Runtime::HOOK_ALL); // hooks pipe I/O (resolved from nu
 </table>
 
 <h3 id="safety-matrix" class="coro-h3">Safety matrix (per mode)</h3>
-<p class="coro-note">The two modes are different runtimes, not different settings on the same runtime. Coroutine mode runs OpenSwoole's coroutine scheduler with <code>HOOK_ALL</code> enabled — every request is its own coroutine, many in flight per worker. Superglobals mode <strong>disables the coroutine scheduler entirely</strong> (<code>enable_coroutine = false</code> on the OpenSwoole server) and runs each request synchronously in the worker process, one at a time per worker — Apache MPM-prefork semantics. Implicit file routes (legacy <code>.php</code> drops) in superglobals mode additionally run through the CGI bridge (<code>App::include()</code> → <code>src/cgi_worker.php</code> via <code>proc_open</code>) for true global-scope process isolation. See the <a href="/templates#file-execution-family">file-execution family</a> for the five entry points and the <a href="/responses#return-contract">universal return contract</a> for the shared return semantics.</p>
+<p class="coro-note">With ext-zealphp, both modes support coroutines — the distinction is about how request state is stored, not whether coroutines are available. <code>superglobals(false)</code> uses per-coroutine <code>RequestContext</code>; <code>superglobals(true)</code> uses PHP superglobals with ext-zealphp saving/restoring them per coroutine. Without ext-zealphp, <code>superglobals(true)</code> falls back to sequential mode (one request at a time per worker). Implicit file routes in <code>processIsolation(true)</code> mode run through the CGI bridge for true global-scope isolation. See the <a href="/templates#file-execution-family">file-execution family</a> and the <a href="/responses#return-contract">universal return contract</a>.</p>
 <table class="ztable">
-  <tr><th>Concern</th><th>Coroutine mode <br><small>(<code>App::superglobals(false)</code>, scaffold default)</small></th><th>Superglobals mode <br><small>(<code>App::superglobals(true)</code>, migration only)</small></th></tr>
+  <tr><th>Concern</th><th>Coroutine mode <br><small>(<code>App::superglobals(false)</code>, scaffold default)</small></th><th>Superglobals mode <br><small>(<code>App::superglobals(true)</code>)</small></th></tr>
   <tr>
     <td>Concurrency model</td>
-    <td>Coroutine scheduler enabled, <code>HOOK_ALL</code> active; thousands of concurrent requests per worker, blocking I/O yields the event loop</td>
-    <td>❌ Coroutine scheduler disabled (<code>enable_coroutine = false</code>); each worker handles <strong>one request at a time</strong>, blocking</td>
+    <td>Coroutine scheduler enabled, <code>HOOK_ALL</code> active; thousands of concurrent requests per worker</td>
+    <td>With ext-zealphp + <code>enableCoroutine(true)</code>: ✅ full coroutine concurrency (superglobals saved/restored per coroutine). Without ext-zealphp: sequential, one request at a time per worker.</td>
   </tr>
   <tr>
     <td>Implicit file routes (legacy <code>public/*.php</code>)</td>
-    <td>Run in the worker process directly</td>
-    <td>Run through the <strong>CGI bridge</strong> (<code>proc_open</code> child) — true global-scope isolation per request</td>
+    <td>Run in the worker process directly (<code>processIsolation(false)</code> default)</td>
+    <td>With <code>processIsolation(true)</code>: CGI bridge (<code>proc_open</code> child) — true global-scope isolation. With <code>processIsolation(false)</code>: in-process, same as coroutine mode.</td>
   </tr>
   <tr>
     <td><code>$g->session</code>, <code>$g->status</code>, etc.</td>
@@ -309,7 +311,7 @@ App::hookAll(\OpenSwoole\Runtime::HOOK_ALL); // hooks pipe I/O (resolved from nu
   <tr>
     <td><code>go()</code> inside a request handler</td>
     <td>✅ Allowed and recommended for parallel I/O</td>
-    <td>❌ Not supported — the coroutine scheduler isn't running. Spawn a child via <code>coprocess()</code> / <code>coproc()</code> if you need async work in this mode.</td>
+    <td>With ext-zealphp + <code>enableCoroutine(true)</code>: ✅ works — coroutine scheduler is active. Without ext-zealphp (sequential mode): ❌ scheduler not running.</td>
   </tr>
   <tr>
     <td><code>static $cache = []</code> in user functions</td>

--- a/tests/Unit/AppConfigurablesTest.php
+++ b/tests/Unit/AppConfigurablesTest.php
@@ -468,7 +468,10 @@ class AppConfigurablesTest extends TestCase
         // superglobals=false → enable_coroutine=true by default.
         $this->assertTrue(App::enableCoroutine());
         App::superglobals(true);
-        $this->assertFalse(App::enableCoroutine());
+        // With ext-zealphp: superglobals(true) auto-enables coroutines (per-coroutine safe).
+        // Without ext-zealphp: superglobals(true) → coroutines off (race prevention).
+        $expected = \extension_loaded('zealphp') ? true : false;
+        $this->assertSame($expected, App::enableCoroutine());
         App::superglobals(false);
     }
 
@@ -495,7 +498,10 @@ class AppConfigurablesTest extends TestCase
         // superglobals=false → HOOK_ALL.
         $this->assertSame(\OpenSwoole\Runtime::HOOK_ALL, App::hookAll());
         App::superglobals(true);
-        $this->assertSame(0, App::hookAll());
+        // With ext-zealphp: superglobals(true) auto-enables HOOK_ALL (per-coroutine safe).
+        // Without ext-zealphp: superglobals(true) → hookAll=0 (race prevention).
+        $expected = \extension_loaded('zealphp') ? \OpenSwoole\Runtime::HOOK_ALL : 0;
+        $this->assertSame($expected, App::hookAll());
         App::superglobals(false);
     }
 

--- a/tests/Unit/LifecycleModesMatrixTest.php
+++ b/tests/Unit/LifecycleModesMatrixTest.php
@@ -170,11 +170,15 @@ final class LifecycleModesMatrixTest extends TestCase
 
         $this->assertTrue(App::$superglobals);
         $this->assertTrue(App::processIsolation(), 'pi null → follows sg=true → true');
-        $this->assertFalse(App::enableCoroutine(), 'ec null → follows !sg → false');
-        $this->assertSame(0, App::hookAll(), 'ha null → follows !sg → 0 (no hooks)');
+        $hasZealphp = \extension_loaded('zealphp');
+        // With ext-zealphp: coroutines + HOOK_ALL auto-enable (per-coroutine safe).
+        // Without: sequential mode (race prevention).
+        $this->assertSame($hasZealphp, App::enableCoroutine(), 'ec null → ext-zealphp aware');
+        $expectedHook = $hasZealphp ? \OpenSwoole\Runtime::HOOK_ALL : 0;
+        $this->assertSame($expectedHook, App::hookAll(), 'ha null → ext-zealphp aware');
 
         // Boot-time validator passes for this shape.
-        $this->assertNull($this->validate(true, 0, false), 'legacy CGI is supported');
+        $this->assertNull($this->validate(true, $expectedHook, $hasZealphp), 'legacy CGI is supported');
     }
 
     /**
@@ -230,10 +234,12 @@ final class LifecycleModesMatrixTest extends TestCase
 
         $this->assertTrue(App::$superglobals);
         $this->assertFalse(App::processIsolation(), 'pi=false — App::include() runs INLINE');
-        $this->assertFalse(App::enableCoroutine());
-        $this->assertSame(0, App::hookAll());
+        $hasZealphp = \extension_loaded('zealphp');
+        $this->assertSame($hasZealphp, App::enableCoroutine(), 'ec null → ext-zealphp aware');
+        $expectedHook = $hasZealphp ? \OpenSwoole\Runtime::HOOK_ALL : 0;
+        $this->assertSame($expectedHook, App::hookAll(), 'ha null → ext-zealphp aware');
 
-        $this->assertNull($this->validate(true, 0, false), 'mixed-mode is supported');
+        $this->assertNull($this->validate(true, $expectedHook, $hasZealphp), 'mixed-mode is supported');
     }
 
     /**


### PR DESCRIPTION
Coroutines page had pre-ext-zealphp framing: superglobals(true) = always sequential, $_GET breaks in coroutine mode, go() not supported. All stale with ext-zealphp.