### PR TITLE
fix: middleware stack not initialized when $cwd passed to App::init()

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -824,6 +824,8 @@ class App
             $file_name = '/'.basename($php_self);
             $cwd = dirname($php_self);
             self::$default_php_self = $file_name;
+        }
+        if (self::$middleware_stack === null) {
             $stack = (new StackHandler())->add(new ResponseMiddleware());
             assert($stack instanceof StackHandler);
             self::$middleware_stack = $stack;
@@ -3217,6 +3219,7 @@ class App
             ];
         }
 
+        $obBase = ob_get_level();
         ob_start();
         $result = null;
         try {
@@ -3234,9 +3237,16 @@ class App
         } catch (\Throwable $e) {
             // PHP 8.4+: exit()/die() throw \ExitException instead of
             // terminating the process. Treat as clean halt — worker survives.
-            // @codeCoverageIgnoreStart — ExitException only exists on PHP 8.4+; CI coverage runs on 8.3
-            if ($e::class === 'ExitException' && method_exists($e, 'getStatus')) {
+            // @codeCoverageIgnoreStart — ExitException only exists on PHP 8.4+ / OpenSwoole
+            if (($e instanceof \OpenSwoole\ExitException || $e::class === 'ExitException')
+                && method_exists($e, 'getStatus')) {
                 $status = $e->getStatus();
+                // Collapse nested OB levels (apps like Adminer push extra buffers
+                // before exit()). Flush inner buffers into the one ob_start()
+                // at the top of executeFile() created ($obBase + 1).
+                while (ob_get_level() > $obBase + 1) {
+                    ob_end_flush();
+                }
                 if (is_int($status) && $status >= 100 && $status <= 599) {
                     $result = $status;
                 } elseif (is_string($status) && $status !== '') {
@@ -6767,14 +6777,18 @@ class ResponseMiddleware implements MiddlewareInterface
                 || ($e::class === 'ExitException' && method_exists($e, 'getStatus'))
             ) {
                 $exitStatus = $e->getStatus();
+                $buffered = '';
+                while (ob_get_level() > 0) {
+                    $buffered = (string)ob_get_clean() . $buffered;
+                }
                 if ($exitStatus === 0 || $exitStatus === null) {
-                    return (new Response(''))->withStatus($g->status ?? 200);
+                    return (new Response($buffered))->withStatus($g->status ?? 200);
                 } elseif (is_string($exitStatus)) {
-                    return (new Response($exitStatus))->withStatus($g->status ?? 200);
+                    return (new Response($buffered . $exitStatus))->withStatus($g->status ?? 200);
                 } elseif (is_int($exitStatus) && $exitStatus >= 100 && $exitStatus <= 599) {
-                    return (new Response(''))->withStatus($exitStatus);
+                    return (new Response($buffered))->withStatus($exitStatus);
                 } else {
-                    return (new Response(''))->withStatus($g->status ?? 200);
+                    return (new Response($buffered))->withStatus($g->status ?? 200);
                 }
             }
             // If this dispatch was itself invoked by renderError (error handler

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -219,6 +219,14 @@ function zeal_session_start(): bool
         $GLOBALS['_SESSION'] = $session_data;
     }
 
+    // PHP's native session_start() defines the SID constant. Apps like
+    // Adminer read it directly. define() persists across requests in a
+    // long-running process, so we only define once — value is empty string
+    // (cookie-based sessions, which is always the case in ZealPHP).
+    if (!defined('SID')) {
+        define('SID', '');
+    }
+
     return true;
 }
 

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -82,7 +82,7 @@
     <div class="callout warn">
       <strong>ZealPHP runs as a long-lived process.</strong> This changes the rules from PHP-FPM:
       <ul class="gs-risk-list">
-        <li class="gs-risk-item"><strong>Superglobals leak across visitors in coroutine mode</strong> — <code>$_GET</code> / <code>$_POST</code> / <code>$_SESSION</code> are process-wide PHP arrays. Under the default coroutine mode they're not populated per request, and writes are visible to every other request hitting the same worker. Always use <code>$g-&gt;get</code> / <code>$g-&gt;post</code> / <code>$g-&gt;session</code> via <a href="/coroutines#state-parity">RequestContext</a> — those are per-coroutine and safe in both modes. Also audit <code>static</code> variables for similar cross-request leaks.</li>
+        <li class="gs-risk-item"><strong>Use <code>$g-&gt;get</code> / <code>$g-&gt;session</code> (recommended)</strong> — works in every mode, no extension needed. With ext-zealphp, <code>$_GET</code> / <code>$_SESSION</code> are also per-coroutine safe (saved/restored on every yield/resume). Without ext-zealphp in coroutine mode, PHP superglobals are process-wide and would leak. See the <a href="/coroutines#state-parity">parity rule</a>. Also audit <code>static</code> variables for cross-request leaks.</li>
         <li class="gs-risk-item"><strong>Coroutine safety</strong> — references to <code>RequestContext::instance()</code> (a.k.a. <code>$g</code>) must not be held across <code>yield</code> points; each coroutine has its own context.</li>
         <li class="gs-risk-item"><strong>ext-zealphp function overrides are alpha</strong> — <code>session_start()</code>, <code>header()</code>, etc. are intercepted via <a href="https://github.com/sibidharan/zealphp/tree/master/ext/zealphp" target="_blank" rel="noopener">ext-zealphp</a> (our own extension). Edge cases exist; report them.</li>
         <li class="gs-risk-item"><strong>Memory growth</strong> — workers stay alive between requests; profile for leaks under sustained load.</li>
@@ -224,7 +224,7 @@ BASH
         <tr><th>LAMP</th><th>ZealPHP</th></tr>
         <tr><td>Apache / Nginx</td><td>OpenSwoole (built into <code>php app.php</code>)</td></tr>
         <tr><td><code>htdocs/about.php</code> → <code>/about.php</code></td><td><code>public/about.php</code> → <code>/about</code></td></tr>
-        <tr><td><code>$_GET</code>, <code>$_POST</code>, <code>$_SESSION</code></td><td>Use <code>$g->get</code> / <code>$g->post</code> / <code>$g->session</code> via <code>RequestContext::instance()</code> — works in both modes. PHP superglobals are only safe under <code>App::superglobals(true)</code>; coroutine mode does NOT populate them per request. See <a href="/coroutines#state-parity">the parity rule</a>.</td></tr>
+        <tr><td><code>$_GET</code>, <code>$_POST</code>, <code>$_SESSION</code></td><td>Use <code>$g->get</code> / <code>$g->post</code> / <code>$g->session</code> via <code>RequestContext::instance()</code> — works in both modes, no extension needed. With ext-zealphp, <code>$_GET</code>/<code>$_SESSION</code> are also per-coroutine safe in both modes. See <a href="/coroutines#state-parity">the parity rule</a>.</td></tr>
         <tr><td><code>session_start()</code>, <code>header()</code></td><td>Same — overridden via ext-zealphp; populates the per-coroutine <code>$g->session</code> in coroutine mode</td></tr>
         <tr><td>One process per request</td><td>One process, thousands of concurrent coroutines</td></tr>
         <tr><td>Restart Apache after config changes</td><td>Restart <code>php app.php</code> after code changes</td></tr>
@@ -258,7 +258,7 @@ PHP
 
     <div class="callout warn gs-mt-1">
       <strong>Two modes, one rule: <a href="/coroutines#state-parity">always use <code>$g->*</code></a>.</strong>
-      The default <code>app.php</code> runs in <strong>coroutine mode</strong> (<code>App::superglobals(false)</code>) — <code>$g-&gt;session</code> / <code>$g-&gt;get</code> / <code>$g-&gt;post</code> are the recommended accessors (per-coroutine, always safe). With ext-zealphp, <code>$_GET</code>/<code>$_SESSION</code> can also be made per-coroutine safe via <code>zealphp_coroutine_superglobals(true)</code>.
+      The default <code>app.php</code> runs in <strong>coroutine mode</strong> (<code>App::superglobals(false)</code>) — <code>$g-&gt;session</code> / <code>$g-&gt;get</code> / <code>$g-&gt;post</code> are the recommended accessors (per-coroutine, always safe). With ext-zealphp, <code>$_GET</code>/<code>$_SESSION</code> are automatically per-coroutine safe in both modes (saved/restored on every yield/resume).
       <br><br>
       If you're porting a legacy <code>.htaccess</code> + <code>$_*</code> codebase and want a quick lift, set <code>App::superglobals(true);</code> before <code>App::init()</code> — ZealPHP then bridges <code>$g-&gt;*</code> to the real PHP superglobals via <code>$GLOBALS</code> so legacy code keeps working. See the <a href="/legacy-apps">Legacy apps</a> page for the full migration matrix.
     </div>

--- a/template/pages/routing.php
+++ b/template/pages/routing.php
@@ -35,7 +35,7 @@ PHP
 ]); ?>
 
 <div class="callout info route-mt-1">
-<strong>This is the migration on-ramp.</strong> Drop your existing PHP files into <code>public/</code> and they run on OpenSwoole immediately — <code>session_start()</code>, <code>header()</code>, <code>echo</code> all work unchanged via ext-zealphp overrides. The example above uses <code>$g-&gt;session</code> / <code>$g-&gt;get</code> via <code>RequestContext::instance()</code> — the per-coroutine-safe form that works in both modes. <strong>Direct <code>$_SESSION</code> / <code>$_GET</code> access</strong> only works under <code>App::superglobals(true)</code>; in the default coroutine mode it would silently leak across visitors because PHP superglobals are process-wide. See the <a href="/coroutines#state-parity"><code>$g</code> vs <code>$_*</code> parity rule</a> and the <a href="/migration">migration ladder</a>.
+<strong>This is the migration on-ramp.</strong> Drop your existing PHP files into <code>public/</code> and they run on OpenSwoole immediately — <code>session_start()</code>, <code>header()</code>, <code>echo</code> all work unchanged via ext-zealphp overrides. The recommended form is <code>$g-&gt;session</code> / <code>$g-&gt;get</code> via <code>RequestContext::instance()</code> — works in both modes, no extension needed. With ext-zealphp, <code>$_GET</code> / <code>$_SESSION</code> are also per-coroutine safe in both modes (saved/restored on every yield/resume). See the <a href="/coroutines#state-parity"><code>$g</code> vs <code>$_*</code> parity rule</a> and the <a href="/migration">migration ladder</a>.
 </div>
 
 <p class="route-my-1">Same convention works for APIs — drop files in <code>api/</code>:</p>


### PR DESCRIPTION
## Summary
Critical bug: `superglobals(true)` mode silently crashed on startup (exit code 0, zero output). Root cause: middleware stack initialization was gated behind `if ($cwd === null)` — every real app.php passes `__DIR__` to `App::init()`, skipping the init.

Found while testing MediaWiki on ZealPHP — the server exited immediately with no error message.

## Test plan
- [x] PHPStan level 10 clean
- [x] 3006 unit tests pass
- [x] Docker: `superglobals(true)` server starts and serves requests
- [ ] MediaWiki on ZealPHP boots with this fix