### PR TITLE
fix: revert auto-enable coroutines for superglobals(true) + remove constants_clear auto-wiring

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1559,11 +1559,11 @@ class App
         if (self::$enable_coroutine_override !== null) {
             return self::$enable_coroutine_override;
         }
-        // With ext-zealphp, superglobals(true) can safely run coroutines
-        // (per-coroutine save/restore). Default to coroutines ON.
-        if (self::$superglobals && \extension_loaded('zealphp')) {
-            return true;
-        }
+        // superglobals(true) defaults to coroutines OFF — SessionManager
+        // uses native session_set_save_handler() which is not coroutine-safe.
+        // ext-zealphp makes $_GET/$_SESSION per-coroutine safe, but the
+        // session lifecycle integration needs work before auto-enabling.
+        // Users can explicitly set App::enableCoroutine(true) to opt in.
         return !self::$superglobals;
     }
 
@@ -1598,11 +1598,6 @@ class App
         }
         $v = self::$hook_all_override;
         if ($v === null) {
-            // With ext-zealphp, superglobals(true) safely supports coroutines
-            // (per-coroutine save/restore), so HOOK_ALL is safe too.
-            if (self::$superglobals && \extension_loaded('zealphp')) {
-                return \OpenSwoole\Runtime::HOOK_ALL;
-            }
             return self::$superglobals ? 0 : \OpenSwoole\Runtime::HOOK_ALL;
         }
         if ($v === true)  return \OpenSwoole\Runtime::HOOK_ALL;

--- a/tests/Unit/AppConfigurablesTest.php
+++ b/tests/Unit/AppConfigurablesTest.php
@@ -468,10 +468,7 @@ class AppConfigurablesTest extends TestCase
         // superglobals=false → enable_coroutine=true by default.
         $this->assertTrue(App::enableCoroutine());
         App::superglobals(true);
-        // With ext-zealphp: superglobals(true) auto-enables coroutines (per-coroutine safe).
-        // Without ext-zealphp: superglobals(true) → coroutines off (race prevention).
-        $expected = \extension_loaded('zealphp') ? true : false;
-        $this->assertSame($expected, App::enableCoroutine());
+        $this->assertFalse(App::enableCoroutine());
         App::superglobals(false);
     }
 
@@ -498,10 +495,7 @@ class AppConfigurablesTest extends TestCase
         // superglobals=false → HOOK_ALL.
         $this->assertSame(\OpenSwoole\Runtime::HOOK_ALL, App::hookAll());
         App::superglobals(true);
-        // With ext-zealphp: superglobals(true) auto-enables HOOK_ALL (per-coroutine safe).
-        // Without ext-zealphp: superglobals(true) → hookAll=0 (race prevention).
-        $expected = \extension_loaded('zealphp') ? \OpenSwoole\Runtime::HOOK_ALL : 0;
-        $this->assertSame($expected, App::hookAll());
+        $this->assertSame(0, App::hookAll());
         App::superglobals(false);
     }
 

--- a/tests/Unit/LifecycleModesMatrixTest.php
+++ b/tests/Unit/LifecycleModesMatrixTest.php
@@ -170,15 +170,11 @@ final class LifecycleModesMatrixTest extends TestCase
 
         $this->assertTrue(App::$superglobals);
         $this->assertTrue(App::processIsolation(), 'pi null → follows sg=true → true');
-        $hasZealphp = \extension_loaded('zealphp');
-        // With ext-zealphp: coroutines + HOOK_ALL auto-enable (per-coroutine safe).
-        // Without: sequential mode (race prevention).
-        $this->assertSame($hasZealphp, App::enableCoroutine(), 'ec null → ext-zealphp aware');
-        $expectedHook = $hasZealphp ? \OpenSwoole\Runtime::HOOK_ALL : 0;
-        $this->assertSame($expectedHook, App::hookAll(), 'ha null → ext-zealphp aware');
+        $this->assertFalse(App::enableCoroutine(), 'ec null → follows !sg → false');
+        $this->assertSame(0, App::hookAll(), 'ha null → follows !sg → 0 (no hooks)');
 
         // Boot-time validator passes for this shape.
-        $this->assertNull($this->validate(true, $expectedHook, $hasZealphp), 'legacy CGI is supported');
+        $this->assertNull($this->validate(true, 0, false), 'legacy CGI is supported');
     }
 
     /**
@@ -234,12 +230,10 @@ final class LifecycleModesMatrixTest extends TestCase
 
         $this->assertTrue(App::$superglobals);
         $this->assertFalse(App::processIsolation(), 'pi=false — App::include() runs INLINE');
-        $hasZealphp = \extension_loaded('zealphp');
-        $this->assertSame($hasZealphp, App::enableCoroutine(), 'ec null → ext-zealphp aware');
-        $expectedHook = $hasZealphp ? \OpenSwoole\Runtime::HOOK_ALL : 0;
-        $this->assertSame($expectedHook, App::hookAll(), 'ha null → ext-zealphp aware');
+        $this->assertFalse(App::enableCoroutine());
+        $this->assertSame(0, App::hookAll());
 
-        $this->assertNull($this->validate(true, $expectedHook, $hasZealphp), 'mixed-mode is supported');
+        $this->assertNull($this->validate(true, 0, false), 'mixed-mode is supported');
     }
 
     /**


### PR DESCRIPTION
## Summary
Reverts two premature auto-activations:

1. **enableCoroutine/hookAll auto-ON with ext-zealphp** — SessionManager uses native
   session_set_save_handler() which is not coroutine-safe. Issue #134 confirmed
   worker crashes under concurrent load. superglobals(true) stays sequential by default;
   users opt in explicitly via App::enableCoroutine(true).

2. **zealphp_define_hook/zealphp_constants_clear auto-wiring** — breaks any app using
   require_once + define() (virtually all PHP apps). Removed from App::run() and both
   SessionManagers. The ext-zealphp primitives remain available for explicit use by
   pool workers and apps that manage their own lifecycle.

Closes #134