### PR TITLE
docs: fix stale superglobal claims across routing + getting-started

### DIFF
--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -82,7 +82,7 @@
     <div class="callout warn">
       <strong>ZealPHP runs as a long-lived process.</strong> This changes the rules from PHP-FPM:
       <ul class="gs-risk-list">
-        <li class="gs-risk-item"><strong>Superglobals leak across visitors in coroutine mode</strong> — <code>$_GET</code> / <code>$_POST</code> / <code>$_SESSION</code> are process-wide PHP arrays. Under the default coroutine mode they're not populated per request, and writes are visible to every other request hitting the same worker. Always use <code>$g-&gt;get</code> / <code>$g-&gt;post</code> / <code>$g-&gt;session</code> via <a href="/coroutines#state-parity">RequestContext</a> — those are per-coroutine and safe in both modes. Also audit <code>static</code> variables for similar cross-request leaks.</li>
+        <li class="gs-risk-item"><strong>Use <code>$g-&gt;get</code> / <code>$g-&gt;session</code> (recommended)</strong> — works in every mode, no extension needed. With ext-zealphp, <code>$_GET</code> / <code>$_SESSION</code> are also per-coroutine safe (saved/restored on every yield/resume). Without ext-zealphp in coroutine mode, PHP superglobals are process-wide and would leak. See the <a href="/coroutines#state-parity">parity rule</a>. Also audit <code>static</code> variables for cross-request leaks.</li>
         <li class="gs-risk-item"><strong>Coroutine safety</strong> — references to <code>RequestContext::instance()</code> (a.k.a. <code>$g</code>) must not be held across <code>yield</code> points; each coroutine has its own context.</li>
         <li class="gs-risk-item"><strong>ext-zealphp function overrides are alpha</strong> — <code>session_start()</code>, <code>header()</code>, etc. are intercepted via <a href="https://github.com/sibidharan/zealphp/tree/master/ext/zealphp" target="_blank" rel="noopener">ext-zealphp</a> (our own extension). Edge cases exist; report them.</li>
         <li class="gs-risk-item"><strong>Memory growth</strong> — workers stay alive between requests; profile for leaks under sustained load.</li>
@@ -224,7 +224,7 @@ BASH
         <tr><th>LAMP</th><th>ZealPHP</th></tr>
         <tr><td>Apache / Nginx</td><td>OpenSwoole (built into <code>php app.php</code>)</td></tr>
         <tr><td><code>htdocs/about.php</code> → <code>/about.php</code></td><td><code>public/about.php</code> → <code>/about</code></td></tr>
-        <tr><td><code>$_GET</code>, <code>$_POST</code>, <code>$_SESSION</code></td><td>Use <code>$g->get</code> / <code>$g->post</code> / <code>$g->session</code> via <code>RequestContext::instance()</code> — works in both modes. PHP superglobals are only safe under <code>App::superglobals(true)</code>; coroutine mode does NOT populate them per request. See <a href="/coroutines#state-parity">the parity rule</a>.</td></tr>
+        <tr><td><code>$_GET</code>, <code>$_POST</code>, <code>$_SESSION</code></td><td>Use <code>$g->get</code> / <code>$g->post</code> / <code>$g->session</code> via <code>RequestContext::instance()</code> — works in both modes, no extension needed. With ext-zealphp, <code>$_GET</code>/<code>$_SESSION</code> are also per-coroutine safe in both modes. See <a href="/coroutines#state-parity">the parity rule</a>.</td></tr>
         <tr><td><code>session_start()</code>, <code>header()</code></td><td>Same — overridden via ext-zealphp; populates the per-coroutine <code>$g->session</code> in coroutine mode</td></tr>
         <tr><td>One process per request</td><td>One process, thousands of concurrent coroutines</td></tr>
         <tr><td>Restart Apache after config changes</td><td>Restart <code>php app.php</code> after code changes</td></tr>
@@ -258,7 +258,7 @@ PHP
 
     <div class="callout warn gs-mt-1">
       <strong>Two modes, one rule: <a href="/coroutines#state-parity">always use <code>$g->*</code></a>.</strong>
-      The default <code>app.php</code> runs in <strong>coroutine mode</strong> (<code>App::superglobals(false)</code>) — <code>$g-&gt;session</code> / <code>$g-&gt;get</code> / <code>$g-&gt;post</code> are the recommended accessors (per-coroutine, always safe). With ext-zealphp, <code>$_GET</code>/<code>$_SESSION</code> can also be made per-coroutine safe via <code>zealphp_coroutine_superglobals(true)</code>.
+      The default <code>app.php</code> runs in <strong>coroutine mode</strong> (<code>App::superglobals(false)</code>) — <code>$g-&gt;session</code> / <code>$g-&gt;get</code> / <code>$g-&gt;post</code> are the recommended accessors (per-coroutine, always safe). With ext-zealphp, <code>$_GET</code>/<code>$_SESSION</code> are automatically per-coroutine safe in both modes (saved/restored on every yield/resume).
       <br><br>
       If you're porting a legacy <code>.htaccess</code> + <code>$_*</code> codebase and want a quick lift, set <code>App::superglobals(true);</code> before <code>App::init()</code> — ZealPHP then bridges <code>$g-&gt;*</code> to the real PHP superglobals via <code>$GLOBALS</code> so legacy code keeps working. See the <a href="/legacy-apps">Legacy apps</a> page for the full migration matrix.
     </div>

--- a/template/pages/routing.php
+++ b/template/pages/routing.php
@@ -35,7 +35,7 @@ PHP
 ]); ?>
 
 <div class="callout info route-mt-1">
-<strong>This is the migration on-ramp.</strong> Drop your existing PHP files into <code>public/</code> and they run on OpenSwoole immediately — <code>session_start()</code>, <code>header()</code>, <code>echo</code> all work unchanged via ext-zealphp overrides. The example above uses <code>$g-&gt;session</code> / <code>$g-&gt;get</code> via <code>RequestContext::instance()</code> — the per-coroutine-safe form that works in both modes. <strong>Direct <code>$_SESSION</code> / <code>$_GET</code> access</strong> only works under <code>App::superglobals(true)</code>; in the default coroutine mode it would silently leak across visitors because PHP superglobals are process-wide. See the <a href="/coroutines#state-parity"><code>$g</code> vs <code>$_*</code> parity rule</a> and the <a href="/migration">migration ladder</a>.
+<strong>This is the migration on-ramp.</strong> Drop your existing PHP files into <code>public/</code> and they run on OpenSwoole immediately — <code>session_start()</code>, <code>header()</code>, <code>echo</code> all work unchanged via ext-zealphp overrides. The recommended form is <code>$g-&gt;session</code> / <code>$g-&gt;get</code> via <code>RequestContext::instance()</code> — works in both modes, no extension needed. With ext-zealphp, <code>$_GET</code> / <code>$_SESSION</code> are also per-coroutine safe in both modes (saved/restored on every yield/resume). See the <a href="/coroutines#state-parity"><code>$g</code> vs <code>$_*</code> parity rule</a> and the <a href="/migration">migration ladder</a>.
 </div>
 
 <p class="route-my-1">Same convention works for APIs — drop files in <code>api/</code>:</p>


### PR DESCRIPTION
Part of the ext-zealphp docs sweep. routing.php and getting-started.php had pre-v0.3.0 claims that $_GET only works in superglobals(true) mode. With ext-zealphp, superglobals are per-coroutine safe in both modes.