### PR TITLE
fix(cgi): unmodified WordPress (wp-admin + block editor) in cgi-pool/proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+WordPress (and any legacy `require_once`-bootstrap app) now runs end-to-end in the **CGI-subprocess modes** — `cgi-pool` and `cgi-proc` — including **wp-admin and the Gutenberg block editor**, with **unmodified WordPress source**. All four fixes live entirely in ZealPHP's CGI worker layer; the in-process (`coroutine`/`mixed`) paths and `App.php` are unchanged. Huge thanks to **@Guruprasanth-M** for the rigorous, source-cited bug reports (#167, #169) and the reference patches this lands.
+
+### Fixed
+
+- **wp-admin no longer 500s with `uksort(): … null given` (#167).** The CGI worker now performs the request `include` at **true global scope** in the worker's top-level request loop instead of inside a function. A legacy app's top-level variables (WordPress's `$menu`/`$submenu`, built at file scope in `wp-admin/menu.php`) therefore become real `$GLOBALS`, so `global $menu` resolves and the admin menu builds. `src/pool_worker.php`'s `pool_handle_request()` was split into `pool_prepare_request()` (per-request setup) + `pool_finish_request()` (output capture / response), with the `include` hoisted to the caller. **Subprocess modes only** — the trick is structurally impossible on the in-process path (the include runs deep in the OpenSwoole event loop), so `coroutine`/`mixed` are unchanged.
+- **`cgiMode('proc')` no longer hangs on large responses (#167).** `Dispatcher::cgiSubprocess()` drained the child's stderr to EOF *before* reading stdout, which deadlocked once the response body exceeded the ~64 KB OS pipe buffer (the child blocked writing stdout nobody was reading; the parent blocked reading stderr the child wouldn't close). stdout and stderr are now drained **concurrently via `stream_select`** (non-blocking, bounded by `App::$cgi_timeout`), in both the buffered and SSE-streaming paths.
+- **WordPress media uploads work in `cgi-pool` (#169).** `src/pool_worker.php` now registers the `is_uploaded_file()` / `move_uploaded_file()` overrides (the same the proc worker already carried), resolving against the live per-request `$_FILES` so OpenSwoole-delivered uploads pass WordPress's `wp_handle_upload()` security gate (previously every upload failed with "Specified file failed upload test").
+
+### Added
+
+- **`ZealPHP\CGI\CgiInputStream`** — a `php://` stream wrapper for the CGI subprocesses that serves `php://input` from the request's raw body (stashed per request by the worker), so legacy code and the WordPress REST API (the block editor's JSON saves) can `file_get_contents('php://input')` under OpenSwoole, where native CLI `php://input` is empty. Other `php://` streams pass through to the original wrapper. The proc worker reads the body from STDIN; `Dispatcher` ships it in the pool IPC frame (skipping multipart, which rides `$_FILES`). Pinned by `tests/Unit/CGI/CgiInputStreamTest.php`.
+
 ## [0.3.7] - 2026-06-01
 
 A large maintenance + feature release. **`src/App.php` was broken down** (≈9,690 → ≈7,630 lines) into real classes — `ZealPHP\ResponseMiddleware` (the router/dispatch terminal), `ZealPHP\CLI` (server-lifecycle CLI), and `ZealPHP\CGI\Dispatcher` (the CGI execution machinery) — with the 1,085-line `App::run()` decomposed into named private boot steps. Every method moved **verbatim** (adversarially diff-verified against the pre-refactor file); the public `App::` API is unchanged. On top of that: **per-route + `App::when()` path-scoped middleware**, **dev route hot-reload** (`php app.php --dev`), an **Apache mod_php-parity `phpinfo()` redesign**, three security fixes, four bug fixes (#164, #157, #155, and the runtime-dir collision), a complete env-var reference, and the ext-zealphp `v0.3.25` pin.

--- a/src/CGI/CgiInputStream.php
+++ b/src/CGI/CgiInputStream.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\CGI;
+
+/**
+ * php:// stream wrapper for the CGI subprocesses (proc `cgi_worker.php` and the
+ * pooled `pool_worker.php`).
+ *
+ * It serves `php://input` from the CURRENT request's raw body, stashed in
+ * `$GLOBALS['__zeal_cgi_raw_input']` by the worker before the target file runs.
+ * This bridges an OpenSwoole-delivered request body (e.g. the JSON payload the
+ * WordPress block editor PUT/POSTs to the REST API) to legacy code that reads
+ * `file_get_contents('php://input')` — which native CLI `php://input` does NOT
+ * provide. Every other `php://` stream (memory/temp/filter/fd/…) passes through
+ * to the default wrapper unchanged.
+ *
+ * Counterpart to \ZealPHP\IOStreamWrapper (in-process modes, body from
+ * RequestContext). String-backed for input (no php://memory round-trip).
+ *
+ * NOTE: `$context` is RESERVED — PHP injects the stream context resource into it,
+ * so it must never be fclose()'d. The passthrough handle lives in `$fh`.
+ */
+class CgiInputStream
+{
+    /** @var resource|null PHP-injected stream context (reserved; never fclose). */
+    public $context;
+    /** @var resource|null Passthrough handle for non-input php:// streams. */
+    private $fh = null;
+    private string $input = '';
+    private int $pos = 0;
+    private bool $isInput = false;
+
+    /**
+     * @param string      $path
+     * @param string      $mode
+     * @param int         $options
+     * @param string|null $opened_path
+     */
+    public function stream_open($path, $mode, $options, &$opened_path): bool
+    {
+        if ($path === 'php://input') {
+            $b = $GLOBALS['__zeal_cgi_raw_input'] ?? '';
+            $this->input   = is_string($b) ? $b : '';
+            $this->pos     = 0;
+            $this->isInput = true;
+            return true;
+        }
+        // Delegate every other php:// stream to the original wrapper.
+        stream_wrapper_restore('php');
+        $h = @fopen($path, $mode);
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', self::class);
+        if ($h === false) {
+            return false;
+        }
+        $this->fh = $h;
+        return true;
+    }
+
+    /**
+     * @param int $count
+     * @return string|false
+     */
+    public function stream_read($count)
+    {
+        if ($this->isInput) {
+            if ($count < 1) {
+                return '';
+            }
+            $d = substr($this->input, $this->pos, (int) $count);
+            $this->pos += strlen($d);
+            return $d;
+        }
+        return is_resource($this->fh) ? fread($this->fh, max(1, (int) $count)) : false;
+    }
+
+    /**
+     * @param string $data
+     * @return int|false
+     */
+    public function stream_write($data)
+    {
+        return is_resource($this->fh) ? fwrite($this->fh, (string) $data) : false;
+    }
+
+    public function stream_eof(): bool
+    {
+        if ($this->isInput) {
+            return $this->pos >= strlen($this->input);
+        }
+        return is_resource($this->fh) ? feof($this->fh) : true;
+    }
+
+    /**
+     * @param int $offset
+     * @param int $whence
+     */
+    public function stream_seek($offset, $whence = SEEK_SET): bool
+    {
+        if ($this->isInput) {
+            $len = strlen($this->input);
+            $new = match ((int) $whence) {
+                SEEK_SET => (int) $offset,
+                SEEK_CUR => $this->pos + (int) $offset,
+                SEEK_END => $len + (int) $offset,
+                default  => -1,
+            };
+            if ($new < 0 || $new > $len) {
+                return false;
+            }
+            $this->pos = $new;
+            return true;
+        }
+        return is_resource($this->fh) ? fseek($this->fh, (int) $offset, (int) $whence) === 0 : false;
+    }
+
+    /** @return int */
+    public function stream_tell()
+    {
+        if ($this->isInput) {
+            return $this->pos;
+        }
+        return is_resource($this->fh) ? (int) ftell($this->fh) : 0;
+    }
+
+    /** @return array<int|string,mixed>|false */
+    public function stream_stat()
+    {
+        if ($this->isInput) {
+            return ['size' => strlen($this->input)];
+        }
+        return is_resource($this->fh) ? fstat($this->fh) : [];
+    }
+
+    /**
+     * @param int $option
+     * @param int $arg1
+     * @param int $arg2
+     */
+    public function stream_set_option($option, $arg1, $arg2): bool
+    {
+        return true; // no-op success — avoids "not implemented" warnings
+    }
+
+    public function stream_close(): void
+    {
+        if (is_resource($this->fh)) {
+            fclose($this->fh);
+        }
+        $this->fh = null;
+    }
+}

--- a/src/CGI/Dispatcher.php
+++ b/src/CGI/Dispatcher.php
@@ -442,15 +442,15 @@ class Dispatcher
             return 500;
         }
 
-        // Drain any remaining stderr after the metadata line and route via elog
-        // so PHP fatal errors / warnings from the subprocess are visible.
-        // Apache parity: cgi_common.h:103-126 log_script_err() reads child stderr line-by-line.
-        stream_set_blocking($pipes[2], true);
-        $stderrRemainder = stream_get_contents($pipes[2]);
-        fclose($pipes[2]);
-        if (is_string($stderrRemainder) && $stderrRemainder !== '') {
-            elog("[cgi_worker] stderr: " . rtrim($stderrRemainder), "cgi_worker");
-        }
+        // NOTE: stderr is deliberately NOT drained to EOF here. The worker writes
+        // the metadata line to stderr and THEN the (often >64 KB) body to stdout at
+        // shutdown; blocking on stderr-to-EOF before reading stdout deadlocks once
+        // the body exceeds the ~64 KB OS pipe buffer — the child blocks writing the
+        // stdout we aren't reading, while we block reading the stderr the child
+        // won't close until it exits (the WordPress-on-proc hang, Issue 3). stdout
+        // and any remaining stderr (for log visibility — Apache cgi_common.h:103-126
+        // log_script_err parity) are drained CONCURRENTLY below instead.
+        $stderrRemainder = '';
 
         $streaming   = false;
         $returnValue = null;
@@ -518,23 +518,41 @@ class Dispatcher
             }
         }
 
+        // ── Streaming (SSE) path: forward stdout to the client progressively,
+        // draining stderr non-blocking in the same select loop so warnings can
+        // never wedge the child (same pipe-ordering hazard as the buffered path).
         // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
         if ($streaming && $g->openswoole_response->isWritable()) {
             // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any route dispatches
             $g->zealphp_response->flush();
+            stream_set_blocking($pipes[1], false);
+            stream_set_blocking($pipes[2], false);
             while (!feof($pipes[1])) {
-                $chunk = fread($pipes[1], 8192);
-                if ($chunk === false || $chunk === '') {
-                    usleep(10000);
-                    continue;
+                $read = [$pipes[1], $pipes[2]];
+                $w = $e = null;
+                $sel = @stream_select($read, $w, $e, 1, 0);
+                if ($sel === false) { usleep(1000); continue; } // EINTR — retry
+                if ($sel === 0) { continue; }
+                foreach ($read as $stream) {
+                    $chunk = fread($stream, 65536);
+                    if ($chunk === false || $chunk === '') { continue; }
+                    if ($stream === $pipes[2]) { $stderrRemainder .= $chunk; continue; }
+                    // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                    if (!$g->openswoole_response->isWritable()) { break 2; }
+                    // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                    $g->openswoole_response->write($chunk);
                 }
-                // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
-                if (!$g->openswoole_response->isWritable()) break;
-                // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
-                $g->openswoole_response->write($chunk);
+            }
+            // Grab any stderr tail the child flushed as it exited (non-blocking).
+            while (($chunk = fread($pipes[2], 65536)) !== false && $chunk !== '') {
+                $stderrRemainder .= $chunk;
             }
             fclose($pipes[1]);
+            fclose($pipes[2]);
             proc_close($process);
+            if ($stderrRemainder !== '') {
+                elog("[cgi_worker] stderr: " . rtrim($stderrRemainder), "cgi_worker");
+            }
             // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
             if ($g->openswoole_response->isWritable()) {
                 // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
@@ -544,10 +562,44 @@ class Dispatcher
             return null;
         }
 
-        $body = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
+        // ── Buffered path: read stdout (body) and any remaining stderr (logging)
+        // CONCURRENTLY via stream_select, so an oversized body on stdout can never
+        // deadlock against an undrained stderr (Issue 3 — the WordPress-on-proc
+        // hang). Bounded by a fresh App::$cgi_timeout window so a wedged child can
+        // never pin the worker. stream_select yields the coroutine under HOOK_ALL
+        // and is a plain blocking syscall in legacy-cgi (no scheduler).
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+        $body = '';
+        $open = [1 => $pipes[1], 2 => $pipes[2]];
+        $drainDeadline = microtime(true) + App::$cgi_timeout;
+        while ($open !== []) {
+            if (microtime(true) >= $drainDeadline) {
+                elog("cgiSubprocess: stdout/stderr drain timeout after " . App::$cgi_timeout . "s for $path", "error");
+                break;
+            }
+            $read = array_values($open);
+            $w = $e = null;
+            $sel = @stream_select($read, $w, $e, 1, 0);
+            if ($sel === false) { usleep(1000); continue; } // EINTR (e.g. SIGCHLD) — retry
+            if ($sel === 0) { continue; }
+            foreach ($read as $stream) {
+                $fd = ($stream === $pipes[1]) ? 1 : 2;
+                $chunk = fread($stream, 65536);
+                if ($chunk === false || $chunk === '') {
+                    // select reported the pipe readable + an empty read = EOF.
+                    fclose($stream);
+                    unset($open[$fd]);
+                    continue;
+                }
+                if ($fd === 1) { $body .= $chunk; } else { $stderrRemainder .= $chunk; }
+            }
+        }
+        foreach ($open as $stream) { @fclose($stream); }
         proc_close($process);
-        $body = $body === false ? '' : $body;
+        if ($stderrRemainder !== '') {
+            elog("[cgi_worker] stderr: " . rtrim($stderrRemainder), "cgi_worker");
+        }
 
         // Surface the file's return value when it was explicit (int / array /
         // string). Trust the subprocess: when return_value is non-null AND
@@ -808,6 +860,27 @@ class Dispatcher
         // cgi_worker.php's ZEALPHP_REQUEST_CONTEXT env JSON.
         // RequestContext properties are typed non-nullable arrays — no
         // need for `?? []` guards.
+        // Raw request body for php://input (e.g. a JSON REST payload from the WP
+        // block editor). Skip multipart/form-data — those ride $_FILES (tmp file
+        // already on disk); shipping the full multipart blob through the IPC frame
+        // would bloat it (and a large upload could exceed IPC's 64 MB cap).
+        $rawBody = '';
+        $ct = '';
+        foreach ($g->server as $k => $v) {
+            $kl = strtolower((string) $k);
+            if ($kl === 'content_type' || $kl === 'http_content_type' || $kl === 'content-type') {
+                $ct = is_scalar($v) ? (string) $v : '';
+                break;
+            }
+        }
+        if (stripos($ct, 'multipart/form-data') === false) {
+            try {
+                // @phpstan-ignore-next-line — zealphp_request set by CoSessionManager before dispatch
+                $rawBody = (string) $g->zealphp_request->parent->getContent();
+            } catch (\Throwable $e) {
+                $rawBody = '';
+            }
+        }
         $request = [
             'file'    => $path,
             'server'  => $g->server,
@@ -815,6 +888,7 @@ class Dispatcher
             'post'    => $g->post,
             'cookies' => $g->cookie,
             'files'   => $g->files,
+            'body'    => $rawBody,
         ];
 
         try {

--- a/src/cgi_worker.php
+++ b/src/cgi_worker.php
@@ -376,6 +376,16 @@ if (!$__z_file || !file_exists($__z_file)) {
 $__z_cwd = getenv('ZEALPHP_CWD');
 if ($__z_cwd) chdir($__z_cwd);
 
+// Bridge php://input: the parent (Dispatcher) wrote the request body to our STDIN
+// and closed it, but native CLI php://input does NOT expose that. Read it here and
+// serve it via CgiInputStream so legacy code / the WP REST API (the block editor's
+// JSON save) can read file_get_contents('php://input'). Other php:// pass through.
+// (Also drains STDIN so a >64 KB POST body can't block the parent's pipe write.)
+$GLOBALS['__zeal_cgi_raw_input'] = (string) (@stream_get_contents(STDIN) ?: '');
+require_once __DIR__ . '/CGI/CgiInputStream.php';
+@stream_wrapper_unregister('php');
+@stream_wrapper_register('php', \ZealPHP\CGI\CgiInputStream::class);
+
 register_shutdown_function(function() {
     global $__z_meta_sent;
     __z_send_meta();

--- a/src/pool_worker.php
+++ b/src/pool_worker.php
@@ -57,6 +57,16 @@ foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php
 
 use ZealPHP\CGI\IPC;
 
+// Bridge php://input to the request's raw body (REST/JSON payloads) for legacy
+// code in this pooled subprocess — mirrors \ZealPHP\IOStreamWrapper (in-process
+// modes) and cgi_worker.php (proc). CgiInputStream serves the CURRENT request's
+// body from $GLOBALS['__zeal_cgi_raw_input'], set per request by
+// pool_prepare_request; every other php:// stream passes through.
+require_once __DIR__ . '/CGI/CgiInputStream.php';
+$GLOBALS['__zeal_cgi_raw_input'] = '';
+@stream_wrapper_unregister('php');
+@stream_wrapper_register('php', \ZealPHP\CGI\CgiInputStream::class);
+
 $maxRequests = (int) (getenv('ZEALPHP_POOL_MAX_REQUESTS') ?: '500');
 $count       = 0;
 
@@ -389,6 +399,58 @@ if (function_exists('zealphp_override') || function_exists('uopz_set_return')) {
         // response flow through the normal shutdown path.
         return true;
     }, true);
+
+    // is_uploaded_file() / move_uploaded_file() — bridge OpenSwoole-delivered
+    // uploads to legacy code (same overrides cgi_worker.php carries for proc).
+    // The pool repopulates $_FILES per request (pool_prepare_request), so these
+    // resolve against the LIVE $_FILES superglobal at call time, not a boot
+    // snapshot. WITHOUT them, PHP's native is_uploaded_file() runs — and its
+    // SAPI upload list is empty under OpenSwoole — so WordPress's
+    // wp_handle_upload() fails every media upload with "Specified file failed
+    // upload test." (handles both scalar and array `tmp_name` shapes).
+    $z_override('is_uploaded_file', function (string $filename): bool {
+        foreach ($_FILES as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $tmp = $entry['tmp_name'] ?? null;
+            if (is_array($tmp)) {
+                if (in_array($filename, $tmp, true)) {
+                    return true;
+                }
+            } elseif (is_string($tmp) && $tmp === $filename) {
+                return true;
+            }
+        }
+        return false;
+    }, true);
+
+    $z_override('move_uploaded_file', function (string $from, string $to): bool {
+        $isUpload = false;
+        foreach ($_FILES as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $tmp = $entry['tmp_name'] ?? null;
+            if ((is_array($tmp) && in_array($from, $tmp, true))
+                || (is_string($tmp) && $tmp === $from)) {
+                $isUpload = true;
+                break;
+            }
+        }
+        if (!$isUpload) {
+            return false;
+        }
+        // rename within a filesystem; copy+unlink across (e.g. /tmp → uploads).
+        if (@rename($from, $to)) {
+            return true;
+        }
+        if (@copy($from, $to)) {
+            @unlink($from);
+            return true;
+        }
+        return false;
+    }, true);
 }
 
 // Drain any output buffering that may have been auto-started so PHP errors
@@ -447,7 +509,22 @@ while ($count < $maxRequests) {
     }
 
     $__pw_mid_request = true;
-    $resp = pool_handle_request($req);
+    // Run the include AT GLOBAL SCOPE (not inside pool_handle_request) so a
+    // legacy app's top-level variables become real $GLOBALS. [Issue 1]
+    $__pw_prep = pool_prepare_request($req);
+    if (isset($__pw_prep['__error'])) {
+        $resp = $__pw_prep['__error'];
+    } else {
+        $__pw_inc_result = null;
+        $__pw_inc_error  = null;
+        try {
+            /** @psalm-suppress UnresolvableInclude */
+            $__pw_inc_result = include $__pw_prep['file'];
+        } catch (\Throwable $__pw_e) {
+            $__pw_inc_error = $__pw_e;
+        }
+        $resp = pool_finish_request($__pw_inc_result, $__pw_inc_error, $__pw_prep['prevCwd']);
+    }
 
     // FD-3 IPC happy path: body goes to STDOUT, metadata frame goes to fd 3.
     // The metadata frame carries `body_length` so the parent reads exactly
@@ -484,22 +561,27 @@ while ($count < $maxRequests) {
 exit(0);
 
 /**
+ * Prepare per-request state and return the file to include + the prior cwd.
+ * The `include` itself is performed by the CALLER at GLOBAL scope (see the
+ * request loop) — NOT here — so a legacy app's top-level variables
+ * ($menu / $submenu in WP's wp-admin) become real `$GLOBALS`. Including from
+ * inside a function made them function-locals, so WP's `global $menu` resolved
+ * to null and `uksort($menu, …)` fataled. [Issue 1: include scope]
+ *
  * @param array<mixed,mixed> $req
- * @return array<string,mixed>
+ * @return array{file:string,prevCwd:mixed}|array{__error:array<string,mixed>}
  */
-function pool_handle_request(array $req): array
+function pool_prepare_request(array $req): array
 {
-    global $__pw_headers, $__pw_cookies, $__pw_rawcookies, $__pw_status;
-
     $file = isset($req['file']) && is_string($req['file']) ? $req['file'] : '';
     if ($file === '' || !is_file($file)) {
-        return [
+        return ['__error' => [
             'status'     => 404,
             'body'       => "pool_worker: file not found: $file",
             'headers'    => [],
             'cookies'    => [],
             'rawcookies' => [],
-        ];
+        ]];
     }
 
     // Populate request-input superglobals. Merging $_SERVER (rather than
@@ -512,28 +594,47 @@ function pool_handle_request(array $req): array
     $_FILES   = is_array($req['files']   ?? null) ? $req['files']   : [];
     $_REQUEST = array_merge($_GET, $_POST);
 
+    // Raw request body for php://input (CgiInputStream serves it). IPC base64s
+    // the body only when it isn't valid UTF-8 (binary); decode that case.
+    $__pw_body = $req['body'] ?? '';
+    if (is_string($__pw_body) && ($req['body_encoding'] ?? '') === 'base64') {
+        $__pw_body = (string) base64_decode($__pw_body, true);
+    }
+    $GLOBALS['__zeal_cgi_raw_input'] = is_string($__pw_body) ? $__pw_body : '';
+
     $prevCwd = getcwd();
     chdir(dirname($file));
 
     ob_start();
-    $result = null;
-    try {
-        /** @psalm-suppress UnresolvableInclude */
-        $result = include $file;
-    } catch (\Throwable $e) {
-        ob_end_clean();
+    return ['file' => $file, 'prevCwd' => $prevCwd];
+}
+
+/**
+ * Capture output and build the response AFTER the global-scope include.
+ *
+ * @param mixed           $result   the include's return value (null if it threw)
+ * @param \Throwable|null $error    exception thrown by the include, if any
+ * @param mixed           $prevCwd  cwd to restore
+ * @return array<string,mixed>
+ */
+function pool_finish_request(mixed $result, ?\Throwable $error, mixed $prevCwd): array
+{
+    global $__pw_headers, $__pw_cookies, $__pw_rawcookies, $__pw_status;
+
+    if ($error !== null) {
+        while (ob_get_level() > 0) { ob_end_clean(); }
         if (is_string($prevCwd)) chdir($prevCwd);
         return [
             'status'     => 500,
-            'body'       => 'pool_worker fatal: ' . $e->getMessage(),
+            'body'       => 'pool_worker fatal: ' . $error->getMessage(),
             'headers'    => [],
             'cookies'    => [],
             'rawcookies' => [],
-            'stderr'     => $e->getTraceAsString(),
+            'stderr'     => $error->getTraceAsString(),
         ];
     }
     if (is_string($prevCwd)) chdir($prevCwd);
-    
+
     // Execute registered shutdown functions before capturing the output buffer.
     // CRITICAL: clear each entry from $__pw_shutdown_functions as it runs.
     // If a user shutdown function calls exit() (phpMyAdmin's
@@ -607,6 +708,7 @@ function pool_reset_request_state(): void
     $_FILES   = [];
     $_REQUEST = [];
     $_SESSION = null;
+    $GLOBALS['__zeal_cgi_raw_input'] = '';
 
     $__pw_headers    = [];
     $__pw_cookies    = [];

--- a/tests/Unit/CGI/CgiInputStreamTest.php
+++ b/tests/Unit/CGI/CgiInputStreamTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\CGI;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\CGI\CgiInputStream;
+
+/**
+ * Unit coverage for the CGI subprocess php:// stream wrapper.
+ *
+ * CgiInputStream serves `php://input` from $GLOBALS['__zeal_cgi_raw_input']
+ * (the per-request raw body the pool/proc worker stashes) so legacy code and
+ * the WordPress REST API can `file_get_contents('php://input')` under
+ * OpenSwoole, where native CLI php://input is empty. Every other php:// stream
+ * passes through to the original wrapper.
+ *
+ * The wrapper is registered as the 'php' handler for each test and restored in
+ * tearDown so no other test sees the swap.
+ */
+class CgiInputStreamTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', CgiInputStream::class);
+    }
+
+    protected function tearDown(): void
+    {
+        stream_wrapper_restore('php');
+        unset($GLOBALS['__zeal_cgi_raw_input']);
+        parent::tearDown();
+    }
+
+    public function testPhpInputServesStashedBody(): void
+    {
+        $GLOBALS['__zeal_cgi_raw_input'] = '{"hello":"world"}';
+        $this->assertSame('{"hello":"world"}', file_get_contents('php://input'));
+    }
+
+    public function testPhpInputEmptyWhenNothingStashed(): void
+    {
+        unset($GLOBALS['__zeal_cgi_raw_input']);
+        $this->assertSame('', file_get_contents('php://input'));
+    }
+
+    public function testChunkedReadThenEof(): void
+    {
+        $GLOBALS['__zeal_cgi_raw_input'] = 'abcdef';
+        $h = fopen('php://input', 'r');
+        $this->assertIsResource($h);
+        $this->assertSame('abc', fread($h, 3));
+        $this->assertSame('def', fread($h, 3));
+        $this->assertTrue(feof($h));
+        $this->assertSame('', fread($h, 3)); // nothing left
+        fclose($h);
+    }
+
+    public function testSeekTellAndStatSize(): void
+    {
+        $GLOBALS['__zeal_cgi_raw_input'] = 'abcdefghij'; // 10 bytes
+        $h = fopen('php://input', 'r');
+        $this->assertIsResource($h);
+        $this->assertSame(0, ftell($h));
+        $this->assertSame(0, fseek($h, 4, SEEK_SET));   // SEEK_SET
+        $this->assertSame(4, ftell($h));
+        $this->assertSame('ef', fread($h, 2));          // pos → 6
+        $this->assertSame(0, fseek($h, 2, SEEK_CUR));   // SEEK_CUR → pos 8
+        $this->assertSame('ij', fread($h, 5));
+        $this->assertSame(0, fseek($h, -3, SEEK_END));  // SEEK_END → pos 7
+        $this->assertSame('hij', fread($h, 99));
+        $st = fstat($h);
+        $this->assertIsArray($st);
+        $this->assertSame(10, $st['size']);
+        fclose($h);
+    }
+
+    public function testSeekOutOfRangeFails(): void
+    {
+        $GLOBALS['__zeal_cgi_raw_input'] = 'abc';
+        $h = fopen('php://input', 'r');
+        $this->assertIsResource($h);
+        $this->assertSame(-1, fseek($h, 100, SEEK_SET)); // beyond EOF → stream_seek false → fseek -1
+        $this->assertSame(-1, fseek($h, -1, SEEK_SET));  // negative → false
+        fclose($h);
+    }
+
+    public function testNonInputPhpStreamPassesThrough(): void
+    {
+        // php://temp must still work — the wrapper delegates non-input streams
+        // to the original php handler.
+        $h = fopen('php://temp', 'r+');
+        $this->assertIsResource($h);
+        $this->assertSame(11, fwrite($h, 'passthrough'));
+        rewind($h);
+        $this->assertSame('passthrough', stream_get_contents($h));
+        fclose($h);
+    }
+}

--- a/tests/Unit/CGI/CgiSubprocessTest.php
+++ b/tests/Unit/CGI/CgiSubprocessTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\CGI;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+use ZealPHP\CGI\Dispatcher;
+use ZealPHP\RequestContext;
+
+/**
+ * End-to-end coverage for Dispatcher::cgiSubprocess() — the proc-mode CGI path
+ * that spawns src/cgi_worker.php and reads back the response. Exercises the
+ * concurrent stdout/stderr stream_select drain (the Issue 3 deadlock fix),
+ * header/status/cookie application from the metadata frame, the explicit
+ * return-value contract, and the SSE streaming branch.
+ *
+ * $g->zealphp_response / openswoole_response are `mixed` slots, so a no-op stub
+ * stands in for the OpenSwoole response a real request would carry. No server
+ * boot needed; stream_select is a plain blocking syscall outside a coroutine.
+ */
+class CgiSubprocessTest extends TestCase
+{
+    private static string $tmpDir = '';
+    /** @var array<int,string> */
+    private array $fixtures = [];
+    /** @var int|bool|null */
+    private $origPi;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$tmpDir = sys_get_temp_dir() . '/zealphp_cgisub_' . getmypid();
+        if (!is_dir(self::$tmpDir)) {
+            mkdir(self::$tmpDir, 0777, true);
+        }
+        App::$cwd = ZEALPHP_ROOT;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$tmpDir !== '' && is_dir(self::$tmpDir)) {
+            foreach (glob(self::$tmpDir . '/*') ?: [] as $f) {
+                @unlink($f);
+            }
+            @rmdir(self::$tmpDir);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Keep cgiOwnsSessions() false so mintCgiSession() is a no-op.
+        $this->origPi = App::$process_isolation;
+        App::$process_isolation = false;
+
+        $g = RequestContext::instance();
+        $g->server = ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => '/', 'SERVER_NAME' => 'localhost'];
+        $g->get = [];
+        $g->post = [];
+        $g->cookie = [];
+        $g->files = [];
+        $g->env = [];
+        $g->status = null;
+        $g->zealphp_response = $this->responseStub();
+        $g->openswoole_response = $this->openswooleStub();
+        $g->zealphp_request = $this->requestStub();
+    }
+
+    protected function tearDown(): void
+    {
+        App::$process_isolation = $this->origPi;
+        foreach ($this->fixtures as $f) {
+            if (is_file($f)) {
+                @unlink($f);
+            }
+        }
+        $this->fixtures = [];
+        parent::tearDown();
+    }
+
+    private function responseStub(): object
+    {
+        return new class {
+            /** @var array<string,string> */
+            public array $headers = [];
+            /** @var array<int,array<mixed>> */
+            public array $cookies = [];
+            public function header(mixed $k, mixed $v): void { $this->headers[(string) $k] = (string) $v; }
+            public function cookie(mixed ...$a): void { $this->cookies[] = $a; }
+            public function rawCookie(mixed ...$a): void { $this->cookies[] = $a; }
+            public function __call(string $n, array $a): mixed { return true; }
+        };
+    }
+
+    private function openswooleStub(): object
+    {
+        return new class {
+            public string $written = '';
+            public function isWritable(): bool { return true; }
+            public function isEstablished(): bool { return true; }
+            public function write(mixed $c): bool { $this->written .= (string) $c; return true; }
+            public function __call(string $n, array $a): mixed { return true; }
+        };
+    }
+
+    /** Stub the request wrapper so cgiSubprocess() can read the POST body for STDIN. */
+    private function requestStub(): object
+    {
+        return new class {
+            public object $parent;
+            public function __construct()
+            {
+                $this->parent = new class {
+                    public string $body = '';
+                    public function getContent(): string { return $this->body; }
+                };
+            }
+        };
+    }
+
+    private function fixture(string $name, string $php): string
+    {
+        $path = self::$tmpDir . '/' . $name;
+        file_put_contents($path, $php);
+        $this->fixtures[] = $path;
+        return $path;
+    }
+
+    public function testBufferedResponseReturnsEchoedBody(): void
+    {
+        $f = $this->fixture('plain.php', "<?php\necho 'HELLO-CGI';\n");
+        $this->assertSame('HELLO-CGI', Dispatcher::cgiSubprocess($f));
+    }
+
+    public function testLargeBodyDrainedAcrossMultipleIterations(): void
+    {
+        // > the ~64 KB OS pipe buffer → the drain loop iterates and the body
+        // can't deadlock against undrained stderr (the Issue 3 fix).
+        $f = $this->fixture('big.php', "<?php\necho str_repeat('A', 200000);\n");
+        $out = Dispatcher::cgiSubprocess($f);
+        $this->assertIsString($out);
+        $this->assertSame(200000, strlen($out));
+    }
+
+    public function testStderrWarningsDoNotWedgeTheResponse(): void
+    {
+        // error_log() writes to the child's stderr; the concurrent drain must
+        // read it without blocking the stdout body.
+        $f = $this->fixture('warn.php', "<?php\nerror_log('a noisy warning');\necho 'body-ok';\n");
+        $this->assertSame('body-ok', Dispatcher::cgiSubprocess($f));
+    }
+
+    public function testHeadersAndStatusFromMetadataAreApplied(): void
+    {
+        $f = $this->fixture('hdr.php', "<?php\nheader('X-Foo: bar');\nheader('Status: 201 Created');\necho 'made';\n");
+        $out = Dispatcher::cgiSubprocess($f);
+        $this->assertSame('made', $out);
+        $this->assertSame(201, RequestContext::instance()->status, 'Status: header sets the response status');
+        $resp = RequestContext::instance()->zealphp_response;
+        $this->assertSame('bar', $resp->headers['X-Foo'] ?? null, 'custom header applied to the response');
+        $this->assertArrayNotHasKey('Status', $resp->headers, 'Status: pseudo-header is stripped, not forwarded');
+    }
+
+    public function testExplicitReturnValueRidesTheContract(): void
+    {
+        $f = $this->fixture('ret.php', "<?php\nreturn 404;\n");
+        $this->assertSame(404, Dispatcher::cgiSubprocess($f), 'an explicit int return becomes the status');
+    }
+
+    public function testPostBodyReachesSubprocessViaPhpInput(): void
+    {
+        // The body is written to the child's STDIN; cgi_worker.php reads it and
+        // serves it via CgiInputStream, so file_get_contents('php://input') in
+        // the target file sees it (the WP REST / block-editor bridge).
+        RequestContext::instance()->zealphp_request->parent->body = 'payload=42&x=y';
+        $f = $this->fixture('input.php', "<?php\necho file_get_contents('php://input');\n");
+        $this->assertSame('payload=42&x=y', Dispatcher::cgiSubprocess($f));
+    }
+
+    public function testEchoThenStringReturnConcatenates(): void
+    {
+        // echo-shell-then-return-body idiom: a string return is folded onto the
+        // echoed output (matches executeFile()).
+        $f = $this->fixture('echoret.php', "<?php\necho 'shell-';\nreturn 'body';\n");
+        $this->assertSame('shell-body', Dispatcher::cgiSubprocess($f));
+    }
+
+    public function testSseStreamingPathWritesToTheResponse(): void
+    {
+        $f = $this->fixture('sse.php', "<?php\nheader('Content-Type: text/event-stream');\necho \"data: stream-hi\\n\\n\";\n");
+        $out = Dispatcher::cgiSubprocess($f);
+        // The streaming branch writes to openswoole_response and returns null.
+        $this->assertNull($out);
+        $this->assertStringContainsString('data: stream-hi', RequestContext::instance()->openswoole_response->written);
+    }
+}


### PR DESCRIPTION
Lands the CGI-worker fixes that make **unmodified WordPress** run end-to-end in the subprocess modes (`cgi-pool`, `cgi-proc`) — **including wp-admin and the Gutenberg block editor**. Investigated against a live working instance: **WordPress source is 100% stock** (only the standard SQLite `db.php` drop-in); `App.php` (the in-process path) is **byte-identical**; all changes are in ZealPHP's CGI worker layer. Reference patches + the rigorous source-cited reports by **@Guruprasanth-M** (#167, #169).

## Fixes

- **wp-admin `uksort(): … null given` (#167-1).** The worker now performs the request `include` at **true global scope** in its top-level request loop instead of inside `pool_handle_request()`. WordPress builds `$menu`/`$submenu` as *file-scope* variables in `wp-admin/menu.php`; including from a function made them function-locals, so `global $menu` was null and `uksort($menu, …)` fataled. Split into `pool_prepare_request()` + `pool_finish_request()` with the `include` hoisted to the caller. **Subprocess modes only** — structurally impossible in-process (the include runs deep in the OpenSwoole event loop), which is exactly why `App.php` is untouched.
- **`cgiMode('proc')` hang (#167-3).** `Dispatcher::cgiSubprocess()` drained stderr to EOF before reading stdout → deadlock once the body exceeded the ~64 KB OS pipe buffer. Now drains stdout+stderr **concurrently via `stream_select`** (non-blocking, bounded by `App::$cgi_timeout`), buffered + SSE paths.
- **Media uploads in `cgi-pool` (#169).** `pool_worker.php` now registers `is_uploaded_file`/`move_uploaded_file` overrides against the live `$_FILES`, so `wp_handle_upload()` accepts OpenSwoole-delivered uploads.
- **New `ZealPHP\CGI\CgiInputStream`** — serves `php://input` from the request body for CGI subprocesses (WP REST / block-editor JSON saves). Pinned by `tests/Unit/CGI/CgiInputStreamTest.php`.

## Verification

- Empirical (live instance): `GET /wp-admin/` → 200, 124 KB Dashboard, **zero `uksort`/Fatal**; `edit.php`/`options-general.php`/`upload.php`/`plugins.php`/`post-new.php` (Gutenberg, 680 KB) all render with the admin menu; public site renders styled.
- PHPStan L10 **clean**; **220** CGI/pool/worker tests + **6** `CgiInputStream` tests green.

## Scope

Closes #169. Addresses #167 sub-issues **1** and **3** (the umbrella also tracks 2/4/5/6/7 — docs + BC-default items — left open). No `src/App.php` / in-process-mode changes; purely additive to the CGI subprocess path.