### PR TITLE
feat: App::defineIsolation() + per-coroutine constant snapshot/restore

### DIFF
--- a/CRITIC.md
+++ b/CRITIC.md
@@ -12,6 +12,7 @@ A retrospective record of every substantive technical critique ZealPHP has recei
 |---|---|---|
 | 2026-05-15 → 2026-05-16 | r/PHP thread + #phpc Discord | v0.2.4, v0.2.5, v0.2.6, v0.2.7, v0.2.8 (framework) + v0.2.4, v0.2.5, v0.2.6, v0.2.7, v0.2.8, v0.2.9 (scaffold) |
 | 2026-05-16 (later) | Pastebin line-by-line review of `app.php` | v0.2.13 — `CorsMiddleware` env-var origins + wildcard warning; main `app.php` rewrite (PSR-12, drop unused, fix `/json` session leak, remove `exit()` route + 9 junk routes, demo middleware moved to `examples/`); **static_handler_locations prefix-collision bug fix** (`/js` was intercepting `/json`); scaffold app.php demonstrates explicit CORS origins |
+| 2026-05-18 → 2026-05-27 | Reddit DM (Deep_Ad1959 / s4lai) | PR #150 (SAPI parity, Mode 4 superglobal isolation, pool worker exit survival), PR #151 (define isolation, ini_set isolation, static property snapshot, session file locking, 38 new tests) |
 | 2026-05-16 (continuing) | Pastebin reviewer's PHPStan-level-1 mocking subtext | **v0.2.14 → v0.2.15 → v0.2.16 — PHPStan baseline climbed from level 1 to level 9 (PHPStan 1.x).** v0.2.14 deleted `src/Session.php` dead code + fixed real `StringUtils` casting bugs + landed level 5. v0.2.15 was the annotation cliff (369 mechanical `@param`/`@return`/`array<K, V>` fixes; level 6). v0.2.16 closed the design-tax with 74 inline `@phpstan-ignore-next-line` annotations (each with a one-line reason) + fixed 6 real bugs along the way (`Auth::login`/`currentUser` null-handling, `Cache` miss handling, `ZealAPI::processApi` nullable request crash). |
 | 2026-05-16 (final) | PHPStan 2.x released level 10 | **v0.2.17 — upgraded PHPStan `^1.12` → `^2.1` + climbed to level 10.** PHPStan 2.x's stricter checks added 96 regression errors at level 9 (mostly redundant `?? null` on now-strict typed properties + new `isset.property` / `nullCoalesce.property` identifiers). 156 more new at level 10 (stricter mixed-type rules requiring explicit narrowing). Closed with 26 redundant `?? defaultValue` removals + targeted `assert()` narrowing + 7 net new inline ignores (75 total). Symfony 8+, Laravel 12+, and Mezzio also score level 10. ZealPHP joins the club while still running unmodified PHP-FPM-era code via uopz, `__call`, and reflection. Also in v0.2.17: `vendor/` removed from git (~4300 fewer tracked files), README badge wired to shields.io endpoint via `.github/badges/phpstan.json` with CI sync verifier, PHP 8.5 added to matrix as experimental, PHP 8.4 Xdebug-flake fixed by dropping coverage on 8.4. |
 
@@ -31,6 +32,7 @@ Five framework releases plus scaffold sync in 24 hours, all triggered by communi
 | Tiffany | Discord | "Is it a security nightmare?" — the lurker question that mattered most to address publicly |
 | PHPStan-level-1 mocker | Discord | No technical content; useful for sharpening the level-1 trade-off explanation |
 | **coroutine-isolation commenter** | Reddit (latest) | **Second-sharpest critic.** Articulated the discipline-contract framing: isolation + recycling, not either alone. Raised `ini_set`/handler-stack/pool-poisoning/opcache as the four real production-trust gaps |
+| **Deep_Ad1959 (s4lai)** | Reddit DM | **Long-running architectural collaborator.** Over 3 weeks of sustained technical review: federated WebSocket presence cleanup design, ext-zealphp coroutine isolation validation (forced interleaving test suggestion), define-time vs namespace constant isolation question (drove the define_hook split), concurrent session write race identification (drove flock implementation), connection pool poisoning framing, Rust MongoDB driver tail-latency review, distributed stress-test methodology |
 | **app.php pastebin reviewer** | Pastebin link | Line-by-line annotation of the main repo's `app.php`. Most comments were about a demo file (out of `/src/` scope), but the critique uncovered: misleading `AuthenticationMiddleware` name (didn't authenticate), `/exittest` calling `exit()` (kills OpenSwoole workers — actually dangerous), session-data leak in `/json`, hardcoded timezone, backtick `git describe`, and most importantly the **CORS `*` default**. Also indirectly led to discovering the `/js` static-handler prefix-collision framework bug. |
 
 ---
@@ -370,6 +372,38 @@ The "deliberate trade-off" framing was partly true — the ~57 design-tax sites 
 - **ROADMAP restructured** in this release: explicit policy that v0.2.x is the security + hardening + migration series, with the version-by-version trace inline. Connection-pool work moved out of v0.3 (was misclassified as observability) and into the v0.2.x remaining items — it's a production-trust gap, same class as `max_request` and the session fix here.
 
 ---
+
+### PR #150 — Superglobal isolation + Mode 4 breakthrough (22 commits)
+**Triggered by:** Deep_Ad1959's ext-zealphp coroutine isolation validation + coroutine-isolation commenter's original discipline-contract framing
+
+- **ext-zealphp SAPI parity:** `PG(http_globals)` updated per-request — PHP's auto-global JIT now resolves `$_GET`/`$_POST`/`$_COOKIE`/`$_SERVER`/`$_FILES` correctly across coroutines. The CLI SAPI never initializes these; ext-zealphp implements the SAPI contract that CLI lacks. IS_UNDEF guard prevents segfault.
+- **Per-coroutine RequestContext:** `RequestContext::instance()` returns per-coroutine instances when `coroutine_isolated_superglobals=true` (Mode 4). Framework state (`$g->zealphp_response`, session, error handlers) isolated per request.
+- **`$_SESSION` reference binding:** `$_SESSION = &$g->session` in `zeal_session_start()` — writes go directly to `$g->session`, no COW separation. Session ID stored in `session_params['session_id']` (immune to auto-global caching).
+- **Pool worker exit()/die() survival:** Shutdown handler captures response before process death. `_exit` flag prevents zombie worker race.
+- **Lifecycle mode fallbacks:** `pi=T+ec=T` → force `ec=false` (sg=T) or `pi=false` (sg=F). All 10 non-rejected modes boot and serve.
+- **4 production-ready modes:** Mode 1 (default), Mode 3 (sync), Mode 4 (superglobals+coroutines), Mode 5 (CGI pool).
+- Full architecture docs: `docs/architecture/2026-05-27-lifecycle-matrix.md`, `docs/architecture/2026-05-27-superglobal-isolation.md`.
+
+### PR #151 — Per-coroutine process isolation: constants, ini_set, statics, session locking
+**Triggered by:** Deep_Ad1959's define-time isolation question + concurrent session write race identification
+
+- **`App::defineIsolation(true)`:** Opt-in per-request constant cleanup via `zealphp_define_hook` + `zealphp_constants_clear`. Split by define-time: boot-time constants (PHP_VERSION, E_ALL, extension defines) survive; request-time userland `define()` calls are tracked and cleaned. Per-coroutine snapshot/restore on yield/resume for concurrent coroutines.
+- **`zealphp_ini_restore()`:** Restores all `ini_set()` modifications at request end via `zend_restore_ini_entry()`. Wired in CoSessionManager + SessionManager finally blocks.
+- **Static property snapshot/restore:** `CE_STATIC_MEMBERS` saved/restored per coroutine on yield/resume. Only processes accessed classes (lazy — skips cold classes).
+- **Session file locking:** `flock(LOCK_SH)` on read, `flock(LOCK_EX)` on write with re-read-merge-write under the lock. Apache mod_session parity. Closes the concurrent coroutine session race where two writers silently clobber each other.
+- **38 new unit tests:** DefineIsolationTest, LifecycleModeTest, SessionLifecycleModeTest, WorkerPoolExitFlagTest. Total: 3045 tests, 5838 assertions.
+
+### Deep_Ad1959's review arc — changes driven and pending
+
+| Topic | Status | What it drove |
+|---|---|---|
+| Federated WebSocket presence cleanup | Implemented (v0.2.40) | Deterministic owner sweep, soft sweeper lease, heartbeat+liveness |
+| ext-zealphp coroutine validation | Shipped (PR #150) | Forced-interleaving test methodology, SAPI parity discovery |
+| define-time vs namespace constant split | Shipped (PR #151) | `zealphp_define_hook` with define-time tracking, `App::defineIsolation()` |
+| Concurrent session write race | Shipped (PR #151) | `flock(LOCK_SH/LOCK_EX)` read-merge-write |
+| Connection pool poisoning | **Pending** | `PDOPool` + `RedisPool` with reset-on-checkout semantics |
+| Rust MongoDB driver tail-latency | **Pending** | p99.9 under concurrent burst (1-async-worker queue depth) |
+| Distributed stress test methodology | **Pending** | CTF-driven load test with coordinated student DDoS tool |
 
 ## Outstanding work — remaining v0.2.x items
 

--- a/src/App.php
+++ b/src/App.php
@@ -115,6 +115,21 @@ class App
     public static bool $coroutine_isolated_superglobals = false;
 
     /**
+     * Per-request define() isolation. When true, constants defined during
+     * a request are tracked and removed at request end. Boot-time constants
+     * (PHP_VERSION, extension defines, autoloaded class constants) survive.
+     *
+     * WARNING: breaks `require_once` apps — the file won't re-execute to
+     * re-define the constant on the next request. Use only with apps that
+     * guard defines (`defined('X') ?: define('X', ...)`) AND use `require`
+     * (not `require_once`) for the defining file, OR with processIsolation
+     * where each request gets a fresh process.
+     *
+     * Set via `App::defineIsolation(true)` BEFORE `App::run()`.
+     */
+    public static bool $define_isolation = false;
+
+    /**
      * Set true at the top of `App::run()` so the four lifecycle setters
      * (`superglobals`, `processIsolation`, `enableCoroutine`, `hookAll`)
      * can refuse mutations made AFTER the server has booted.
@@ -1615,6 +1630,17 @@ class App
         if ($v === true)  return \OpenSwoole\Runtime::HOOK_ALL;
         if ($v === false) return 0;
         return (int) $v;
+    }
+
+    /**
+     * Per-request define() isolation. Opt-in — see $define_isolation docblock.
+     */
+    public static function defineIsolation(?bool $on = null): bool
+    {
+        if ($on !== null) {
+            self::$define_isolation = $on;
+        }
+        return self::$define_isolation;
     }
 
     /**
@@ -6022,14 +6048,18 @@ HELP;
             self::$coroutine_isolated_superglobals = true;
         }
 
-        // Per-request define() / $GLOBALS / process-state isolation are
-        // available via ext-zealphp but NOT auto-activated. Any app using
-        // require_once for files that call define() (virtually all PHP apps)
-        // would break on request 2: require_once is a no-op, so cleaned
-        // constants are never re-defined. These primitives are for:
-        //   - The CGI pool worker (fresh process state per iteration)
-        //   - Apps that explicitly manage their own lifecycle
-        // Use processIsolation(true) for define()-heavy legacy apps.
+        // Per-request define() isolation — opt-in via App::defineIsolation(true).
+        // When enabled, ext-zealphp's define_hook intercepts define() calls,
+        // tracks request-scoped constants, and constants_clear() removes them
+        // at request end. Per-coroutine snapshot/restore on yield/resume
+        // handles concurrent coroutines. Boot-time constants survive.
+        // NOT auto-activated: require_once apps break (see docblock).
+        if (self::$define_isolation
+            && \extension_loaded('zealphp')
+            && \function_exists('zealphp_define_hook')
+        ) {
+            (\zealphp_define_hook(...))((bool) true);
+        }
         // @codeCoverageIgnoreEnd
 
         // Transparent coroutine-safe exec family. Overriding `shell_exec` ALSO

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -147,6 +147,9 @@ class CoSessionManager
             ) {
                 (\zealphp_constants_clear(...))();
             }
+            if (\function_exists('zealphp_ini_restore')) {
+                (\zealphp_ini_restore(...))();
+            }
         }
     }
 }

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -142,6 +142,11 @@ class CoSessionManager
             }
             $g->session = [];
             unset($g->session);
+            if (\ZealPHP\App::$define_isolation
+                && \function_exists('zealphp_constants_clear')
+            ) {
+                (\zealphp_constants_clear(...))();
+            }
         }
     }
 }

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -220,6 +220,9 @@ class SessionManager
             ) {
                 (\zealphp_constants_clear(...))();
             }
+            if (\function_exists('zealphp_ini_restore')) {
+                (\zealphp_ini_restore(...))();
+            }
         }
     }
 }

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -215,6 +215,11 @@ class SessionManager
                 $_SESSION = [];
                 unset($_SESSION);
             }
+            if (\ZealPHP\App::$define_isolation
+                && \function_exists('zealphp_constants_clear')
+            ) {
+                (\zealphp_constants_clear(...))();
+            }
         }
     }
 }

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -211,7 +211,17 @@ function zeal_session_start(): bool
     } else {
         $session_file = $save_path . '/sess_' . $session_id;
         if (file_exists($session_file)) {
-            $contents = @file_get_contents($session_file);
+            // Shared lock prevents reading a partially-written file
+            // from a concurrent write_close on another coroutine.
+            $fp = @fopen($session_file, 'r');
+            if ($fp !== false) {
+                flock($fp, LOCK_SH);
+                $contents = stream_get_contents($fp);
+                flock($fp, LOCK_UN);
+                fclose($fp);
+            } else {
+                $contents = false;
+            }
             if (is_string($contents) && $contents !== '') {
                 $session_data = php_session_decode_to_array($contents);
             }
@@ -419,8 +429,39 @@ function zeal_session_write_close(): bool
             /** @var array<string, mixed> $data */
             $wHandler->write((string) $session_id, php_session_encode_from_array($data));
         } else {
+            // File-based sessions: flock(LOCK_EX) serializes concurrent
+            // writes to the same session file (Apache mod_session parity).
+            // Without locking, two coroutines writing the same session race:
+            // the loser's changes are silently lost. The lock is held briefly
+            // (encode + write + flush) — negligible performance impact.
+            //
+            // Read-merge-write under the lock: re-read the file's current
+            // state (another coroutine may have written since our read at
+            // session_start), merge with our changes, write back.
             /** @var array<string, mixed> $data */
-            file_put_contents($session_file, php_session_encode_from_array($data));
+            $fp = fopen($session_file, 'c+');
+            if ($fp !== false) {
+                flock($fp, LOCK_EX);
+                $diskContents = stream_get_contents($fp);
+                if (is_string($diskContents) && $diskContents !== '') {
+                    $diskData = php_session_decode_to_array($diskContents);
+                    $current = $data;
+                    $data = array_merge($diskData, $current);
+                    foreach ($g->session_loaded_keys as $loadedKey) {
+                        if (!array_key_exists($loadedKey, $current)) {
+                            unset($data[$loadedKey]);
+                        }
+                    }
+                }
+                ftruncate($fp, 0);
+                rewind($fp);
+                fwrite($fp, php_session_encode_from_array($data));
+                fflush($fp);
+                flock($fp, LOCK_UN);
+                fclose($fp);
+            } else {
+                file_put_contents($session_file, php_session_encode_from_array($data));
+            }
         }
 
         // Mark inactive — in both modes. Unset the typed slot in coroutine

--- a/tests/Unit/DefineIsolationTest.php
+++ b/tests/Unit/DefineIsolationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+/**
+ * Tests for App::defineIsolation() and App::$define_isolation.
+ *
+ * defineIsolation() follows the same fluent getter/setter contract as the
+ * other App configurables: no-arg call returns current value; one-arg call
+ * sets and returns the new value.
+ */
+final class DefineIsolationTest extends TestCase
+{
+    private static bool $origDefineIsolation = false;
+    private static bool $origRunHasStarted = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$origDefineIsolation = App::$define_isolation;
+        self::$origRunHasStarted   = App::$run_has_started;
+    }
+
+    protected function setUp(): void
+    {
+        // Ensure setters are accepted (pre-boot state).
+        App::$run_has_started  = false;
+        App::$define_isolation = false;
+    }
+
+    protected function tearDown(): void
+    {
+        App::$run_has_started  = self::$origRunHasStarted;
+        App::$define_isolation = self::$origDefineIsolation;
+    }
+
+    // ── Getter behaviour ──────────────────────────────────────────────────
+
+    public function testDefaultIsFalse(): void
+    {
+        $this->assertFalse(App::defineIsolation());
+    }
+
+    public function testGetterReturnsCurrentBackingProperty(): void
+    {
+        App::$define_isolation = true;
+        $this->assertTrue(App::defineIsolation());
+
+        App::$define_isolation = false;
+        $this->assertFalse(App::defineIsolation());
+    }
+
+    // ── Setter behaviour ─────────────────────────────────────────────────
+
+    public function testSetterToTrue(): void
+    {
+        App::defineIsolation(true);
+        $this->assertTrue(App::$define_isolation);
+        $this->assertTrue(App::defineIsolation());
+    }
+
+    public function testSetterToFalse(): void
+    {
+        App::$define_isolation = true;
+        App::defineIsolation(false);
+        $this->assertFalse(App::$define_isolation);
+        $this->assertFalse(App::defineIsolation());
+    }
+
+    public function testSetterReturnsSameValueAfterSet(): void
+    {
+        $result = App::defineIsolation(true);
+        $this->assertTrue($result);
+
+        $result2 = App::defineIsolation(false);
+        $this->assertFalse($result2);
+    }
+
+    // ── Null arg (getter-only call) ──────────────────────────────────────
+
+    public function testNullArgActsAsGetter(): void
+    {
+        App::$define_isolation = true;
+        // Passing null explicitly should NOT change the value.
+        $result = App::defineIsolation(null);
+        $this->assertTrue($result);
+        $this->assertTrue(App::$define_isolation);
+    }
+}

--- a/tests/Unit/LifecycleModeTest.php
+++ b/tests/Unit/LifecycleModeTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+use ZealPHP\RequestContext;
+
+/**
+ * Tests for lifecycle mode features introduced alongside the 4-mode
+ * architecture (PR #150): App::$coroutine_isolated_superglobals, the
+ * processIsolation + enableCoroutine fallback wiring, and
+ * RequestContext::instance() per-coroutine branching under
+ * $coroutine_isolated_superglobals.
+ *
+ * These complement LifecycleModesMatrixTest which covers the five supported
+ * modes and the two refused combos. This file focuses on:
+ *
+ *   1. App::$coroutine_isolated_superglobals defaults false.
+ *   2. RequestContext::instance() uses per-coroutine branch when
+ *      $coroutine_isolated_superglobals is true (even though sg=true).
+ *   3. Lifecycle validator — sg=F + ec=F throws RuntimeException (Mode 2
+ *      refused combo pinned from LifecycleModesMatrixTest side for clarity).
+ *   4. sg=T + ec=T without ext-zealphp throws RuntimeException.
+ *   5. pi=T + ec=T + sg=T auto-forces ec=false (fallback wiring).
+ *   6. pi=T + ec=T + sg=F auto-forces pi=false (fallback wiring).
+ */
+final class LifecycleModeTest extends TestCase
+{
+    /** @var bool|null */
+    private static ?bool $origSg = null;
+    /** @var bool|null */
+    private static ?bool $origPi = null;
+    /** @var bool|null */
+    private static ?bool $origEc = null;
+    /** @var bool|int|null */
+    private static mixed $origHa = null;
+    private static bool $origCis = false;
+    private static bool $origRunHasStarted = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$origSg             = App::$superglobals;
+        self::$origPi             = App::$process_isolation;
+        self::$origEc             = App::$enable_coroutine_override;
+        self::$origHa             = App::$hook_all_override;
+        self::$origCis            = App::$coroutine_isolated_superglobals;
+        self::$origRunHasStarted  = App::$run_has_started;
+    }
+
+    protected function setUp(): void
+    {
+        App::$run_has_started = false;
+    }
+
+    protected function tearDown(): void
+    {
+        App::$run_has_started                  = self::$origRunHasStarted;
+        App::$superglobals                     = self::$origSg ?? true;
+        App::$process_isolation                = self::$origPi;
+        App::$enable_coroutine_override        = self::$origEc;
+        App::$hook_all_override                = self::$origHa;
+        App::$coroutine_isolated_superglobals  = self::$origCis;
+    }
+
+    // ── App::$coroutine_isolated_superglobals ─────────────────────────────
+
+    public function testCoroutineIsolatedSuperglobalsDefaultsFalse(): void
+    {
+        // The property default in the class definition must be false.
+        $default = (new \ReflectionClass(App::class))->getDefaultProperties()['coroutine_isolated_superglobals'] ?? null;
+        $this->assertFalse($default, 'coroutine_isolated_superglobals class default is false');
+    }
+
+    public function testCoroutineIsolatedSuperglobalsIsPublicBool(): void
+    {
+        $rp = new \ReflectionProperty(App::class, 'coroutine_isolated_superglobals');
+        $this->assertTrue($rp->isPublic());
+        $this->assertTrue($rp->isStatic());
+        $this->assertFalse(App::$coroutine_isolated_superglobals);
+    }
+
+    public function testCoroutineIsolatedSuperglobalsCanBeSetTrue(): void
+    {
+        App::$coroutine_isolated_superglobals = true;
+        $this->assertTrue(App::$coroutine_isolated_superglobals);
+    }
+
+    // ── RequestContext::instance() per-coroutine branch ───────────────────
+    //
+    // When $coroutine_isolated_superglobals is true, instance() uses the
+    // per-coroutine path even though $superglobals is true. Outside a
+    // coroutine context (getCid() < 0), the singleton fallback is used —
+    // so we verify the branch condition, not the coroutine dispatch (which
+    // requires a live coroutine scheduler).
+
+    public function testInstanceUsesCoroutineBranchConditionWhenCisTrue(): void
+    {
+        // Verify the instance() source code reflects the correct branch check.
+        // We do this via ReflectionMethod source rather than mocking the
+        // coroutine scheduler — the scheduler isn't running in PHPUnit.
+        $rm = new \ReflectionMethod(RequestContext::class, 'instance');
+        $file = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        // The branch must check BOTH flags — not just $superglobals.
+        $this->assertStringContainsString('coroutine_isolated_superglobals', $body,
+            'instance() must branch on coroutine_isolated_superglobals');
+        $this->assertStringContainsString('superglobals', $body,
+            'instance() must also check superglobals');
+    }
+
+    public function testInstanceConditionIsOrNotAnd(): void
+    {
+        // The condition must be: !sg OR cis — meaning cis=true alone routes
+        // to the per-coroutine path regardless of sg.
+        $rm = new \ReflectionMethod(RequestContext::class, 'instance');
+        $file = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        // The canonical form is: !App::$superglobals || App::$coroutine_isolated_superglobals
+        $this->assertMatchesRegularExpression(
+            '/!.*superglobals.*\|\|.*coroutine_isolated_superglobals/s',
+            $body,
+            'instance() condition must be !superglobals || coroutine_isolated_superglobals'
+        );
+    }
+
+    // ── Lifecycle validator — via ReflectionMethod ────────────────────────
+
+    /**
+     * Drive validateLifecycleCombination() directly (same helper pattern as
+     * LifecycleModesMatrixTest) so we exercise the throw without booting a server.
+     *
+     * @return \Throwable|null The caught exception, or null on no-throw.
+     */
+    private function validate(bool $sg, int $hookFlags, bool $enableCo): ?\Throwable
+    {
+        $rm = new \ReflectionMethod(App::class, 'validateLifecycleCombination');
+        $rm->setAccessible(true);
+        try {
+            $rm->invoke(null, $sg, $hookFlags, $enableCo);
+            return null;
+        } catch (\Throwable $e) {
+            return $e;
+        }
+    }
+
+    public function testMode2SgFalseEcFalseThrows(): void
+    {
+        $ex = $this->validate(false, 0, false);
+        $this->assertInstanceOf(\RuntimeException::class, $ex);
+        $this->assertStringContainsString(
+            'superglobals(false) + App::enableCoroutine(false)',
+            (string) $ex->getMessage()
+        );
+    }
+
+    public function testSgTrueEcTrueWithoutExtZealphpThrows(): void
+    {
+        if (\extension_loaded('zealphp')) {
+            $this->markTestSkipped('ext-zealphp makes this combination safe');
+        }
+        $ex = $this->validate(true, 0, true);
+        $this->assertInstanceOf(\RuntimeException::class, $ex);
+        $this->assertStringContainsString('ext-zealphp', (string) $ex->getMessage());
+        $this->assertStringContainsString('enableCoroutine(true)', (string) $ex->getMessage());
+    }
+
+    public function testSgTrueEcFalseHookZeroIsValid(): void
+    {
+        $this->assertNull($this->validate(true, 0, false), 'sg=T ec=F ha=0 is the legacy CGI mode — valid');
+    }
+
+    public function testSgFalseEcTrueHookAllIsValid(): void
+    {
+        $this->assertNull(
+            $this->validate(false, \OpenSwoole\Runtime::HOOK_ALL, true),
+            'sg=F ec=T ha=HOOK_ALL is coroutine mode — valid'
+        );
+    }
+
+    // ── pi + ec fallback wiring ────────────────────────────────────────────
+    //
+    // When processIsolation(true) + enableCoroutine(true), App resolves
+    // the conflict depending on superglobals:
+    //
+    //   sg=T + pi=T + ec=T  → ec forced false  (Legacy CGI wins; coroutine
+    //                         would race process-wide superglobals)
+    //   sg=F + pi=T + ec=T  → pi stays true    (Mode 6 hybrid is valid;
+    //                         ec stays true; validator passes for sg=F)
+    //
+    // These tests verify the RESOLVED knob values match the documented matrix,
+    // not the internal forcing logic (which lives in App::run() and requires
+    // a live server).  We pin the getter resolution shape.
+
+    public function testSgTruePiTrueEcNullResolvesEcFalse(): void
+    {
+        App::superglobals(true);
+        App::processIsolation(true);
+        App::enableCoroutine(null); // null → follows !sg → false
+
+        $this->assertTrue(App::processIsolation());
+        $this->assertFalse(App::enableCoroutine(),
+            'sg=T ec=null resolves to false (follows !sg)');
+        // Validator must pass for this resolved shape.
+        $this->assertNull($this->validate(true, 0, false));
+    }
+
+    public function testSgFalsePiTrueEcNullResolvesEcTrue(): void
+    {
+        App::superglobals(false);
+        App::processIsolation(true);
+        App::enableCoroutine(null); // null → follows !sg → true
+
+        $this->assertTrue(App::processIsolation());
+        $this->assertTrue(App::enableCoroutine(),
+            'sg=F ec=null resolves to true (follows !sg)');
+        // Validator must pass for this resolved shape (Mode 6 hybrid).
+        $this->assertNull($this->validate(false, \OpenSwoole\Runtime::HOOK_ALL, true));
+    }
+
+    public function testSgFalsePiExplicitTrueKeepsEcTrue(): void
+    {
+        // Mode 6: sg=false explicit pi=true explicit ec=null → ec resolves true.
+        App::superglobals(false);
+        App::processIsolation(true);
+        App::enableCoroutine(null);
+        App::hookAll(null);
+
+        $this->assertTrue(App::processIsolation(), 'explicit pi=true survives');
+        $this->assertTrue(App::enableCoroutine(), 'ec resolves true in sg=false mode');
+        $this->assertSame(\OpenSwoole\Runtime::HOOK_ALL, App::hookAll());
+
+        $this->assertNull(
+            $this->validate(false, \OpenSwoole\Runtime::HOOK_ALL, true),
+            'Mode 6 (sg=F pi=T ec=T) passes the validator'
+        );
+    }
+}

--- a/tests/Unit/SessionLifecycleModeTest.php
+++ b/tests/Unit/SessionLifecycleModeTest.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\App;
+use ZealPHP\RequestContext;
+use ZealPHP\Tests\TestCase;
+
+use function ZealPHP\Session\zeal_session_start;
+use function ZealPHP\Session\zeal_session_write_close;
+use function ZealPHP\Session\zeal_session_id;
+
+/**
+ * Tests for session behaviour that depends on lifecycle mode flags introduced
+ * in PR #150: App::$coroutine_isolated_superglobals, the early-return guard
+ * in zeal_session_start(), session_id stored in session_params, and
+ * zeal_session_write_close() reading from session_params['session_id'].
+ *
+ * All tests are pure unit tests — no running server required.
+ *
+ * Coverage targets:
+ *   - zeal_session_start() early-return when _session_started=true AND
+ *     coroutine_isolated_superglobals=true  (the double-start guard).
+ *   - zeal_session_start() runs full logic when _session_started=true but
+ *     coroutine_isolated_superglobals=false  (sync mode: second call is OK).
+ *   - zeal_session_start() always runs when _session_started=false.
+ *   - zeal_session_start() stores session_id in session_params['session_id'].
+ *   - zeal_session_write_close() reads session_params['session_id'] when set.
+ *   - zeal_session_write_close() falls back to zeal_session_id() when
+ *     session_params['session_id'] is absent.
+ *   - zeal_session_write_close() uses $g->session in cis=true mode.
+ *
+ * SessionManager._session_started reset is verified via SessionManager's
+ * __invoke() source — checked structurally (same guard pattern as
+ * CoSessionManagerTest for the constructor).
+ */
+final class SessionLifecycleModeTest extends TestCase
+{
+    private string $savePath;
+    /** @var bool|null */
+    private ?bool $savedSuperglobals = null;
+    private bool $savedCis = false;
+    private bool $savedSessionLifecycle = true;
+    /** @var mixed */
+    private mixed $savedSuperSession = null;
+
+    protected function setUp(): void
+    {
+        App::$cwd = dirname(__DIR__, 2);
+
+        $this->savedSuperglobals    = App::$superglobals;
+        $this->savedCis             = App::$coroutine_isolated_superglobals;
+        $this->savedSessionLifecycle = App::$session_lifecycle;
+        $this->savedSuperSession    = $GLOBALS['_SESSION'] ?? null;
+
+        // Default test mode: superglobals=true, cis=false (sync mode).
+        // Individual tests override as needed.
+        App::superglobals(true);
+        App::$coroutine_isolated_superglobals = false;
+        App::$session_lifecycle = true;
+
+        $this->savePath = sys_get_temp_dir() . '/zealphp_sess_lc_' . bin2hex(random_bytes(6));
+        @mkdir($this->savePath, 0700, true);
+
+        $g = RequestContext::instance();
+
+        // Re-initialize the declared typed `session` slot in coroutine mode
+        // (same guard pattern as SessionUtilsCoverageTest).
+        App::superglobals(false);
+        $g->session = [];
+        App::superglobals(true);
+
+        $g->session_params   = ['save_path' => $this->savePath, 'name' => 'PHPSESSID'];
+        $g->cookie           = [];
+        $g->server           = [];
+        $g->openswoole_response = null;
+        $g->_session_started = false;
+        $GLOBALS['_SESSION'] = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $g = RequestContext::instance();
+
+        App::superglobals(false);
+        $g->session = [];
+        App::superglobals(true);
+
+        $g->session_params   = [];
+        $g->cookie           = [];
+        $g->server           = [];
+        $g->openswoole_response = null;
+        $g->_session_started = false;
+
+        if ($this->savedSuperSession === null) {
+            unset($GLOBALS['_SESSION']);
+        } else {
+            $GLOBALS['_SESSION'] = $this->savedSuperSession;
+        }
+
+        App::$coroutine_isolated_superglobals = $this->savedCis;
+        App::$session_lifecycle               = $this->savedSessionLifecycle;
+        if ($this->savedSuperglobals !== null) {
+            App::superglobals($this->savedSuperglobals);
+        }
+
+        if (is_dir($this->savePath)) {
+            foreach (glob($this->savePath . '/*') ?: [] as $f) {
+                @unlink($f);
+            }
+            @rmdir($this->savePath);
+        }
+
+        parent::tearDown();
+    }
+
+    // ── Early-return guard (double-start protection) ──────────────────────
+
+    /**
+     * When _session_started=true AND coroutine_isolated_superglobals=true,
+     * a second call to zeal_session_start() must return true immediately
+     * without re-reading from disk or re-setting $g->session.
+     */
+    public function testStartEarlyReturnWhenAlreadyStartedAndCisTrue(): void
+    {
+        App::superglobals(true);
+        App::$coroutine_isolated_superglobals = true;
+
+        $g = RequestContext::instance();
+        $g->_session_started = true;
+
+        // Poison the session with a sentinel value before the second call.
+        // If start() re-ran, it would reset session to [] from the empty file.
+        App::superglobals(false);
+        $g->session = ['sentinel' => 'preserved'];
+        App::superglobals(true);
+
+        $result = zeal_session_start();
+
+        $this->assertTrue($result, 'early-return path still returns true');
+        // Session must not have been reset — early return skipped the disk read.
+        App::superglobals(false);
+        /** @phpstan-ignore-next-line isset.property */
+        $sessionValue = isset($g->session) ? ($g->session['sentinel'] ?? 'missing') : 'missing';
+        App::superglobals(true);
+        $this->assertSame('preserved', $sessionValue,
+            'session data must be unchanged when early-return fired');
+    }
+
+    /**
+     * When _session_started=true but coroutine_isolated_superglobals=false
+     * (sync mode), zeal_session_start() must run the full logic (no early return).
+     * We verify this by checking that session_params['session_id'] is populated,
+     * which only happens in the full code path.
+     */
+    public function testStartNoEarlyReturnWhenAlreadyStartedAndCisFalse(): void
+    {
+        App::superglobals(true);
+        App::$coroutine_isolated_superglobals = false;
+
+        $g = RequestContext::instance();
+        $g->_session_started = true;
+        unset($g->session_params['session_id']); // ensure it's absent before the call
+
+        $result = zeal_session_start();
+
+        $this->assertTrue($result);
+        // Full path was taken — session_id was stored in session_params.
+        $this->assertArrayHasKey('session_id', $g->session_params,
+            'full session_start path must store session_id in session_params');
+    }
+
+    /**
+     * When _session_started=false, start() always runs the full logic
+     * regardless of coroutine_isolated_superglobals value.
+     */
+    public function testStartRunsFullLogicWhenNotYetStarted(): void
+    {
+        App::superglobals(true);
+        App::$coroutine_isolated_superglobals = false;
+
+        $g = RequestContext::instance();
+        $g->_session_started = null;
+        unset($g->session_params['session_id']);
+
+        $result = zeal_session_start();
+
+        $this->assertTrue($result);
+        $this->assertArrayHasKey('session_id', $g->session_params);
+        $this->assertTrue($g->_session_started,
+            '_session_started must be true after successful start');
+    }
+
+    public function testStartRunsFullLogicWhenNotYetStartedAndCisTrue(): void
+    {
+        App::superglobals(true);
+        App::$coroutine_isolated_superglobals = true;
+
+        $g = RequestContext::instance();
+        $g->_session_started = null;
+        unset($g->session_params['session_id']);
+
+        $result = zeal_session_start();
+
+        $this->assertTrue($result);
+        $this->assertArrayHasKey('session_id', $g->session_params);
+        $this->assertTrue($g->_session_started);
+    }
+
+    // ── session_id stored in session_params ───────────────────────────────
+
+    public function testStartStoresSessionIdInSessionParams(): void
+    {
+        $g = RequestContext::instance();
+        $g->cookie = ['PHPSESSID' => 'test-sid-abc'];
+
+        zeal_session_start();
+
+        $this->assertArrayHasKey('session_id', $g->session_params,
+            'zeal_session_start must store session_id in session_params');
+        $this->assertSame('test-sid-abc', $g->session_params['session_id']);
+    }
+
+    public function testStartStoresGeneratedSessionIdWhenNoCookie(): void
+    {
+        $g = RequestContext::instance();
+        $g->cookie = []; // no incoming cookie → new ID generated
+
+        zeal_session_start();
+
+        $this->assertArrayHasKey('session_id', $g->session_params);
+        $stored = $g->session_params['session_id'];
+        $this->assertIsString($stored);
+        $this->assertNotEmpty($stored);
+    }
+
+    // ── zeal_session_write_close() reads session_params['session_id'] ──────
+
+    public function testWriteCloseReadsSessionIdFromSessionParams(): void
+    {
+        $g = RequestContext::instance();
+        $g->session_params['session_id'] = 'wc-sid-from-params';
+        $g->session_params['save_path']  = $this->savePath;
+
+        // Initialize session data via coroutine-mode write so it's present.
+        App::superglobals(false);
+        $g->session = ['key' => 'value'];
+        App::superglobals(true);
+        // In cis=false superglobals mode, write_close reads $GLOBALS['_SESSION'].
+        $GLOBALS['_SESSION'] = ['key' => 'value'];
+
+        $result = zeal_session_write_close();
+
+        $this->assertTrue($result);
+        $expectedFile = $this->savePath . '/sess_wc-sid-from-params';
+        $this->assertFileExists($expectedFile,
+            'write_close must use session_params[session_id] as the file name');
+    }
+
+    public function testWriteCloseUsesGSessionWhenCisTrue(): void
+    {
+        App::superglobals(true);
+        App::$coroutine_isolated_superglobals = true;
+
+        $g = RequestContext::instance();
+        $g->session_params['session_id'] = 'wc-cis-sid';
+        $g->session_params['save_path']  = $this->savePath;
+
+        // In cis=true mode, $g->session is the canonical store.
+        App::superglobals(false);
+        $g->session = ['cis_key' => 'cis_value'];
+        App::superglobals(true);
+
+        // Deliberately set GLOBALS to something different — write_close
+        // must use $g->session, not $GLOBALS['_SESSION'].
+        $GLOBALS['_SESSION'] = ['wrong_key' => 'wrong_value'];
+
+        $result = zeal_session_write_close();
+        $this->assertTrue($result);
+
+        $sessionFile = $this->savePath . '/sess_wc-cis-sid';
+        $this->assertFileExists($sessionFile);
+        $contents = (string) file_get_contents($sessionFile);
+        $this->assertStringContainsString('cis_key', $contents,
+            'write_close must persist $g->session contents when cis=true');
+        $this->assertStringNotContainsString('wrong_key', $contents,
+            'write_close must NOT use $GLOBALS[_SESSION] when cis=true');
+    }
+
+    public function testWriteCloseFallsBackToZealSessionIdWhenNoSessionParamId(): void
+    {
+        $g = RequestContext::instance();
+        // Explicitly absent from session_params.
+        unset($g->session_params['session_id']);
+        $g->cookie = ['PHPSESSID' => 'fallback-cookie-sid'];
+        $g->session_params['save_path'] = $this->savePath;
+        $GLOBALS['_SESSION'] = ['fb_key' => 'fb_value'];
+
+        $result = zeal_session_write_close();
+        $this->assertTrue($result);
+
+        $expectedFile = $this->savePath . '/sess_fallback-cookie-sid';
+        $this->assertFileExists($expectedFile,
+            'write_close falls back to zeal_session_id() when session_params[session_id] absent');
+    }
+
+    // ── SessionManager._session_started reset ────────────────────────────
+
+    /**
+     * Verify structurally that SessionManager.__invoke() resets _session_started
+     * to false at the start of each request invocation. We check the source
+     * directly (same approach as CoSessionManagerTest for contract pinning).
+     */
+    public function testSessionManagerResetsSessionStartedFlagAtRequestStart(): void
+    {
+        $rm = new \ReflectionMethod(\ZealPHP\Session\SessionManager::class, '__invoke');
+        $file  = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        $this->assertStringContainsString('_session_started', $body,
+            'SessionManager::__invoke must reference _session_started');
+        // The reset to false must be present.
+        $this->assertMatchesRegularExpression(
+            '/_session_started\s*=\s*false/',
+            $body,
+            'SessionManager::__invoke must reset _session_started to false'
+        );
+        // The reset must appear BEFORE the main request dispatch. We use the
+        // LAST call_user_func in the method body — that's the main middleware
+        // dispatch (not the early bench-mode path). The reset at the start of
+        // each request must come before the main dispatch call.
+        $resetPos       = (int) strpos($body, '_session_started         = false');
+        $lastDispatch   = (int) strrpos($body, 'call_user_func($this->middleware');
+        $this->assertGreaterThan(0, $resetPos,
+            '_session_started = false line must exist in __invoke');
+        $this->assertGreaterThan(0, $lastDispatch,
+            'main call_user_func($this->middleware) dispatch must exist');
+        $this->assertLessThan($lastDispatch, $resetPos,
+            '_session_started must be reset BEFORE the main middleware dispatch');
+    }
+
+    // ── CoSessionManager cgiOwnsSessions check ───────────────────────────
+
+    /**
+     * cgiOwnsSessions() returns true when sg=true AND processIsolation()=true.
+     * Both SessionManager and CoSessionManager gate $manageSession on this.
+     * Verify the condition logic via App::cgiOwnsSessions() directly.
+     */
+    public function testCgiOwnsSessionsTrueWhenSgTrueAndPiTrue(): void
+    {
+        App::$run_has_started = false;
+        App::superglobals(true);
+        App::processIsolation(true);
+
+        $this->assertTrue(App::cgiOwnsSessions(),
+            'cgiOwnsSessions() must return true when sg=T and pi=T');
+    }
+
+    public function testCgiOwnsSessionsFalseWhenPiFalse(): void
+    {
+        App::$run_has_started = false;
+        App::superglobals(true);
+        App::processIsolation(false);
+
+        $this->assertFalse(App::cgiOwnsSessions(),
+            'cgiOwnsSessions() must return false when pi=false (mixed-mode)');
+    }
+
+    public function testCgiOwnsSessionsFalseWhenSgFalse(): void
+    {
+        App::$run_has_started = false;
+        App::superglobals(false);
+        App::processIsolation(null); // follows sg=false → pi=false
+
+        $this->assertFalse(App::cgiOwnsSessions(),
+            'cgiOwnsSessions() must return false when sg=false (coroutine mode)');
+    }
+
+    /**
+     * CoSessionManager.__invoke sets $manageSession = false when
+     * cgiOwnsSessions() returns true. Verify the source includes both guards.
+     */
+    public function testCoSessionManagerGatesManageSessionOnCgiOwnsSessions(): void
+    {
+        $rm = new \ReflectionMethod(\ZealPHP\Session\CoSessionManager::class, '__invoke');
+        $file  = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        $this->assertStringContainsString('cgiOwnsSessions', $body,
+            'CoSessionManager::__invoke must check cgiOwnsSessions()');
+        $this->assertStringContainsString('session_lifecycle', $body,
+            'CoSessionManager::__invoke must check session_lifecycle');
+        // $manageSession is false when EITHER lifecycle flag is off OR cgi owns sessions.
+        $this->assertStringContainsString('manageSession', $body,
+            'CoSessionManager::__invoke must have a $manageSession variable');
+    }
+}

--- a/tests/Unit/WorkerPoolExitFlagTest.php
+++ b/tests/Unit/WorkerPoolExitFlagTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\CGI\WorkerPool;
+
+/**
+ * Tests for WorkerPool._exit flag behaviour (PR #150 / fix/pool-worker-exit-survival).
+ *
+ * When a pool subprocess calls exit() it fires a registered shutdown function
+ * that writes a final IPC frame with `_exit => true` before the process
+ * terminates. On the next dispatch() call that reads this frame, WorkerPool
+ * detects the flag and respawns the worker proactively — instead of waiting
+ * for the next request to fail with a broken pipe.
+ *
+ * Coverage targets:
+ *   - dispatch() source contains the _exit flag check and respawn call.
+ *   - The four respawn triggers (null resp, exitFlag, recycle limit, dead process)
+ *     are all present in dispatch().
+ *   - The exitFlag derivation is correct (is_array guard + _exit key).
+ *   - dispatch() with a normal response increments served count.
+ *   - dispatch() when response carries _exit=true triggers respawn
+ *     (served count resets to 0 on the new worker).
+ *   - dispatch() on a closed pool throws RuntimeException.
+ *
+ * Live-subprocess tests use minimal PHP stubs that correctly implement the
+ * WorkerPool IPC contract: emit "READY\n" on stderr, then loop reading and
+ * writing IPC frames.
+ */
+final class WorkerPoolExitFlagTest extends TestCase
+{
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /**
+     * Write a temporary stub PHP file and return its path. The caller is
+     * responsible for unlinking it after the test.
+     */
+    private function writeStub(string $body): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'zealphp_wp_stub_') . '.php';
+        $autoload = dirname(__DIR__, 2) . '/vendor/autoload.php';
+        file_put_contents($path, "<?php\nrequire " . var_export($autoload, true) . ";\nuse ZealPHP\\CGI\\IPC;\n" . $body);
+        return $path;
+    }
+
+    // ── Structural checks (no live subprocess needed) ─────────────────────
+
+    /**
+     * The dispatch() source must read the _exit key from the response frame
+     * and use it to decide whether to respawn the worker.
+     */
+    public function testDispatchSourceContainsExitFlagCheck(): void
+    {
+        $rm = new \ReflectionMethod(WorkerPool::class, 'dispatch');
+        $file  = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        $this->assertStringContainsString('_exit', $body,
+            'dispatch() must read the _exit flag from the response frame');
+        $this->assertStringContainsString('respawn', $body,
+            'dispatch() must call respawn when _exit flag is detected');
+        $this->assertStringContainsString('exitFlag', $body,
+            'dispatch() must use an $exitFlag variable (not inline the condition)');
+    }
+
+    /**
+     * The respawn condition must cover _exit, null response, recycle limit,
+     * and dead process — all four triggers must be present in dispatch().
+     */
+    public function testDispatchRespawnConditionCoversAllFourTriggers(): void
+    {
+        $rm = new \ReflectionMethod(WorkerPool::class, 'dispatch');
+        $file  = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        $this->assertStringContainsString('$resp === null', $body,
+            'dispatch() must handle null response (subprocess died)');
+        $this->assertStringContainsString('$exitFlag', $body,
+            'dispatch() must handle exitFlag');
+        $this->assertStringContainsString('maxRequestsPerWorker', $body,
+            'dispatch() must handle recycle limit');
+        $this->assertStringContainsString('isAlive', $body,
+            'dispatch() must check isAlive()');
+    }
+
+    /**
+     * The exitFlag must be derived from the response's _exit key with an
+     * is_array guard — not from a hardcoded string or a different field.
+     */
+    public function testExitFlagDerivationIsCorrect(): void
+    {
+        $rm = new \ReflectionMethod(WorkerPool::class, 'dispatch');
+        $file  = (string) $rm->getFileName();
+        $start = (int) $rm->getStartLine();
+        $end   = (int) $rm->getEndLine();
+
+        $lines = array_slice(file($file) ?: [], $start - 1, $end - $start + 1);
+        $body  = implode('', $lines);
+
+        $this->assertMatchesRegularExpression(
+            '/is_array\(\$resp\).*_exit/s',
+            $body,
+            "exitFlag derivation must guard is_array(\$resp) before accessing ['_exit']"
+        );
+    }
+
+    // ── Live dispatch — normal (non-exit) path ────────────────────────────
+
+    /**
+     * A normal request that completes successfully increments the served
+     * counter and returns the worker to the idle pool — pool size stays the same.
+     */
+    public function testNormalDispatchIncrementsServedCount(): void
+    {
+        // Stub: emits READY on stderr, then loops reading/writing IPC frames.
+        $stub = $this->writeStub(<<<'PHP'
+            fwrite(STDERR, "READY\n");
+            while (true) {
+                $req = IPC::readFrame(STDIN);
+                if ($req === null) break;
+                IPC::writeFrame(STDOUT, [
+                    'status'       => 200,
+                    'headers'      => [],
+                    'cookies'      => [],
+                    'body'         => 'ok',
+                    'return_value' => null,
+                ]);
+            }
+            PHP);
+
+        try {
+            $pool = new WorkerPool(1, 500, $stub);
+            $this->assertSame([0], $pool->servedCounts(), 'served=0 before any dispatch');
+
+            $resp = $pool->dispatch([
+                'file' => '/fake.php', 'server' => [], 'get' => [],
+                'post' => [], 'cookies' => [], 'files' => [], 'body' => '',
+            ]);
+
+            $this->assertSame(200, $resp['status'] ?? null, 'normal dispatch returns 200');
+            $this->assertSame([1], $pool->servedCounts(), 'served incremented to 1');
+            $this->assertSame(1, $pool->size(), 'pool size unchanged after normal dispatch');
+        } finally {
+            @unlink($stub);
+        }
+    }
+
+    /**
+     * When the response frame contains _exit=true the worker is respawned.
+     * After respawn the pool size is the same (new worker) and its served count
+     * is 0.
+     */
+    public function testExitFlagCausesRespawn(): void
+    {
+        // Stub: emits READY, handles one request with _exit=true, then exits.
+        // After respawn the replacement stub also emits READY and handles requests.
+        $stub = $this->writeStub(<<<'PHP'
+            fwrite(STDERR, "READY\n");
+            $req = IPC::readFrame(STDIN);
+            if ($req !== null) {
+                IPC::writeFrame(STDOUT, [
+                    'status'       => 200,
+                    'headers'      => [],
+                    'cookies'      => [],
+                    'body'         => 'exiting',
+                    'return_value' => null,
+                    '_exit'        => true,
+                ]);
+            }
+            // Process exits — WorkerPool must respawn it.
+            PHP);
+
+        try {
+            $pool = new WorkerPool(1, 500, $stub);
+
+            $resp = $pool->dispatch([
+                'file' => '/fake.php', 'server' => [], 'get' => [],
+                'post' => [], 'cookies' => [], 'files' => [], 'body' => '',
+            ]);
+
+            $this->assertSame(200, $resp['status'] ?? null);
+            $this->assertSame('exiting', $resp['body'] ?? null);
+
+            // Pool size is still 1 — respawn replaced the exiting worker.
+            $this->assertSame(1, $pool->size(),
+                'pool size must remain 1 after respawn triggered by _exit flag');
+
+            // The new worker has served=0 (fresh spawn).
+            $this->assertSame([0], $pool->servedCounts(),
+                'respawned worker served count must reset to 0');
+        } finally {
+            @unlink($stub);
+        }
+    }
+
+    // ── Closed pool guard ─────────────────────────────────────────────────
+
+    public function testDispatchOnClosedPoolThrows(): void
+    {
+        $stub = $this->writeStub(<<<'PHP'
+            fwrite(STDERR, "READY\n");
+            while (true) {
+                $req = IPC::readFrame(STDIN);
+                if ($req === null) break;
+                IPC::writeFrame(STDOUT, ['status' => 200, 'headers' => [], 'cookies' => [], 'body' => '']);
+            }
+            PHP);
+
+        try {
+            $pool = new WorkerPool(1, 500, $stub);
+            $pool->close();
+
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('already closed');
+            $pool->dispatch([]);
+        } finally {
+            @unlink($stub);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New opt-in API: `App::defineIsolation(true)` for per-request constant cleanup
- ext-zealphp: per-coroutine constant snapshot/restore on yield/resume
- Boot-time constants (PHP_VERSION, E_ALL, etc.) survive — never tracked

## Test plan
- [x] 5 sequential requests: `already_defined=false` on all (constants cleaned)
- [x] PHP_VERSION and E_ALL survive across requests
- [x] Session, Exit/die, CSRF: no regression
- [x] PHPStan level 10 clean, 3007 unit tests pass