### PR TITLE
fix: use CoSessionManager when coroutines enabled (#134, #139)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -6286,7 +6286,14 @@ HELP;
             });
         }
 
-        $SessionManager = self::$superglobals ?  'ZealPHP\Session\SessionManager' : 'ZealPHP\Session\CoSessionManager';
+        // When coroutines are enabled, always use CoSessionManager — it uses
+        // per-coroutine RequestContext and overridden zeal_session_start(),
+        // both coroutine-safe. SessionManager uses PHP's native session_start()
+        // + session_set_save_handler() which race under concurrent coroutines.
+        // sg(true)+ec(true) with ext-zealphp needs CoSessionManager (#134).
+        $SessionManager = ($enableCoroutine || !self::$superglobals)
+            ? 'ZealPHP\Session\CoSessionManager'
+            : 'ZealPHP\Session\SessionManager';
 
         assert(self::$middleware_stack !== null);
         foreach (array_reverse(self::$middleware_wait_stack) as $middleware) {


### PR DESCRIPTION
## Summary
- **#134**: sg(true)+ec(true) crashes workers under concurrent load because
  SessionManager uses native session_start() which isn't coroutine-safe.
  Fix: use CoSessionManager whenever enableCoroutine=true, regardless of
  superglobals setting. CoSessionManager uses per-coroutine RequestContext.

- **#139**: Mode 6 (sg(false)+pi(true)) _contract/co-state fixture fails
  because the subprocess doesn't share parent coroutine context. This is
  expected behavior — processIsolation dispatches to a separate process.
  Documented, not a framework bug.

## Test plan
- [x] PHPStan level 10 clean
- [x] 3007 unit tests pass

Closes #134