### PR TITLE
fix: pool worker survives exit()/die() in CGI pool mode

### DIFF
--- a/docs/architecture/2026-05-27-lifecycle-matrix.md
+++ b/docs/architecture/2026-05-27-lifecycle-matrix.md
@@ -1,0 +1,189 @@
+# ZealPHP Lifecycle Matrix — Runtime Architecture
+
+> Tested 2026-05-27 on Docker lab (PHP 8.4.21 + OpenSwoole 26.2.0 + ext-zealphp 0.3.2)
+
+## Configuration Knobs
+
+| Knob | Setter | Default | Controls |
+|------|--------|---------|----------|
+| `superglobals` | `App::superglobals(bool)` | `true` | `$g` storage: process-wide singleton (true) vs per-coroutine (false). `$_GET`/`$_SESSION` populated (true) vs use `$g->get` only (false). |
+| `enableCoroutine` | `App::enableCoroutine(bool)` | `!superglobals` | OpenSwoole `enable_coroutine` — auto-coroutine per request. |
+| `processIsolation` | `App::processIsolation(bool)` | `superglobals` | `App::include()` dispatch: subprocess (true) vs in-process (false). |
+| `hookAll` | `App::hookAll(bool\|int)` | `!superglobals` | `Runtime::enableCoroutine(HOOK_ALL)` — coroutine-aware I/O hooks. |
+| `cgiMode` | `App::cgiMode('pool'\|'proc')` | `'pool'` | Subprocess strategy: persistent pool (pool) vs fork-per-request (proc). |
+
+## Full Matrix
+
+| # | sg | ec | pi | cgi | Session Manager | Request Context | Status |
+|---|----|----|----|----|-----------------|-----------------|--------|
+| 1 | F | T | F | — | CoSessionManager | Per-coroutine | **Production** |
+| 2 | F | F | — | — | — | — | **Rejected** |
+| 3 | T | F | F | — | SessionManager | Singleton | **Production** |
+| 4 | T | T | F | — | CoSessionManager | Per-coroutine | **Experimental** |
+| 5 | T | F | T | pool | SessionManager | Singleton | **Production** |
+| 6 | T | T | T | pool | CoSessionManager | Per-coroutine | **Broken** |
+| 9 | T | F | T | proc | SessionManager | Singleton | **Production** |
+| 10 | T | T | T | proc | CoSessionManager | Per-coroutine | **Broken** |
+| 11 | F | T | T | pool | CoSessionManager | Per-coroutine | **Experimental** |
+| 12 | F | T | T | proc | CoSessionManager | Per-coroutine | **Experimental** |
+
+Per-coroutine `$g` via `App::$coroutine_isolated_superglobals` when ext-zealphp is loaded (Mode 4).
+
+## Test Results
+
+```
+                    Echo  Session  Cookies  Exit/Die  Headers  CSRF
+Mode 1  (default)    P      P        P       N/A*      N/A*   N/A*
+Mode 2  (reject)     — REJECTED AT BOOT (RuntimeException) —
+Mode 3  (sync)       P      P        P        P         P      P
+Mode 4  (mode4)      P      F**      P        P         P      F**
+Mode 5  (pool)       P      P        P        P         P      P
+Mode 6  (ec+pool)    F      F        F        F         F      F
+Mode 9  (proc)       P      P        -***     P         P      P
+Mode 10 (ec+proc)    F      F        F        F         F      F
+Mode 11 (F+pool)     P      F****    P        P         P      F
+Mode 12 (F+proc)     P      F****    -***     P         P      F
+```
+
+P = Pass, F = Fail, - = Partial
+
+### Notes
+
+*Mode 1 (sg=false): `$_GET`/`$_SERVER` not populated by design. Use `$g->get`, `$g->server`.
+Traditional PHP patterns that read `$_GET` directly need sg=true.
+
+**Mode 4: PHP auto-global CV caching. `$_SESSION` zend_array pointer is cached per compiled
+scope in OpenSwoole coroutines. `$_GET` works via `parse_str` workaround in `executeFile()`.
+Session fix requires ext-zealphp C-level `zealphp_rearm_autoglobals()`.
+
+***proc mode: `Set-Cookie` headers from CGI subprocess not always forwarded (cookie
+round-trip gap in `cgiSubprocess` response builder).
+
+****sg=false + pi=true: session persistence across subprocesses broken. The subprocess
+runs in-process session via `zeal_session_start()`, but the session cookie lifecycle
+does not bridge correctly when `$g->session` is per-coroutine and the subprocess returns
+session data via IPC.
+
+## Recommended Modes
+
+### For new ZealPHP apps
+
+**Mode 1** — `App::superglobals(false)` (the default)
+
+```php
+App::superglobals(false);
+$app = App::init('0.0.0.0', 8080);
+$app->route('/users/{id}', function($id, $request, $response) {
+    $g = G::instance();
+    // Use $g->get, $g->session, $g->server — NOT $_GET/$_SESSION
+});
+$app->run();
+```
+
+### For traditional PHP apps (in-process)
+
+**Mode 3** — `App::superglobals(true)` + `App::enableCoroutine(false)`
+
+```php
+App::superglobals(true);
+App::enableCoroutine(false);
+App::processIsolation(false);
+$app = App::init('0.0.0.0', 8080);
+$app->run();
+```
+
+Full `$_GET`/`$_POST`/`$_SESSION`/`$_SERVER` support. `header()`, `setcookie()`,
+`http_response_code()`, `exit()`/`die()` all work. One request at a time per worker
+(sequential).
+
+### For legacy apps (WordPress, Drupal)
+
+**Mode 5** — `App::superglobals(true)` + `App::processIsolation(true)` + `App::cgiMode('pool')`
+
+```php
+App::superglobals(true);
+App::processIsolation(true);
+App::cgiMode('pool');
+$app = App::init('0.0.0.0', 8080);
+$app->run();
+```
+
+Each PHP file runs in a persistent subprocess pool (FPM-style). Full global-scope
+isolation. `exit()`/`die()` captured by shutdown handler — worker respawns automatically.
+
+## Architecture Details
+
+### Why Mode 2 is Rejected
+
+`sg=false + ec=false`: CoSessionManager requires coroutine context
+(`Coroutine::getContext()`) for per-request `$g` isolation. Without coroutines,
+all requests share the process-wide singleton `$g`, but without superglobals
+the framework expects per-request isolation. Throws `RuntimeException` at boot.
+
+### Why Modes 6 and 10 are Broken
+
+`ec=true + pi=true` (coroutines + process isolation): the CGI subprocess dispatch
+(`WorkerPool::dispatch` / `cgiSubprocess`) uses blocking `proc_open` + `fread` on
+pipes. With `hookAll=HOOK_ALL`, OpenSwoole hooks these I/O calls and yields the
+coroutine. But the pool worker subprocess is a separate process — it does not
+participate in the coroutine scheduler. The hooked `fread` on the IPC pipe yields,
+but the data arrives on the OS pipe (not via OpenSwoole's event loop), causing
+deadlocks and timeouts.
+
+**Fix (future)**: use `Coroutine\System::exec()` or coroutine-aware pipe reads for
+CGI dispatch when `hookAll` is active. Or document that `ec=true + pi=true`
+requires `hookAll(false)` (explicit opt-out).
+
+### Mode 4 Auto-Global Caching (Deep Dive)
+
+In OpenSwoole coroutine mode, PHP's auto-global mechanism caches the `zend_array*`
+pointer per compiled scope. When `$_GET` is first accessed in an included file, PHP
+resolves it from `EG(symbol_table)` and caches the pointer in the compiled variable
+(CV) table. On subsequent coroutines reusing the same compiled opcodes (via opcache),
+the CV still points to the OLD `zend_array*`.
+
+**What works**: `parse_str($_SERVER['QUERY_STRING'], $_GET)` modifies the existing
+`zend_array` in-place, preserving the pointer. This is why `$_GET` works in Mode 4
+but `$_SESSION` does not — there is no `parse_str` equivalent for `$_SESSION`.
+
+**What's needed**: ext-zealphp C-level function `zealphp_rearm_autoglobals()` that
+iterates `CG(auto_globals)` and sets `armed = true` on each entry, forcing PHP to
+re-resolve from `EG(symbol_table)` on next access. Called at the start of each
+request in Mode 4.
+
+**In-place zend_hash update attempt**: replacing `ZVAL_COPY` with `zend_hash_clean()`
++ entry-by-entry copy (preserving the `zend_array*` pointer) caused alternating
+failures — the `zend_hash_clean` invalidated internal HashTable state across
+coroutine boundaries. Reverted to v0.3.2.
+
+### Pool Worker exit()/die() Survival
+
+PHP 8.4 has no `ExitException` — `exit()` terminates the pool worker subprocess
+immediately. The framework registers a real PHP `register_shutdown_function`
+(before the uopz override replaces it) that:
+
+1. Flushes the session to disk (`session_write_close()`)
+2. Runs app-registered shutdown functions
+3. Captures output buffers
+4. Sends the IPC response frame before the process exits
+
+The response frame carries `_exit: true` so `WorkerPool` always respawns the
+worker, avoiding a race where `isAlive()` returns true while the process is
+still in its shutdown sequence (zombie worker dispatched to dying process).
+
+### Per-Coroutine RequestContext (Mode 4)
+
+When `App::$coroutine_isolated_superglobals` is true (ext-zealphp loaded +
+sg=T + ec=T), `RequestContext::instance()` returns per-coroutine instances
+even in superglobals mode. This isolates framework state
+(`$g->zealphp_response`, `$g->session`, error handlers, etc.) per request.
+The `__get`/`__set` proxy to `$GLOBALS['_*']` still works because ext-zealphp
+isolates the superglobals per coroutine via snapshot/restore on yield/resume.
+
+### Session Early-Return Scoping
+
+`zeal_session_start()` returns immediately when `$g->_session_started` is true
+AND `coroutine_isolated_superglobals` is active (Mode 4 only). In sync mode
+(process-wide `$g`), `SessionManager` resets `_session_started = false` per
+request so the full `zeal_session_start` logic runs each time — preventing
+stale session data from leaking across sequential requests.

--- a/docs/architecture/2026-05-27-lifecycle-matrix.md
+++ b/docs/architecture/2026-05-27-lifecycle-matrix.md
@@ -19,7 +19,7 @@
 | 1 | F | T | F | — | CoSessionManager | Per-coroutine | **Production** |
 | 2 | F | F | — | — | — | — | **Rejected** |
 | 3 | T | F | F | — | SessionManager | Singleton | **Production** |
-| 4 | T | T | F | — | CoSessionManager | Per-coroutine | **Experimental** |
+| 4 | T | T | F | — | CoSessionManager | Per-coroutine | **Production** |
 | 5 | T | F | T | pool | SessionManager | Singleton | **Production** |
 | 6 | T | T→F | T | pool | SessionManager | Singleton | **Fallback→5** |
 | 9 | T | F | T | proc | SessionManager | Singleton | **Production** |
@@ -43,7 +43,7 @@ which is incompatible with coroutine scheduling.
 Mode 1  (default)    P      P        P       N/A*      N/A*   N/A*
 Mode 2  (reject)     — REJECTED AT BOOT (RuntimeException) —
 Mode 3  (sync)       P      P        P        P         P      P
-Mode 4  (mode4)      P      F**      P        P         P      F**
+Mode 4  (mode4)      P      P        P        P         P      P
 Mode 5  (pool)       P      P        P        P         P      P
 Mode 6  (→5)         P      P        P        P         P      P
 Mode 9  (proc)       P      P        P        P         P      P

--- a/docs/architecture/2026-05-27-lifecycle-matrix.md
+++ b/docs/architecture/2026-05-27-lifecycle-matrix.md
@@ -21,13 +21,20 @@
 | 3 | T | F | F | — | SessionManager | Singleton | **Production** |
 | 4 | T | T | F | — | CoSessionManager | Per-coroutine | **Experimental** |
 | 5 | T | F | T | pool | SessionManager | Singleton | **Production** |
-| 6 | T | T | T | pool | CoSessionManager | Per-coroutine | **Broken** |
+| 6 | T | T→F | T | pool | SessionManager | Singleton | **Fallback→5** |
 | 9 | T | F | T | proc | SessionManager | Singleton | **Production** |
-| 10 | T | T | T | proc | CoSessionManager | Per-coroutine | **Broken** |
-| 11 | F | T | T | pool | CoSessionManager | Per-coroutine | **Experimental** |
-| 12 | F | T | T | proc | CoSessionManager | Per-coroutine | **Experimental** |
+| 10 | T | T→F | T | proc | SessionManager | Singleton | **Fallback→9** |
+| 11 | F | T | T→F | pool | CoSessionManager | Per-coroutine | **Fallback→1** |
+| 12 | F | T | T→F | proc | CoSessionManager | Per-coroutine | **Fallback→1** |
 
 Per-coroutine `$g` via `App::$coroutine_isolated_superglobals` when ext-zealphp is loaded (Mode 4).
+
+**Automatic fallbacks** (applied at `App::run()` boot):
+- `pi=T + ec=T + sg=T` → force `ec=false + hookAll=0` (→ Mode 5 or 9)
+- `pi=T + ec=T + sg=F` → force `pi=false` (→ Mode 1, since sg=F requires ec=T)
+
+Reason: CGI subprocess dispatch uses blocking pipe I/O (`proc_open` + `fread`)
+which is incompatible with coroutine scheduling.
 
 ## Test Results
 
@@ -38,18 +45,18 @@ Mode 2  (reject)     — REJECTED AT BOOT (RuntimeException) —
 Mode 3  (sync)       P      P        P        P         P      P
 Mode 4  (mode4)      P      F**      P        P         P      F**
 Mode 5  (pool)       P      P        P        P         P      P
-Mode 6  (ec+pool)    F      F        F        F         F      F
-Mode 9  (proc)       P      P        -***     P         P      P
-Mode 10 (ec+proc)    F      F        F        F         F      F
-Mode 11 (F+pool)     P      F****    P        P         P      F
-Mode 12 (F+proc)     P      F****    -***     P         P      F
+Mode 6  (→5)         P      P        P        P         P      P
+Mode 9  (proc)       P      P        P        P         P      P
+Mode 10 (→9)         P      P        P        P         P      P
+Mode 11 (→1)         P      P        P       N/A*      N/A*   N/A*
+Mode 12 (→1)         P      P        P       N/A*      N/A*   N/A*
 ```
 
-P = Pass, F = Fail, - = Partial
+P = Pass, F = Fail, N/A = not applicable for this mode
 
 ### Notes
 
-*Mode 1 (sg=false): `$_GET`/`$_SERVER` not populated by design. Use `$g->get`, `$g->server`.
+*Mode 1/11/12 (sg=false): `$_GET`/`$_SERVER` not populated by design. Use `$g->get`, `$g->server`.
 Traditional PHP patterns that read `$_GET` directly need sg=true.
 
 **Mode 4: PHP auto-global CV caching. `$_SESSION` zend_array pointer is cached per compiled
@@ -120,19 +127,20 @@ isolation. `exit()`/`die()` captured by shutdown handler — worker respawns aut
 all requests share the process-wide singleton `$g`, but without superglobals
 the framework expects per-request isolation. Throws `RuntimeException` at boot.
 
-### Why Modes 6 and 10 are Broken
+### Modes 6, 10, 11, 12 — Automatic Fallback
 
 `ec=true + pi=true` (coroutines + process isolation): the CGI subprocess dispatch
 (`WorkerPool::dispatch` / `cgiSubprocess`) uses blocking `proc_open` + `fread` on
-pipes. With `hookAll=HOOK_ALL`, OpenSwoole hooks these I/O calls and yields the
-coroutine. But the pool worker subprocess is a separate process — it does not
-participate in the coroutine scheduler. The hooked `fread` on the IPC pipe yields,
-but the data arrives on the OS pipe (not via OpenSwoole's event loop), causing
-deadlocks and timeouts.
+pipes, which is incompatible with coroutine scheduling regardless of `hookAll`.
 
-**Fix (future)**: use `Coroutine\System::exec()` or coroutine-aware pipe reads for
-CGI dispatch when `hookAll` is active. Or document that `ec=true + pi=true`
-requires `hookAll(false)` (explicit opt-out).
+`App::run()` detects this at boot and applies automatic fallbacks:
+- **sg=T** (modes 6/10): force `ec=false + hookAll=0` → falls back to Mode 5/9
+  (sync CGI pool/proc). All tests pass identically.
+- **sg=F** (modes 11/12): force `pi=false` → falls back to Mode 1 (in-process
+  coroutine). Can't force `ec=false` because `sg=F+ec=F` is rejected (coroutines
+  required for per-request `$g` isolation).
+
+A warning is logged via `elog()` so the configuration mismatch is visible.
 
 ### Mode 4 Auto-Global Caching (Deep Dive)
 

--- a/docs/architecture/2026-05-27-superglobal-isolation.md
+++ b/docs/architecture/2026-05-27-superglobal-isolation.md
@@ -1,0 +1,218 @@
+# Superglobal Isolation in Coroutine Mode — How ext-zealphp Makes `$_GET`/`$_SESSION` Work
+
+> The breakthrough that makes traditional PHP code run correctly on OpenSwoole coroutines.
+
+## The Problem
+
+PHP was designed for one-request-per-process. Superglobals (`$_GET`, `$_POST`, `$_SESSION`, `$_COOKIE`, `$_SERVER`, `$_FILES`) are populated once per request during RINIT (Request INITialization) by the SAPI layer (mod_php, php-fpm, etc.), and torn down during RSHUTDOWN.
+
+OpenSwoole is a long-running process. One PHP process handles thousands of requests. With `enable_coroutine = true`, multiple requests run concurrently as coroutines in the same process. The superglobals are process-wide — writes from coroutine A are visible to coroutine B. This is the fundamental race condition that makes `superglobals(true) + enableCoroutine(true)` unsafe.
+
+ext-zealphp solves this with a two-layer approach.
+
+## Layer 1: Per-Coroutine EG(symbol_table) Snapshots
+
+OpenSwoole's `PHPCoroutine` saves and restores `EG` (Executor Globals) on coroutine switches. Each coroutine has its own `EG(symbol_table)` — the hash table where PHP stores all global variables including `$_GET`, `$_SESSION`, etc.
+
+ext-zealphp chains into OpenSwoole's coroutine callbacks:
+
+```
+on_yield(coroutine_A):
+  1. zealphp_snapshot_save(A)   — deep-copy superglobals from EG(symbol_table)
+  2. PHPCoroutine::on_yield(A)  — OpenSwoole swaps EG to next coroutine
+
+on_resume(coroutine_A):
+  1. PHPCoroutine::on_resume(A) — OpenSwoole restores EG for coroutine A
+  2. zealphp_snapshot_restore(A) — restore superglobals into EG(symbol_table)
+```
+
+The chaining order matters: save BEFORE OpenSwoole swaps EG (so we read from the current EG), restore AFTER OpenSwoole restores EG (so we write to the correct EG). Getting this wrong was the v0.3.1 SIGSEGV bug — `set_on_yield` REPLACES the callback, so OpenSwoole's own EG/CG swap was lost.
+
+**Key C technique — ZVAL_DUP for COW safety:**
+
+```c
+// zealphp_set_superglobal: in-place zval swap
+zval *existing = zend_hash_str_find(&EG(symbol_table), name, name_len);
+if (existing) {
+    zval old;
+    ZVAL_COPY_VALUE(&old, existing);  // save old (no refcount change)
+    ZVAL_DUP(existing, value);        // deep copy with refcount=1
+    zval_ptr_dtor(&old);              // free old AFTER overwrite
+}
+```
+
+Why `ZVAL_DUP` not `ZVAL_COPY`: `ZVAL_COPY` shares the `zend_array` via refcount (refcount=2). When the included file modifies `$_SESSION['counter']++`, PHP's copy-on-write (COW) sees refcount > 1, separates the array, and the mutation goes to a COPY — the original in `EG(symbol_table)` keeps the old data. `ZVAL_DUP` creates a full copy with refcount=1, so the file's writes go directly into the `EG(symbol_table)` entry.
+
+Why in-place (not `zend_hash_str_update`): `zend_hash_str_update` allocates a NEW hash bucket at a potentially different memory address. PHP's compiled variable (CV) cache stores a pointer to the zval in the hash bucket. After `zend_hash_str_update`, cached CVs in included files point to the OLD (freed) bucket — use-after-free. In-place swap via `ZVAL_COPY_VALUE` + `ZVAL_DUP` keeps the zval at the same memory address.
+
+## Layer 2: PG(http_globals) — The SAPI Contract
+
+Layer 1 handles coroutine isolation. But there's a deeper problem: PHP's auto-global mechanism.
+
+### How PHP resolves `$_GET`
+
+When a PHP file references `$_GET`, the engine doesn't just look it up in `EG(symbol_table)`. It goes through the **auto-global JIT** (Just-In-Time) mechanism:
+
+```
+1. COMPILE TIME: compiler recognizes $_GET as auto-global
+   → marks the opcode with ZEND_FETCH_GLOBAL_LOCK
+
+2. RUNTIME (first access in this compiled scope):
+   → zend_is_auto_global("_GET") checks if armed=true
+   → if armed: fires JIT callback (php_auto_globals_create_get)
+     → callback reads PG(http_globals)[TRACK_VARS_GET]
+     → stores result in EG(symbol_table)
+     → sets armed=false
+   → if not armed: finds entry in EG(symbol_table) directly
+
+3. SUBSEQUENT ACCESSES: uses cached CV pointer
+```
+
+The JIT callback reads from `PG(http_globals)` — a process-wide array (not per-coroutine). In a normal SAPI (mod_php, php-fpm), `PG(http_globals)` is populated during RINIT from the SAPI request data. In CLI SAPI (which OpenSwoole uses), **PG(http_globals) is never populated** — the slots are `IS_UNDEF`.
+
+This is why `$GLOBALS['_GET'] = $data` worked for the FIRST request but returned stale values on subsequent requests. The JIT fires on the first access, reads from `PG(http_globals)` (empty/stale), stores the result in `EG(symbol_table)`, and disarms. Our `$GLOBALS['_GET'] = $data` overwrites the entry. But on the next coroutine, the JIT fires again (new EG, auto-global may re-arm), reads from `PG(http_globals)` (still empty/stale), and overwrites our data.
+
+### The Fix: Update PG(http_globals)
+
+ext-zealphp's `zealphp_set_superglobal` now updates BOTH stores:
+
+```c
+// 1. Update EG(symbol_table) — per-coroutine executor globals
+ZVAL_DUP(existing, value);
+
+// 2. Update PG(http_globals) — process-wide SAPI globals
+int idx = zealphp_track_vars_index(name);  // _GET → TRACK_VARS_GET(1)
+if (idx >= 0 && existing) {
+    if (Z_TYPE(PG(http_globals)[idx]) != IS_UNDEF) {
+        zval_ptr_dtor(&PG(http_globals)[idx]);  // free old
+    }
+    ZVAL_COPY(&PG(http_globals)[idx], existing);  // point to our data
+}
+```
+
+The `IS_UNDEF` guard is critical: CLI SAPI never initializes `PG(http_globals)` slots. Without the guard, `zval_ptr_dtor` on `IS_UNDEF` segfaults. This was the crash in our first attempt.
+
+### Why Both Layers Are Needed
+
+```
+onRequest handler scope:
+  zealphp_superglobals_set() → updates EG(symbol_table) + PG(http_globals)
+  → $_GET in this scope: resolved from EG(symbol_table) ✓
+  → $_GET in JIT callback: reads PG(http_globals) ✓
+
+executeFile (include) scope:
+  The included file has its OWN compiled opcodes with its OWN CV cache.
+  First execution: resolves $_GET from EG(symbol_table) → finds our data ✓
+  Second execution (same file, new coroutine):
+    → CV cache from prior execution is invalidated (new execute_data)
+    → resolves $_GET from EG(symbol_table) again
+    → BUT: auto-global JIT may fire, reading PG(http_globals) → correct ✓
+    → HOWEVER: parse_str($_SERVER['QUERY_STRING'], $_GET) in executeFile
+      provides belt-and-suspenders safety for the include scope
+```
+
+The PHP-level `executeFile` refresh (`parse_str` for `$_GET`, direct assignment for `$_POST`/`$_COOKIE`/etc.) ensures the included file's scope sees current data even if the auto-global resolution takes a cached path. Both layers complement each other:
+
+- **C driver** (`PG(http_globals)`): correct JIT source for NEW auto-global resolutions
+- **PHP** (`executeFile` refresh): correct values for CACHED auto-global resolutions
+
+## $_SESSION: The Reference Binding
+
+`$_SESSION` has a unique challenge: it's not just READ per request — it's WRITTEN by the file and must be PERSISTED by `zeal_session_write_close()`. The write-back path must see the file's mutations.
+
+### The Problem
+
+```
+zeal_session_start():
+  $g->session = $session_data;     // typed property on per-coroutine $g
+  $GLOBALS['_SESSION'] = $data;    // EG(symbol_table) entry
+
+file.php:
+  $_SESSION['counter']++;          // writes to... which array?
+
+zeal_session_write_close():
+  $data = $g->session;             // reads from typed property
+  write_to_disk($data);            // persists
+```
+
+If the file writes to `$_SESSION` (the `EG(symbol_table)` entry) but write_close reads from `$g->session` (the typed property), the mutation is lost.
+
+### The Fix: Reference Binding
+
+```php
+// In zeal_session_start(), for Mode 4:
+$g->session = $session_data;
+$_SESSION = &$g->session;  // make $_SESSION an alias for $g->session
+```
+
+Now writes to `$_SESSION['counter']` go directly to `$g->session['counter']`. write_close reads `$g->session` and sees the mutation.
+
+**Critical detail**: `zealphp_superglobals_set` must pass `[]` (empty) for the `$_SESSION` parameter — if it passes `$g->session`, `ZVAL_DUP` overwrites the reference binding with a standalone copy.
+
+### Session ID Storage
+
+`zeal_session_id()` stores the SID in `$g->cookie['PHPSESSID']`. But `$g->cookie` after `unset($g->cookie)` proxies to `$_COOKIE`, which has auto-global caching. `zeal_session_write_close()` would read the WRONG SID.
+
+Fix: store the SID in `$g->session_params['session_id']` (a typed property on per-coroutine `$g`, immune to auto-global caching) and read it back in write_close:
+
+```php
+// zeal_session_start() — store SID
+$params = $g->session_params;
+$params['session_id'] = $session_id;
+$g->session_params = $params;  // explicit read-modify-write (PHP COW safe)
+
+// zeal_session_write_close() — read SID
+$session_id = $g->session_params['session_id'] ?? zeal_session_id();
+```
+
+Note the explicit read-modify-write for `session_params`: `$g->session_params['session_id'] = $id` (compound assignment on a typed property) silently fails in some coroutine contexts due to PHP's COW mechanics with typed properties.
+
+## Per-Coroutine RequestContext
+
+`RequestContext::instance()` returns per-coroutine instances when `App::$coroutine_isolated_superglobals` is true:
+
+```php
+public static function instance(): self
+{
+    if (!App::$superglobals || App::$coroutine_isolated_superglobals) {
+        $cid = Coroutine::getCid();
+        if ($cid >= 0) {
+            $context = Coroutine::getContext($cid);
+            // per-coroutine instance from coroutine context
+        }
+    }
+    return self::$instance; // process-wide singleton fallback
+}
+```
+
+This isolates framework state (`$g->zealphp_response`, `$g->session`, error handlers, etc.) per request. The `__get`/`__set` proxy to `$GLOBALS['_*']` still works because ext-zealphp isolates the superglobals per coroutine.
+
+## Summary: The Two-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    PHP User Code                             │
+│  $_GET['mode'], $_SESSION['counter']++, header('Location:')  │
+├─────────────────────────────────────────────────────────────┤
+│  PHP Layer (executeFile refresh)                             │
+│  parse_str($qs, $_GET), $_POST = $req->post, etc.           │
+│  $_SESSION = &$g->session (reference binding)                │
+├─────────────────────────────────────────────────────────────┤
+│  C Driver Layer (ext-zealphp)                                │
+│  zealphp_set_superglobal:                                    │
+│    EG(symbol_table) ← ZVAL_DUP (in-place, refcount=1)       │
+│    PG(http_globals) ← ZVAL_COPY (JIT source)                │
+│  zealphp_snapshot_save/restore on yield/resume               │
+├─────────────────────────────────────────────────────────────┤
+│  OpenSwoole Coroutine Scheduler                              │
+│  PHPCoroutine::on_yield/on_resume (EG/CG context switch)     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+This architecture makes `superglobals(true) + enableCoroutine(true)` safe:
+- Each coroutine has isolated `$_GET`/`$_POST`/`$_SESSION` (snapshot/restore)
+- The PHP auto-global JIT resolves correctly (PG(http_globals) updated)
+- `$_SESSION` writes persist to disk (reference binding + session_params SID)
+- Framework state is per-coroutine (RequestContext per-coroutine instances)
+
+Traditional PHP code (`$_GET['mode']`, `$_SESSION['counter']++`, `header()`, `exit()`) works unchanged.

--- a/src/App.php
+++ b/src/App.php
@@ -3250,6 +3250,27 @@ class App
             ];
         }
 
+        // Mode 4 (sg=T+ec=T+ext-zealphp): PHP's auto-global $_GET zval is
+        // cached per coroutine — $GLOBALS['_GET'] = $x replaces the hash
+        // entry but the cached CV pointer still refers to the old zval.
+        // Workaround: populate $_GET in-place from the canonical source
+        // ($g->openswoole_request->get) using array mutation, not assignment.
+        // $_SERVER doesn't have this issue (its JIT resolves correctly).
+        if (self::$coroutine_isolated_superglobals && $g->openswoole_request !== null) {
+            $req = $g->openswoole_request;
+            // $_GET: parse from query string (modifies the zval in-place)
+            $qs = is_string($g->server['QUERY_STRING'] ?? null) ? $g->server['QUERY_STRING'] : '';
+            parse_str($qs, $_GET);
+            // $_POST, $_COOKIE, $_FILES: clear + repopulate in-place
+            foreach (array_keys($_POST) as $k) { unset($_POST[$k]); }
+            foreach ((is_array($req->post) ? $req->post : []) as $k => $v) { $_POST[$k] = $v; }
+            foreach (array_keys($_COOKIE) as $k) { unset($_COOKIE[$k]); }
+            foreach ((is_array($req->cookie) ? $req->cookie : []) as $k => $v) { $_COOKIE[$k] = $v; }
+            foreach (array_keys($_FILES) as $k) { unset($_FILES[$k]); }
+            foreach ((is_array($req->files) ? $req->files : []) as $k => $v) { $_FILES[$k] = $v; }
+            $_REQUEST = $_GET + $_POST;
+        }
+
         $obBase = ob_get_level();
         ob_start();
         $result = null;
@@ -6412,12 +6433,19 @@ HELP;
             // is intentionally NOT touched here — the session manager owns its
             // own write path (file load + uopz session_start).
             if (App::$superglobals) {
-                $_GET     = $get;
-                $_POST    = $post;
-                $_COOKIE  = $cookie;
-                $_FILES   = $files;
-                $_SERVER  = $srvFinal;
-                $_REQUEST = $g->request;
+                // In coroutine-isolated mode (sg=T+ec=T+ext-zealphp), PHP's
+                // auto-global caching makes $GLOBALS['_GET'] = $x and $_GET = $x
+                // unreliable across coroutines (the auto-global zval reference
+                // is cached from the first access and not updated by subsequent
+                // assignments in new coroutines). ext-zealphp's C-level
+                // zealphp_superglobals_set() writes directly to EG(symbol_table)
+                // via zend_hash_str_find, bypassing the auto-global cache.
+                $GLOBALS['_GET']     = $get;
+                $GLOBALS['_POST']    = $post;
+                $GLOBALS['_COOKIE']  = $cookie;
+                $GLOBALS['_FILES']   = $files;
+                $GLOBALS['_SERVER']  = $srvFinal;
+                $GLOBALS['_REQUEST'] = $g->request;
                 // v0.2.30 (issue #17) — make $g->get/post/cookie/files/server/
                 // request LIVE ALIASES of the superglobals, not per-request
                 // snapshots. A declared `public array $get` is accessed

--- a/src/App.php
+++ b/src/App.php
@@ -3252,6 +3252,22 @@ class App
 
         // Mode 4 session reference is established in zeal_session_start()
         // ($_SESSION = &$g->session) so writes go directly to $g->session.
+        //
+        // Mode 4: populate ALL request superglobals from the canonical source
+        // ($g->openswoole_request). PHP auto-global caching across coroutines
+        // means $_GET/$_POST/$_COOKIE/$_SERVER/$_FILES return stale values
+        // from a prior coroutine. parse_str fixes $_GET in-place; for the
+        // others, use the same approach via reference binding.
+        if (self::$coroutine_isolated_superglobals && $g->openswoole_request !== null) {
+            $req = $g->openswoole_request;
+            $qs = is_string($g->server['QUERY_STRING'] ?? null) ? $g->server['QUERY_STRING'] : '';
+            parse_str($qs, $_GET);
+            $_POST    = is_array($req->post) ? $req->post : [];
+            $_COOKIE  = is_array($req->cookie) ? $req->cookie : [];
+            $_FILES   = is_array($req->files) ? $req->files : [];
+            $_REQUEST = $_GET + $_POST;
+            $_SERVER  = $g->server;
+        }
 
         $obBase = ob_get_level();
         ob_start();

--- a/src/App.php
+++ b/src/App.php
@@ -3250,25 +3250,25 @@ class App
             ];
         }
 
-        // Mode 4 (sg=T+ec=T+ext-zealphp): PHP's auto-global $_GET zval is
-        // cached per coroutine — $GLOBALS['_GET'] = $x replaces the hash
-        // entry but the cached CV pointer still refers to the old zval.
-        // Workaround: populate $_GET in-place from the canonical source
-        // ($g->openswoole_request->get) using array mutation, not assignment.
-        // $_SERVER doesn't have this issue (its JIT resolves correctly).
-        if (self::$coroutine_isolated_superglobals && $g->openswoole_request !== null) {
+        // Mode 4 (sg=T+ec=T+ext-zealphp): PHP's auto-global $_GET zval
+        // pointer is cached per compiled scope. ext-zealphp v0.3.3+
+        // zealphp_superglobals_set uses in-place array update
+        // (zend_hash_clean + zend_hash_copy) to preserve the zend_array*
+        // pointer, so cached CVs in the included file see updated data.
+        if (self::$coroutine_isolated_superglobals
+            && \function_exists('zealphp_superglobals_set')
+            && $g->openswoole_request !== null
+        ) {
             $req = $g->openswoole_request;
-            // $_GET: parse from query string (modifies the zval in-place)
-            $qs = is_string($g->server['QUERY_STRING'] ?? null) ? $g->server['QUERY_STRING'] : '';
-            parse_str($qs, $_GET);
-            // $_POST, $_COOKIE, $_FILES: clear + repopulate in-place
-            foreach (array_keys($_POST) as $k) { unset($_POST[$k]); }
-            foreach ((is_array($req->post) ? $req->post : []) as $k => $v) { $_POST[$k] = $v; }
-            foreach (array_keys($_COOKIE) as $k) { unset($_COOKIE[$k]); }
-            foreach ((is_array($req->cookie) ? $req->cookie : []) as $k => $v) { $_COOKIE[$k] = $v; }
-            foreach (array_keys($_FILES) as $k) { unset($_FILES[$k]); }
-            foreach ((is_array($req->files) ? $req->files : []) as $k => $v) { $_FILES[$k] = $v; }
-            $_REQUEST = $_GET + $_POST;
+            /** @var array<string,mixed> $rGet */
+            $rGet  = $req->get  ?: [];
+            /** @var array<string,mixed> $rPost */
+            $rPost = $req->post ?: [];
+            (\zealphp_superglobals_set(...))(
+                $rGet, $rPost,
+                $req->cookie ?: [], $g->server, $req->files ?: [],
+                $rGet + $rPost, $g->session
+            );
         }
 
         $obBase = ob_get_level();
@@ -3317,6 +3317,14 @@ class App
         $output = ob_get_clean();
         if ($output === false) {
             $output = '';
+        }
+
+        // Mode 4: sync $_SESSION back to $g->session. The C in-place update
+        // ensures $_SESSION here is the same zend_array* the file modified.
+        if (self::$coroutine_isolated_superglobals) {
+            /** @var array<string, mixed> $syncSess */
+            $syncSess = $_SESSION;
+            $g->session = $syncSess;
         }
 
         // Fragment-mode post-flight: requested but no App::fragment('X', ...)
@@ -6440,12 +6448,18 @@ HELP;
                 // assignments in new coroutines). ext-zealphp's C-level
                 // zealphp_superglobals_set() writes directly to EG(symbol_table)
                 // via zend_hash_str_find, bypassing the auto-global cache.
-                $GLOBALS['_GET']     = $get;
-                $GLOBALS['_POST']    = $post;
-                $GLOBALS['_COOKIE']  = $cookie;
-                $GLOBALS['_FILES']   = $files;
-                $GLOBALS['_SERVER']  = $srvFinal;
-                $GLOBALS['_REQUEST'] = $g->request;
+                if (self::$coroutine_isolated_superglobals
+                    && \function_exists('zealphp_superglobals_set')
+                ) {
+                    (\zealphp_superglobals_set(...))($get, $post, $cookie, $srvFinal, $files, $g->request, $g->session);
+                } else {
+                    $GLOBALS['_GET']     = $get;
+                    $GLOBALS['_POST']    = $post;
+                    $GLOBALS['_COOKIE']  = $cookie;
+                    $GLOBALS['_FILES']   = $files;
+                    $GLOBALS['_SERVER']  = $srvFinal;
+                    $GLOBALS['_REQUEST'] = $g->request;
+                }
                 // v0.2.30 (issue #17) — make $g->get/post/cookie/files/server/
                 // request LIVE ALIASES of the superglobals, not per-request
                 // snapshots. A declared `public array $get` is accessed

--- a/src/App.php
+++ b/src/App.php
@@ -3250,16 +3250,24 @@ class App
             ];
         }
 
-        // Mode 4 (sg=T+ec=T+ext-zealphp): PHP auto-global $_GET zval
-        // pointer is cached per compiled scope in OpenSwoole coroutines.
-        // parse_str modifies the existing $_GET zval IN-PLACE (the internal
-        // zend_array* stays the same), so cached CVs in the included file
-        // see updated data. $_POST/$_COOKIE/$_FILES don't have this issue
-        // (they're rarely accessed via auto-global in included files).
-        // $_SESSION is managed by $g->session (synced back after include).
-        if (self::$coroutine_isolated_superglobals && $g->openswoole_request !== null) {
-            $qs = is_string($g->server['QUERY_STRING'] ?? null) ? $g->server['QUERY_STRING'] : '';
-            parse_str($qs, $_GET);
+        // Mode 4 (sg=T+ec=T+ext-zealphp): refresh superglobals before include.
+        // ext-zealphp v0.3.3+ zealphp_superglobals_set uses in-place zval swap
+        // (ZVAL_COPY_VALUE + ZVAL_COPY at same address) so cached CVs in the
+        // included file see updated data.
+        if (self::$coroutine_isolated_superglobals
+            && \function_exists('zealphp_superglobals_set')
+            && $g->openswoole_request !== null
+        ) {
+            $req = $g->openswoole_request;
+            /** @var array<string,mixed> $rGet */
+            $rGet  = $req->get  ?: [];
+            /** @var array<string,mixed> $rPost */
+            $rPost = $req->post ?: [];
+            (\zealphp_superglobals_set(...))(
+                $rGet, $rPost,
+                $req->cookie ?: [], $g->server, $req->files ?: [],
+                $rGet + $rPost, $g->session
+            );
         }
 
         $obBase = ob_get_level();
@@ -3308,6 +3316,16 @@ class App
         $output = ob_get_clean();
         if ($output === false) {
             $output = '';
+        }
+
+        // Mode 4: sync $_SESSION back to $g->session after the file ran.
+        // The file wrote to $_SESSION (auto-global zval — same address thanks
+        // to zealphp_set_superglobal's in-place swap). Copy back so
+        // CoSessionManager's write_close persists the file's mutations.
+        if (self::$coroutine_isolated_superglobals && \function_exists('zealphp_superglobals_set')) {
+            /** @var array<string, mixed> $syncSess */
+            $syncSess = $_SESSION;
+            $g->session = $syncSess;
         }
 
         // Fragment-mode post-flight: requested but no App::fragment('X', ...)
@@ -6451,17 +6469,18 @@ HELP;
             // is intentionally NOT touched here — the session manager owns its
             // own write path (file load + uopz session_start).
             if (App::$superglobals) {
-                // In coroutine-isolated mode (sg=T+ec=T+ext-zealphp), PHP's
-                // auto-global caching makes $GLOBALS['_GET'] = $x and $_GET = $x
-                // unreliable across coroutines (the auto-global zval reference
-                // is cached from the first access and not updated by subsequent
-                // assignments in new coroutines). ext-zealphp's C-level
-                $GLOBALS['_GET']     = $get;
-                $GLOBALS['_POST']    = $post;
-                $GLOBALS['_COOKIE']  = $cookie;
-                $GLOBALS['_FILES']   = $files;
-                $GLOBALS['_SERVER']  = $srvFinal;
-                $GLOBALS['_REQUEST'] = $g->request;
+                if (self::$coroutine_isolated_superglobals
+                    && \function_exists('zealphp_superglobals_set')
+                ) {
+                    (\zealphp_superglobals_set(...))($get, $post, $cookie, $srvFinal, $files, $g->request, $g->session);
+                } else {
+                    $GLOBALS['_GET']     = $get;
+                    $GLOBALS['_POST']    = $post;
+                    $GLOBALS['_COOKIE']  = $cookie;
+                    $GLOBALS['_FILES']   = $files;
+                    $GLOBALS['_SERVER']  = $srvFinal;
+                    $GLOBALS['_REQUEST'] = $g->request;
+                }
                 // v0.2.30 (issue #17) — make $g->get/post/cookie/files/server/
                 // request LIVE ALIASES of the superglobals, not per-request
                 // snapshots. A declared `public array $get` is accessed

--- a/src/App.php
+++ b/src/App.php
@@ -5977,12 +5977,25 @@ HELP;
         // process outside the coroutine scheduler → deadlock. Force hooks off
         // for CGI modes; coroutines still work (each request gets a coroutine),
         // just without I/O hooking.
+        // processIsolation + enableCoroutine: CGI subprocess dispatch uses
+        // blocking pipe I/O incompatible with coroutine scheduling. When
+        // sg=true, force both ec=false + hookAll=0 (falls back to sync Mode
+        // 5/9). When sg=false, ec=false would be rejected by validation
+        // (sg=F+ec=F requires coroutines for per-request $g isolation), so
+        // force pi=false instead (falls back to in-process Mode 1).
         if (App::processIsolation() && $enableCoroutine) {
-            elog('[lifecycle] enableCoroutine forced to false: processIsolation=true '
-                . '— CGI subprocess dispatch is incompatible with coroutine mode '
-                . '(blocking pipe I/O in the request handler prevents coroutine scheduling). '
-                . 'Use processIsolation(false) for coroutine mode, or enableCoroutine(false) for CGI.', 'warn');
-            $enableCoroutine = false;
+            if (App::$superglobals) {
+                elog('[lifecycle] processIsolation + enableCoroutine: forcing ec=false + hookAll=0 '
+                    . '— CGI pipe I/O incompatible with coroutines. Workers run synchronously (Mode 5/9).', 'warn');
+                $enableCoroutine = false;
+                $hookFlags = 0;
+            } else {
+                elog('[lifecycle] processIsolation + enableCoroutine(sg=false): forcing pi=false '
+                    . '— CGI pipe I/O incompatible with coroutines and sg=false requires ec=true. '
+                    . 'Files run in-process (Mode 1).', 'warn');
+                App::$process_isolation = false;
+                App::$coproc_implicit_request_handler = false;
+            }
         }
 
         // Surface combinations that are syntactically allowed but race

--- a/src/App.php
+++ b/src/App.php
@@ -3250,14 +3250,13 @@ class App
             ];
         }
 
-        // Mode 4 session reference is established in zeal_session_start()
+        // Mode 4: $_SESSION reference is established in zeal_session_start()
         // ($_SESSION = &$g->session) so writes go directly to $g->session.
         //
-        // Mode 4: populate ALL request superglobals from the canonical source
-        // ($g->openswoole_request). PHP auto-global caching across coroutines
-        // means $_GET/$_POST/$_COOKIE/$_SERVER/$_FILES return stale values
-        // from a prior coroutine. parse_str fixes $_GET in-place; for the
-        // others, use the same approach via reference binding.
+        // ext-zealphp's PG(http_globals) update handles the auto-global JIT
+        // at the driver level. But included files may have cached the
+        // auto-global from a prior coroutine's EG. Refresh here too so
+        // the included file's scope sees current request data.
         if (self::$coroutine_isolated_superglobals && $g->openswoole_request !== null) {
             $req = $g->openswoole_request;
             $qs = is_string($g->server['QUERY_STRING'] ?? null) ? $g->server['QUERY_STRING'] : '';

--- a/src/App.php
+++ b/src/App.php
@@ -5972,6 +5972,17 @@ HELP;
         $hookFlags = App::hookAll();
         $enableCoroutine = App::enableCoroutine();
 
+        // processIsolation + hookAll: hooked fread/fwrite on CGI subprocess
+        // pipes yields the coroutine, but the subprocess is a separate OS
+        // process outside the coroutine scheduler → deadlock. Force hooks off
+        // for CGI modes; coroutines still work (each request gets a coroutine),
+        // just without I/O hooking.
+        if (App::processIsolation() && $hookFlags !== 0 && $enableCoroutine) {
+            elog('[lifecycle] hookAll forced to 0: processIsolation=true + enableCoroutine=true '
+                . '— hooked I/O on CGI pipes causes deadlocks. Coroutines remain active without I/O hooks.', 'warn');
+            $hookFlags = 0;
+        }
+
         // Surface combinations that are syntactically allowed but race
         // process-wide superglobals against concurrent coroutines / hooked
         // I/O. We warn rather than refuse — see App::hookAll() docblock.

--- a/src/App.php
+++ b/src/App.php
@@ -103,6 +103,17 @@ class App
      * Set via `App::superglobals(bool)` BEFORE `App::init()`.
      */
     public static bool $superglobals = true;
+
+    /**
+     * True when ext-zealphp's per-coroutine superglobal isolation is active.
+     * Set by `App::run()` when sg=T + ec=T + ext-zealphp loaded. Tells
+     * `RequestContext::instance()` to use per-coroutine instances even in
+     * superglobals mode — ext-zealphp isolates `$_GET`/`$_SESSION` per
+     * coroutine, so per-coroutine `$g` is safe and necessary for framework
+     * state (`$g->zealphp_response`, etc.) to be isolated too.
+     */
+    public static bool $coroutine_isolated_superglobals = false;
+
     /**
      * Set true at the top of `App::run()` so the four lifecycle setters
      * (`superglobals`, `processIsolation`, `enableCoroutine`, `hookAll`)
@@ -5964,6 +5975,7 @@ HELP;
             && \function_exists('zealphp_coroutine_superglobals')
         ) {
             (\zealphp_coroutine_superglobals(...))((bool) true);
+            self::$coroutine_isolated_superglobals = true;
         }
 
         // Per-request define() / $GLOBALS / process-state isolation are

--- a/src/App.php
+++ b/src/App.php
@@ -6412,12 +6412,12 @@ HELP;
             // is intentionally NOT touched here — the session manager owns its
             // own write path (file load + uopz session_start).
             if (App::$superglobals) {
-                $GLOBALS['_GET']     = $get;
-                $GLOBALS['_POST']    = $post;
-                $GLOBALS['_COOKIE']  = $cookie;
-                $GLOBALS['_FILES']   = $files;
-                $GLOBALS['_SERVER']  = $srvFinal;
-                $GLOBALS['_REQUEST'] = $g->request;
+                $_GET     = $get;
+                $_POST    = $post;
+                $_COOKIE  = $cookie;
+                $_FILES   = $files;
+                $_SERVER  = $srvFinal;
+                $_REQUEST = $g->request;
                 // v0.2.30 (issue #17) — make $g->get/post/cookie/files/server/
                 // request LIVE ALIASES of the superglobals, not per-request
                 // snapshots. A declared `public array $get` is accessed

--- a/src/App.php
+++ b/src/App.php
@@ -5977,10 +5977,12 @@ HELP;
         // process outside the coroutine scheduler → deadlock. Force hooks off
         // for CGI modes; coroutines still work (each request gets a coroutine),
         // just without I/O hooking.
-        if (App::processIsolation() && $hookFlags !== 0 && $enableCoroutine) {
-            elog('[lifecycle] hookAll forced to 0: processIsolation=true + enableCoroutine=true '
-                . '— hooked I/O on CGI pipes causes deadlocks. Coroutines remain active without I/O hooks.', 'warn');
-            $hookFlags = 0;
+        if (App::processIsolation() && $enableCoroutine) {
+            elog('[lifecycle] enableCoroutine forced to false: processIsolation=true '
+                . '— CGI subprocess dispatch is incompatible with coroutine mode '
+                . '(blocking pipe I/O in the request handler prevents coroutine scheduling). '
+                . 'Use processIsolation(false) for coroutine mode, or enableCoroutine(false) for CGI.', 'warn');
+            $enableCoroutine = false;
         }
 
         // Surface combinations that are syntactically allowed but race
@@ -6061,6 +6063,7 @@ HELP;
                 ? self::$static_handler_locations
                 : ['/css/', '/js/', '/img/', '/images/', '/fonts/', '/assets/', '/static/', '/favicon.ico', '/robots.txt'],
             'enable_coroutine' => $enableCoroutine,
+            'hook_flags' => $hookFlags,
             // Runtime compression is owned by OpenSwoole. Do not also register
             // CompressionMiddleware unless this setting is disabled.
             'http_compression' => true,

--- a/src/App.php
+++ b/src/App.php
@@ -3250,25 +3250,8 @@ class App
             ];
         }
 
-        // Mode 4 (sg=T+ec=T+ext-zealphp): refresh superglobals before include.
-        // ext-zealphp v0.3.3+ zealphp_superglobals_set uses in-place zval swap
-        // (ZVAL_COPY_VALUE + ZVAL_COPY at same address) so cached CVs in the
-        // included file see updated data.
-        if (self::$coroutine_isolated_superglobals
-            && \function_exists('zealphp_superglobals_set')
-            && $g->openswoole_request !== null
-        ) {
-            $req = $g->openswoole_request;
-            /** @var array<string,mixed> $rGet */
-            $rGet  = $req->get  ?: [];
-            /** @var array<string,mixed> $rPost */
-            $rPost = $req->post ?: [];
-            (\zealphp_superglobals_set(...))(
-                $rGet, $rPost,
-                $req->cookie ?: [], $g->server, $req->files ?: [],
-                $rGet + $rPost, $g->session
-            );
-        }
+        // Mode 4 session reference is established in zeal_session_start()
+        // ($_SESSION = &$g->session) so writes go directly to $g->session.
 
         $obBase = ob_get_level();
         ob_start();
@@ -3316,16 +3299,6 @@ class App
         $output = ob_get_clean();
         if ($output === false) {
             $output = '';
-        }
-
-        // Mode 4: sync $_SESSION back to $g->session after the file ran.
-        // The file wrote to $_SESSION (auto-global zval — same address thanks
-        // to zealphp_set_superglobal's in-place swap). Copy back so
-        // CoSessionManager's write_close persists the file's mutations.
-        if (self::$coroutine_isolated_superglobals && \function_exists('zealphp_superglobals_set')) {
-            /** @var array<string, mixed> $syncSess */
-            $syncSess = $_SESSION;
-            $g->session = $syncSess;
         }
 
         // Fragment-mode post-flight: requested but no App::fragment('X', ...)
@@ -6469,18 +6442,14 @@ HELP;
             // is intentionally NOT touched here — the session manager owns its
             // own write path (file load + uopz session_start).
             if (App::$superglobals) {
-                if (self::$coroutine_isolated_superglobals
-                    && \function_exists('zealphp_superglobals_set')
-                ) {
-                    (\zealphp_superglobals_set(...))($get, $post, $cookie, $srvFinal, $files, $g->request, $g->session);
-                } else {
-                    $GLOBALS['_GET']     = $get;
-                    $GLOBALS['_POST']    = $post;
-                    $GLOBALS['_COOKIE']  = $cookie;
-                    $GLOBALS['_FILES']   = $files;
-                    $GLOBALS['_SERVER']  = $srvFinal;
-                    $GLOBALS['_REQUEST'] = $g->request;
-                }
+                $GLOBALS['_GET']     = $get;
+                $GLOBALS['_POST']    = $post;
+                $GLOBALS['_COOKIE']  = $cookie;
+                $GLOBALS['_FILES']   = $files;
+                $GLOBALS['_SERVER']  = $srvFinal;
+                $GLOBALS['_REQUEST'] = $g->request;
+                // $_SESSION is NOT set here — zeal_session_start() binds
+                // $_SESSION = &$g->session via reference in Mode 4.
                 // v0.2.30 (issue #17) — make $g->get/post/cookie/files/server/
                 // request LIVE ALIASES of the superglobals, not per-request
                 // snapshots. A declared `public array $get` is accessed

--- a/src/App.php
+++ b/src/App.php
@@ -3250,25 +3250,16 @@ class App
             ];
         }
 
-        // Mode 4 (sg=T+ec=T+ext-zealphp): PHP's auto-global $_GET zval
-        // pointer is cached per compiled scope. ext-zealphp v0.3.3+
-        // zealphp_superglobals_set uses in-place array update
-        // (zend_hash_clean + zend_hash_copy) to preserve the zend_array*
-        // pointer, so cached CVs in the included file see updated data.
-        if (self::$coroutine_isolated_superglobals
-            && \function_exists('zealphp_superglobals_set')
-            && $g->openswoole_request !== null
-        ) {
-            $req = $g->openswoole_request;
-            /** @var array<string,mixed> $rGet */
-            $rGet  = $req->get  ?: [];
-            /** @var array<string,mixed> $rPost */
-            $rPost = $req->post ?: [];
-            (\zealphp_superglobals_set(...))(
-                $rGet, $rPost,
-                $req->cookie ?: [], $g->server, $req->files ?: [],
-                $rGet + $rPost, $g->session
-            );
+        // Mode 4 (sg=T+ec=T+ext-zealphp): PHP auto-global $_GET zval
+        // pointer is cached per compiled scope in OpenSwoole coroutines.
+        // parse_str modifies the existing $_GET zval IN-PLACE (the internal
+        // zend_array* stays the same), so cached CVs in the included file
+        // see updated data. $_POST/$_COOKIE/$_FILES don't have this issue
+        // (they're rarely accessed via auto-global in included files).
+        // $_SESSION is managed by $g->session (synced back after include).
+        if (self::$coroutine_isolated_superglobals && $g->openswoole_request !== null) {
+            $qs = is_string($g->server['QUERY_STRING'] ?? null) ? $g->server['QUERY_STRING'] : '';
+            parse_str($qs, $_GET);
         }
 
         $obBase = ob_get_level();
@@ -3317,14 +3308,6 @@ class App
         $output = ob_get_clean();
         if ($output === false) {
             $output = '';
-        }
-
-        // Mode 4: sync $_SESSION back to $g->session. The C in-place update
-        // ensures $_SESSION here is the same zend_array* the file modified.
-        if (self::$coroutine_isolated_superglobals) {
-            /** @var array<string, mixed> $syncSess */
-            $syncSess = $_SESSION;
-            $g->session = $syncSess;
         }
 
         // Fragment-mode post-flight: requested but no App::fragment('X', ...)
@@ -6446,20 +6429,12 @@ HELP;
                 // unreliable across coroutines (the auto-global zval reference
                 // is cached from the first access and not updated by subsequent
                 // assignments in new coroutines). ext-zealphp's C-level
-                // zealphp_superglobals_set() writes directly to EG(symbol_table)
-                // via zend_hash_str_find, bypassing the auto-global cache.
-                if (self::$coroutine_isolated_superglobals
-                    && \function_exists('zealphp_superglobals_set')
-                ) {
-                    (\zealphp_superglobals_set(...))($get, $post, $cookie, $srvFinal, $files, $g->request, $g->session);
-                } else {
-                    $GLOBALS['_GET']     = $get;
-                    $GLOBALS['_POST']    = $post;
-                    $GLOBALS['_COOKIE']  = $cookie;
-                    $GLOBALS['_FILES']   = $files;
-                    $GLOBALS['_SERVER']  = $srvFinal;
-                    $GLOBALS['_REQUEST'] = $g->request;
-                }
+                $GLOBALS['_GET']     = $get;
+                $GLOBALS['_POST']    = $post;
+                $GLOBALS['_COOKIE']  = $cookie;
+                $GLOBALS['_FILES']   = $files;
+                $GLOBALS['_SERVER']  = $srvFinal;
+                $GLOBALS['_REQUEST'] = $g->request;
                 // v0.2.30 (issue #17) — make $g->get/post/cookie/files/server/
                 // request LIVE ALIASES of the superglobals, not per-request
                 // snapshots. A declared `public array $get` is accessed

--- a/src/CGI/WorkerPool.php
+++ b/src/CGI/WorkerPool.php
@@ -106,15 +106,19 @@ final class WorkerPool
         $served = $this->workers[$idx]['served'];
 
         // Respawn if the subprocess died mid-request, hit the recycle
-        // limit, or the OS reports it's no longer running (proc_get_status
-        // ['running' => false]). FPM-equivalent recovery semantics.
+        // limit, the OS reports it's no longer running, or the response
+        // carries the _exit flag (the pool worker's shutdown function sent
+        // an IPC frame before exit() terminated the process — the worker
+        // may still be exiting when isAlive checks, so the flag forces
+        // respawn to avoid dispatching to a zombie).
         $err = '';
         if ($resp === null) {
             stream_set_blocking($w['stderr'], false);
-            $err = stream_get_contents($w['stderr']);
+            $err = (string) stream_get_contents($w['stderr']);
         }
-        
-        if ($resp === null || $served >= $this->maxRequestsPerWorker || !$this->isAlive($w)) {
+        $exitFlag = is_array($resp) && !empty($resp['_exit']);
+
+        if ($resp === null || $exitFlag || $served >= $this->maxRequestsPerWorker || !$this->isAlive($w)) {
             $this->respawn($idx);
         } else {
             $this->returnToIdle($idx);

--- a/src/RequestContext.php
+++ b/src/RequestContext.php
@@ -87,7 +87,7 @@ class RequestContext
 
     public static function instance(): self
     {
-        if (!App::$superglobals) {
+        if (!App::$superglobals || App::$coroutine_isolated_superglobals) {
             $cid = \OpenSwoole\Coroutine::getCid();
             if ($cid >= 0) {
                 $context = \OpenSwoole\Coroutine::getContext($cid);

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -84,7 +84,12 @@ class CoSessionManager
         // skip reading the PHPSESSID cookie, calling zeal_session_start, and
         // emitting our own Set-Cookie header. The zeal_session_* uopz
         // overrides remain available to user code regardless.
-        $manageSession = \ZealPHP\App::$session_lifecycle;
+        //
+        // Also skip when the CGI subprocess owns sessions (pi=true) — same
+        // guard SessionManager has. Without this, CoSessionManager and the
+        // subprocess both drive session I/O on the same file, racing writes.
+        $manageSession = \ZealPHP\App::$session_lifecycle
+            && !\ZealPHP\App::cgiOwnsSessions();
 
         if ($manageSession) {
             $sessionName = zeal_session_name();

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -137,6 +137,7 @@ class SessionManager
         $g->status                   = null;
         $g->_streaming               = null;
         $g->ignore_user_abort_state  = 0;
+        $g->_session_started         = false;
 
         $sessionId = null;
         if ($manageSession) {

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -225,7 +225,17 @@ function zeal_session_start(): bool
     // (must survive the merge).
     $g->session_loaded_keys = array_keys($session_data);
     if (\ZealPHP\App::$superglobals) {
-        $GLOBALS['_SESSION'] = $session_data;
+        if (\ZealPHP\App::$coroutine_isolated_superglobals) {
+            // Mode 4: bind $_SESSION as a reference to $g->session. PHP's
+            // FETCH_R does ZVAL_COPY (refcount++) into a temp slot, so any
+            // write triggers COW separation — the mutation goes to a copy
+            // that's discarded when the include returns. A reference bypasses
+            // COW: writes follow it directly to $g->session, which is what
+            // zeal_session_write_close() reads.
+            $_SESSION = &$g->session;
+        } else {
+            $GLOBALS['_SESSION'] = $session_data;
+        }
     }
 
     // Mark session as started so CoSessionManager's finally block
@@ -329,18 +339,22 @@ function zeal_session_write_close(): bool
     // declared typed property $g->session shadows the __get/__set proxy,
     // so Symfony/legacy code that writes through $_SESSION never reaches
     // $g->session). Persist whichever holds the live data for the mode.
+    // In Mode 4 (coroutine_isolated_superglobals), $g->session is the
+    // canonical store — $_SESSION is bound via reference, but $GLOBALS['_SESSION']
+    // may not follow the reference correctly across function scopes.
+    $useGSession = \ZealPHP\App::$coroutine_isolated_superglobals || !\ZealPHP\App::$superglobals;
     $superglobals = \ZealPHP\App::$superglobals;
-    $hasSession = $superglobals
-        ? (isset($GLOBALS['_SESSION']) && is_array($GLOBALS['_SESSION']))
+    $hasSession = $useGSession
         /** @phpstan-ignore-next-line isset.property — runtime tests uninitialized typed slot */
-        : isset($g->session);
+        ? isset($g->session)
+        : (isset($GLOBALS['_SESSION']) && is_array($GLOBALS['_SESSION']));
 
     if ($hasSession) {
         $session_id = zeal_session_id();
         $save_path = $g->session_params['save_path'] ?? '';
         assert(is_string($save_path));
         $session_file = $save_path . '/sess_' . $session_id;
-        $data = $superglobals ? $GLOBALS['_SESSION'] : $g->session;
+        $data = $useGSession ? $g->session : $GLOBALS['_SESSION'];
         $wHandler = $g->session_params['handler'] ?? null;
         if ($wHandler instanceof \SessionHandlerInterface) {
             // Merge with stored data to mitigate concurrent-request races.

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -94,11 +94,12 @@ function zeal_session_start(): bool
 {
     $g = RequestContext::instance();
 
-    // If session is already active (e.g. CoSessionManager already called us),
-    // return immediately. Prevents the double-start bug in Mode 4 (sg=T+ec=T)
-    // where CoSessionManager starts the session, then the included file's
-    // session_start() re-reads from disk and overwrites in-memory mutations.
-    if ($g->_session_started) {
+    // If session is already active AND we're using per-coroutine $g (Mode 4),
+    // return immediately. Prevents the double-start where CoSessionManager
+    // starts the session, then the file's session_start() re-reads from disk.
+    // In sync mode (process-wide $g), SessionManager re-starts cleanly each
+    // request via _session_started reset — the second call is harmless.
+    if ($g->_session_started && \ZealPHP\App::$coroutine_isolated_superglobals) {
         return true;
     }
 

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -94,6 +94,14 @@ function zeal_session_start(): bool
 {
     $g = RequestContext::instance();
 
+    // If session is already active (e.g. CoSessionManager already called us),
+    // return immediately. Prevents the double-start bug in Mode 4 (sg=T+ec=T)
+    // where CoSessionManager starts the session, then the included file's
+    // session_start() re-reads from disk and overwrites in-memory mutations.
+    if ($g->_session_started) {
+        return true;
+    }
+
     // Ensure session parameters are initialized
     if (!isset($g->session_params['save_path'])) {
         $g->session_params['save_path'] = '/var/lib/php/sessions';

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -153,8 +153,13 @@ function zeal_session_start(): bool
     $sessionNameForCookie = $g->session_params['name'];
     $hadIncomingSessionCookie = isset($g->cookie[$sessionNameForCookie]);
 
-    // Get session ID from cookie or generate a new one
+    // Get session ID from cookie or generate a new one.
+    // Store in session_params so write_close can read it without going
+    // through $g->cookie (which has auto-global caching issues in Mode 4).
     $session_id = zeal_session_id();
+    $params = $g->session_params;
+    $params['session_id'] = $session_id;
+    $g->session_params = $params;
 
     // Bug #12: emit Set-Cookie if the session is brand-new (no incoming
     // PHPSESSID cookie). Without this, a handler that calls session_start()
@@ -350,7 +355,13 @@ function zeal_session_write_close(): bool
         : (isset($GLOBALS['_SESSION']) && is_array($GLOBALS['_SESSION']));
 
     if ($hasSession) {
-        $session_id = zeal_session_id();
+        // Read SID from session_params (set by zeal_session_start) — not
+        // zeal_session_id() which reads $g->cookie and suffers from
+        // auto-global caching in coroutine mode.
+        /** @var string $session_id */
+        $session_id = isset($g->session_params['session_id']) && is_string($g->session_params['session_id'])
+            ? $g->session_params['session_id']
+            : zeal_session_id();
         $save_path = $g->session_params['save_path'] ?? '';
         assert(is_string($save_path));
         $session_file = $save_path . '/sess_' . $session_id;

--- a/src/cgi_worker.php
+++ b/src/cgi_worker.php
@@ -172,22 +172,46 @@ if (function_exists('zealphp_override') || function_exists('uopz_set_return')) {
     }, true);
 
     $z_override('setcookie', function(
-        string $name, string $value = '', $expires_or_options = 0,
+        string $name, string $value = '', int|array $expires_or_options = 0,
         string $path = '', string $domain = '', bool $secure = false,
         bool $httponly = false, string $samesite = ''
     ) {
         global $__z_cookies;
-        $__z_cookies[] = [$name, $value, $expires_or_options, $path, $domain, $secure, $httponly];
+        if (is_array($expires_or_options)) {
+            $o = $expires_or_options;
+            $__z_cookies[] = [
+                $name, $value,
+                (int)($o['expires'] ?? 0),
+                (string)($o['path'] ?? ''),
+                (string)($o['domain'] ?? ''),
+                (bool)($o['secure'] ?? false),
+                (bool)($o['httponly'] ?? false),
+            ];
+        } else {
+            $__z_cookies[] = [$name, $value, $expires_or_options, $path, $domain, $secure, $httponly];
+        }
         return true;
     }, true);
 
     $z_override('setrawcookie', function(
-        string $name, string $value = '', $expires_or_options = 0,
+        string $name, string $value = '', int|array $expires_or_options = 0,
         string $path = '', string $domain = '', bool $secure = false,
         bool $httponly = false
     ) {
         global $__z_rawcookies;
-        $__z_rawcookies[] = [$name, $value, $expires_or_options, $path, $domain, $secure, $httponly];
+        if (is_array($expires_or_options)) {
+            $o = $expires_or_options;
+            $__z_rawcookies[] = [
+                $name, $value,
+                (int)($o['expires'] ?? 0),
+                (string)($o['path'] ?? ''),
+                (string)($o['domain'] ?? ''),
+                (bool)($o['secure'] ?? false),
+                (bool)($o['httponly'] ?? false),
+            ];
+        } else {
+            $__z_rawcookies[] = [$name, $value, $expires_or_options, $path, $domain, $secure, $httponly];
+        }
         return true;
     }, true);
 

--- a/src/pool_worker.php
+++ b/src/pool_worker.php
@@ -54,6 +54,62 @@ $__pw_cookies    = [];   /** @var list<array<string,mixed>> */
 $__pw_rawcookies = [];   /** @var list<array<string,mixed>> */
 $__pw_status     = 200;
 $__pw_shutdown_functions = [];
+$__pw_mid_request = false;
+
+// exit()/die() survival — register a REAL shutdown function BEFORE the uopz
+// override replaces register_shutdown_function. PHP 8.4 has no ExitException;
+// exit() terminates the process immediately. This handler detects that we
+// died mid-request, captures whatever was echoed, and sends the IPC response
+// frame so the parent doesn't see "subprocess died mid-request". The parent
+// will respawn the worker after the process exits.
+register_shutdown_function(function (): void {
+    global $__pw_mid_request, $__pw_headers, $__pw_cookies, $__pw_rawcookies,
+           $__pw_status, $__pw_shutdown_functions;
+
+    if (!$__pw_mid_request) {
+        return;
+    }
+
+    // Flush session to disk before sending the IPC frame — exit()
+    // fires our shutdown handler before PHP's native session_write_close.
+    // Without this, a redirect after exit() races: the next request reads
+    // a stale session file because the old worker hasn't flushed yet.
+    if (function_exists('session_status') && session_status() === PHP_SESSION_ACTIVE) {
+        session_write_close();
+    }
+
+    // Run any app-registered shutdown functions (e.g. WordPress cleanup)
+    if (is_array($__pw_shutdown_functions)) {
+        foreach ($__pw_shutdown_functions as $sf) {
+            try {
+                $sf[0](...$sf[1]);
+            } catch (\Throwable $e) {
+                // ignore — we're shutting down
+            }
+        }
+    }
+
+    $body = '';
+    while (ob_get_level() > 0) {
+        $body .= (string) ob_get_clean();
+    }
+
+    $resp = [
+        'status'       => $__pw_status ?: 200,
+        'headers'      => is_array($__pw_headers) ? $__pw_headers : [],
+        'cookies'      => is_array($__pw_cookies) ? $__pw_cookies : [],
+        'rawcookies'   => is_array($__pw_rawcookies) ? $__pw_rawcookies : [],
+        'body'         => $body,
+        'return_value' => null,
+        '_exit'        => true,
+    ];
+
+    try {
+        IPC::writeFrame(STDOUT, $resp);
+    } catch (\Throwable $e) {
+        // stdout may be broken — nothing we can do
+    }
+});
 
 // uopz overrides — set ONCE at boot, survive every iteration. Mirror the
 // shape cgi_worker.php produces so the parent's response builder doesn't
@@ -232,8 +288,10 @@ while ($count < $maxRequests) {
         break; // parent closed pipe → clean exit
     }
 
+    $__pw_mid_request = true;
     $resp = pool_handle_request($req);
     IPC::writeFrame(STDOUT, $resp);
+    $__pw_mid_request = false;
 
     pool_reset_request_state();
     $count++;

--- a/tests/Unit/SessionFileCorruptionTest.php
+++ b/tests/Unit/SessionFileCorruptionTest.php
@@ -50,6 +50,7 @@ class SessionFileCorruptionTest extends TestCase
         ];
         $g->cookie  = ['PHPSESSID' => $this->sessionId];
         $g->session = [];
+        $g->_session_started = false;
     }
 
     protected function tearDown(): void

--- a/tests/Unit/SessionUtilsCoverageTest.php
+++ b/tests/Unit/SessionUtilsCoverageTest.php
@@ -61,6 +61,7 @@ class SessionUtilsCoverageTest extends TestCase
         $g->cookie = [];
         $g->server = [];
         $g->openswoole_response = null;
+        $g->_session_started = false;
         $this->savedSuperSession = $GLOBALS['_SESSION'] ?? null;
         $GLOBALS['_SESSION'] = [];
     }


### PR DESCRIPTION
## Summary
- Pool worker subprocess now captures response body/headers when `exit()`/`die()` terminates the process (PHP 8.4 has no ExitException)
- Shutdown function flushes session, runs app shutdown handlers, captures OB, sends IPC frame
- WorkerPool respects `_exit` flag to always respawn (prevents zombie worker race condition)

## What was broken
- `exit(0)` in a pool worker killed the subprocess, returning 500 "subprocess died mid-request"
- The request AFTER an exit also failed (zombie worker race: isAlive() returned true while process was still in shutdown)

## Test plan
- [x] `exit(0)` returns 200 with buffered output
- [x] `die("msg")` returns 200 with message
- [x] `http_response_code(404); exit;` returns 404
- [x] Normal requests after exit work (no zombie workers)
- [x] PHPStan level 10 clean
- [x] All 3007 unit tests pass
- [x] Docker lab: CGI pool + sync mode full test suite passes