### PR TITLE
fix: remove auto-wired define() isolation (breaks require_once apps)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -5961,15 +5961,14 @@ HELP;
             (\zealphp_coroutine_superglobals(...))((bool) true);
         }
 
-        // Per-request define() isolation: intercept define() so constants
-        // created during a request are tracked and removed on request end.
-        // CoSessionManager/SessionManager calls zealphp_constants_clear()
-        // in their finally blocks. Boot-time constants (from autoloaders,
-        // framework init) are defined BEFORE this hook activates, so they
-        // survive untouched.
-        if (\extension_loaded('zealphp') && \function_exists('zealphp_define_hook')) {
-            (\zealphp_define_hook(...))((bool) true);
-        }
+        // Per-request define() / $GLOBALS / process-state isolation are
+        // available via ext-zealphp but NOT auto-activated. Any app using
+        // require_once for files that call define() (virtually all PHP apps)
+        // would break on request 2: require_once is a no-op, so cleaned
+        // constants are never re-defined. These primitives are for:
+        //   - The CGI pool worker (fresh process state per iteration)
+        //   - Apps that explicitly manage their own lifecycle
+        // Use processIsolation(true) for define()-heavy legacy apps.
         // @codeCoverageIgnoreEnd
 
         // Transparent coroutine-safe exec family. Overriding `shell_exec` ALSO

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -137,9 +137,6 @@ class CoSessionManager
             }
             $g->session = [];
             unset($g->session);
-            if (\function_exists('zealphp_constants_clear')) {
-                (\zealphp_constants_clear(...))();
-            }
         }
     }
 }

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -209,9 +209,6 @@ class SessionManager
                 $_SESSION = [];
                 unset($_SESSION);
             }
-            if (\function_exists('zealphp_constants_clear')) {
-                (\zealphp_constants_clear(...))();
-            }
         }
     }
 }


### PR DESCRIPTION
Reverts auto-activation of zealphp_define_hook + zealphp_constants_clear. These break any app using require_once + define() (virtually all PHP). Primitives stay available for explicit use.