### PR TITLE
docs(src): codebase-wide PHPDoc quality pass — backticks, fenced blocks, missing docblocks

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -16,6 +16,26 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use OpenSwoole\Coroutine as co;
+/**
+ * ZealPHP framework core — the single process-wide singleton that owns the
+ * OpenSwoole server lifecycle, route table, PSR-15 middleware stack, and all
+ * per-request lifecycle configuration.
+ *
+ * Typical boot sequence:
+ *
+ * ```php
+ * App::superglobals(false);          // choose lifecycle mode
+ * $app = App::init('0.0.0.0', 8080); // create singleton + install overrides
+ * $app->route('/hello', fn() => 'Hello!');
+ * $app->addMiddleware(new CorsMiddleware());
+ * $app->run();                        // start the OpenSwoole event loop
+ * ```
+ *
+ * Configuration is expressed as static fluent setters (e.g. `App::superglobals()`,
+ * `App::documentRoot()`) that MUST be called before `App::run()` — OpenSwoole
+ * freezes the server settings at `$server->start()`. See the "Architecture"
+ * section of `CLAUDE.md` for the full lifecycle-mode matrix.
+ */
 class App
 {
     /** @var array<int, array{path:string,pattern:string,methods:array<int|string,string>,handler:callable|null,param_map:array<int,array<string, mixed>>,raw:bool,middleware:list<\Psr\Http\Server\MiddlewareInterface|string>}> */
@@ -58,6 +78,7 @@ class App
     protected static array $reliableRegistry = [];
     /** True once the onWorkerStart hook for pubsub/streams is wired (one-time guard). */
     protected static bool $pubsubBootWired = false;
+    /** Unix timestamp (float) of the moment this worker's `onWorkerStart` callback finished — used by `App::stats()` to compute per-worker uptime. Zero until the first worker start fires. */
     protected static float $workerStartedAt = 0.0;
 
     // v0.3.0 helpers — registries for App::onSignal / App::addProcess and
@@ -74,7 +95,9 @@ class App
     protected static ?int $bootedAt = null;
     /** Resolved worker counts after `run()` reads CLI/env/settings. */
     protected static int $worker_num = 0;
+    /** Resolved task-worker count after `run()` reads CLI/env/settings. Zero when task workers are disabled. */
     protected static int $task_worker_num = 0;
+    /** Bind address for the OpenSwoole server (e.g. `'0.0.0.0'` or `'127.0.0.1'`). Set in `__construct()` from `App::init()`. */
     protected string $host;
     // Widened protected → public so ZealPHP\CLI (extracted from App.php in the
     // Phase 1 decomposition) can read the running instance's port for PID-file
@@ -828,9 +851,19 @@ class App
      * @var callable|null
      */
     public static $auth_checker = null;
-    /** @var callable|null */
+    /**
+     * Callback consulted by `ZealAPI::isAdmin()`. Signature: `fn(): bool`.
+     * Default `null` → `isAdmin()` returns `false` (fail-closed). Set via `App::adminChecker()`.
+     *
+     * @var callable|null
+     */
     public static $admin_checker = null;
-    /** @var callable|null */
+    /**
+     * Callback consulted by `ZealAPI::getUsername()`. Signature: `fn(): ?string`.
+     * Default `null` → `getUsername()` returns `null`. Set via `App::usernameProvider()`.
+     *
+     * @var callable|null
+     */
     public static $username_provider = null;
     /**
      * Apache `RewriteCond %{REQUEST_FILENAME} !-d` + `RewriteRule ^(.+)/$ /$1 [R=301,L]`.
@@ -1176,6 +1209,22 @@ class App
         return (new Response('', $streamStatus));
     }
 
+    /**
+     * Private constructor — use `App::init()` to obtain the singleton instance.
+     *
+     * Performs one-time per-process setup: validates that ext-zealphp or uopz is
+     * loaded, reads `/etc/environment` into `$_ENV`, captures the initial
+     * `error_reporting()` level, installs the process-level native error and
+     * exception handlers (which delegate to the per-coroutine `RequestContext`
+     * stack), primes `PhpInfo::primeModuleText()`, and calls
+     * `registerAllOverrides()` to replace PHP built-ins with ZealPHP's
+     * coroutine-safe equivalents.
+     *
+     * @param string $host Bind address (e.g. `'0.0.0.0'`).
+     * @param int    $port TCP port.
+     * @param string $cwd  Project root — stored in `App::$cwd`.
+     * @throws \Exception when neither ext-zealphp nor uopz is loaded.
+     */
     private function __construct(string $host = '0.0.0.0', int $port = 8080, string $cwd = __DIR__)
     {
         if (!extension_loaded('zealphp') && !extension_loaded('uopz')) {
@@ -1345,11 +1394,33 @@ class App
      * `$superglobals` etc. leaves the framework in a partial state that
      * races on `$_GET`/`$_POST`/`$_SESSION`. Boot-only is the contract.
      *
-     * Called from `superglobals`, `processIsolation`, `enableCoroutine`,
-     * `hookAll` setters when they receive a write (not a read).
+     * Called from `superglobals()`, `processIsolation()`, `enableCoroutine()`,
+     * and `hookAll()` setters when they receive a write (not a read).
+     *
+     * @throws \RuntimeException when called after `App::run()` has started.
      */
+    private static function refuseAfterRun(string $setter): void
+    {
+        if (self::$run_has_started) {
+            throw new \RuntimeException(
+                "ZealPHP lifecycle: $setter() must be called BEFORE App::run(). "
+                . 'These four knobs (superglobals, processIsolation, enableCoroutine, hookAll) '
+                . 'decide the SessionManager class, the enable_coroutine server setting, and '
+                . 'HOOK_ALL — all frozen at run() boot. Mutating them after the server is '
+                . 'serving requests leaves the framework in a Schrödinger state (coroutines '
+                . 'still active, but per-request handlers now read the new superglobals value) '
+                . 'and races on $_GET / $_POST / $_SESSION. Configure these once in app.php '
+                . 'before App::run() and leave them alone.'
+            );
+        }
+    }
+
     /**
-     * @param callable-string $callable
+     * Install a uopz or ext-zealphp override for a named PHP built-in function,
+     * routing calls to the given ZealPHP replacement. Uses `zealphp_override()`
+     * when ext-zealphp is loaded (preferred), falling back to `uopz_set_return()`.
+     *
+     * @param callable-string $callable Fully-qualified ZealPHP replacement function name.
      */
     private static function overrideBuiltin(string $name, string $callable): void
     {
@@ -1361,8 +1432,18 @@ class App
         }
     }
 
+    /** Guard preventing `registerAllOverrides()` from installing uopz/zealphp built-in overrides more than once per process. */
     private static bool $overridesRegistered = false;
 
+    /**
+     * Install all ZealPHP uopz/ext-zealphp built-in overrides in one shot.
+     * Idempotent — guarded by `$overridesRegistered` so re-entrant calls
+     * (e.g. from tests that re-construct `App`) are no-ops. Covers response
+     * headers (`header()`, `setcookie()`, etc.), session functions
+     * (`session_start()` family), output control (`flush()`, `ob_*`),
+     * error handling (`set_error_handler()`, `error_log()`), and more.
+     * Called once from `__construct()`.
+     */
     private static function registerAllOverrides(): void
     {
         if (self::$overridesRegistered) {
@@ -1429,22 +1510,11 @@ class App
         self::overrideBuiltin('session_module_name', '\ZealPHP\Session\zeal_session_module_name');
     }
 
-    private static function refuseAfterRun(string $setter): void
-    {
-        if (self::$run_has_started) {
-            throw new \RuntimeException(
-                "ZealPHP lifecycle: $setter() must be called BEFORE App::run(). "
-                . 'These four knobs (superglobals, processIsolation, enableCoroutine, hookAll) '
-                . 'decide the SessionManager class, the enable_coroutine server setting, and '
-                . 'HOOK_ALL — all frozen at run() boot. Mutating them after the server is '
-                . 'serving requests leaves the framework in a Schrödinger state (coroutines '
-                . 'still active, but per-request handlers now read the new superglobals value) '
-                . 'and races on $_GET / $_POST / $_SESSION. Configure these once in app.php '
-                . 'before App::run() and leave them alone.'
-            );
-        }
-    }
-
+    /**
+     * Toggle the superglobals-mode lifecycle. See `App::$superglobals` for the full
+     * semantics. Must be called BEFORE `App::run()` — the method calls `refuseAfterRun()`
+     * and throws `\RuntimeException` if the server is already serving requests.
+     */
     public static function superglobals(bool $enable = true): void
     {
         self::refuseAfterRun('App::superglobals');
@@ -1473,18 +1543,32 @@ class App
     // documented API surface and what the converter bot is taught to emit.
     // -----------------------------------------------------------------------
 
+    /**
+     * Whether URLs ending in `.php` are blocked with `403`. Default `true` (Apache
+     * `RewriteRule \.php$ - [F]` parity). Set `false` to allow direct `*.php` routing.
+     * No-arg call returns the current value.
+     */
     public static function ignorePhpExt(?bool $on = null): bool
     {
         if ($on !== null) self::$ignore_php_ext = $on;
         return self::$ignore_php_ext;
     }
 
+    /**
+     * Whether ZealAPI logs a warning when a filename collides with an HTTP method keyword
+     * (e.g. `get.php` defining `$get`) or a filename-matched handler shadows per-method
+     * handlers. Default `true`. No-arg call returns the current value.
+     */
     public static function apiWarnCollisions(?bool $on = null): bool
     {
         if ($on !== null) self::$api_warn_collisions = $on;
         return self::$api_warn_collisions;
     }
 
+    /**
+     * Apache `DirectorySlash` — redirect `/foo` → `/foo/` when `foo` is a directory.
+     * Default `true`. No-arg call returns the current value.
+     */
     public static function directorySlash(?bool $on = null): bool
     {
         if ($on !== null) self::$directory_slash = $on;
@@ -1501,6 +1585,11 @@ class App
         return self::$directory_index;
     }
 
+    /**
+     * Apache `PATH_INFO` — expose the path suffix after a script name as `PATH_INFO`
+     * in `$_SERVER` (e.g. `/script.php/extra/path` → `PATH_INFO=/extra/path`).
+     * Default `true`. No-arg call returns the current value.
+     */
     public static function pathInfo(?bool $on = null): bool
     {
         if ($on !== null) self::$path_info = $on;
@@ -1508,6 +1597,11 @@ class App
     }
 
     /**
+     * URL-prefix whitelist for static-file serving. Empty array (default) allows
+     * any path under `document_root`. When non-empty, only paths whose prefix
+     * matches one of the listed strings are served as static files; others fall
+     * through to route matching. No-arg call returns the current list.
+     *
      * @param array<int, string>|null $prefixes
      * @return array<int, string>
      */
@@ -1517,12 +1611,23 @@ class App
         return self::$static_handler_locations;
     }
 
+    /**
+     * Block any request whose path contains a dotfile component (`.git`, `.env`,
+     * `.htaccess`, etc.) with `403`. Default `true` — matches Apache's convention
+     * of not serving hidden files. No-arg call returns the current value.
+     */
     public static function blockDotfiles(?bool $on = null): bool
     {
         if ($on !== null) self::$block_dotfiles = $on;
         return self::$block_dotfiles;
     }
 
+    /**
+     * Whether framework error pages render the captured exception and stack trace
+     * inline. Default `true` (development-friendly). Set `false` in production so
+     * `5xx` pages show a generic message instead of leaking internal details.
+     * No-arg call returns the current value.
+     */
     public static function displayErrors(?bool $on = null): bool
     {
         if ($on !== null) self::$display_errors = $on;

--- a/src/CGI/CgiInputStream.php
+++ b/src/CGI/CgiInputStream.php
@@ -33,10 +33,13 @@ class CgiInputStream
     private bool $isInput = false;
 
     /**
-     * @param string      $path
-     * @param string      $mode
-     * @param int         $options
-     * @param string|null $opened_path
+     * Open `php://input` from `$GLOBALS['__zeal_cgi_raw_input']`, or delegate any other
+     * `php://` URI to the default PHP wrapper by temporarily restoring it.
+     *
+     * @param string      $path        The `php://` URI being opened.
+     * @param string      $mode        The access mode (e.g. `'r'`, `'rb'`).
+     * @param int         $options     Bitmask of `STREAM_*` flags from PHP.
+     * @param string|null $opened_path Set to the actual path opened (unused here).
      */
     public function stream_open($path, $mode, $options, &$opened_path): bool
     {
@@ -60,8 +63,10 @@ class CgiInputStream
     }
 
     /**
-     * @param int $count
-     * @return string|false
+     * Read up to `$count` bytes. Returns `''` when `$count < 1` on the `php://input` path.
+     *
+     * @param int $count Number of bytes to read.
+     * @return string|false The bytes read, or `false` when the passthrough handle is gone.
      */
     public function stream_read($count)
     {
@@ -77,14 +82,17 @@ class CgiInputStream
     }
 
     /**
-     * @param string $data
-     * @return int|false
+     * Write `$data` to the passthrough handle (not applicable to `php://input`).
+     *
+     * @param string $data The bytes to write.
+     * @return int|false Number of bytes written, or `false` when no passthrough handle is open.
      */
     public function stream_write($data)
     {
         return is_resource($this->fh) ? fwrite($this->fh, (string) $data) : false;
     }
 
+    /** Returns `true` when all `php://input` bytes are consumed, or when the passthrough handle is at EOF. */
     public function stream_eof(): bool
     {
         if ($this->isInput) {
@@ -94,8 +102,10 @@ class CgiInputStream
     }
 
     /**
-     * @param int $offset
-     * @param int $whence
+     * Seek to a position; supports `SEEK_SET`, `SEEK_CUR`, `SEEK_END` on the `php://input` buffer.
+     *
+     * @param int $offset Byte offset relative to `$whence`.
+     * @param int $whence One of `SEEK_SET`, `SEEK_CUR`, or `SEEK_END`.
      */
     public function stream_seek($offset, $whence = SEEK_SET): bool
     {
@@ -116,7 +126,11 @@ class CgiInputStream
         return is_resource($this->fh) ? fseek($this->fh, (int) $offset, (int) $whence) === 0 : false;
     }
 
-    /** @return int */
+    /**
+     * Return the current read position in bytes from the start of the stream.
+     *
+     * @return int Byte offset.
+     */
     public function stream_tell()
     {
         if ($this->isInput) {
@@ -125,7 +139,12 @@ class CgiInputStream
         return is_resource($this->fh) ? (int) ftell($this->fh) : 0;
     }
 
-    /** @return array<int|string,mixed>|false */
+    /**
+     * Return stat information. For `php://input` provides a minimal array with `'size'`;
+     * for passthrough handles delegates to `fstat()`.
+     *
+     * @return array<int|string, mixed>|false Stat array, or `false` when unavailable.
+     */
     public function stream_stat()
     {
         if ($this->isInput) {
@@ -135,15 +154,18 @@ class CgiInputStream
     }
 
     /**
-     * @param int $option
-     * @param int $arg1
-     * @param int $arg2
+     * No-op option handler — always returns `true` to suppress PHP "not implemented" warnings.
+     *
+     * @param int $option One of the `STREAM_OPTION_*` constants.
+     * @param int $arg1   Option-specific argument 1.
+     * @param int $arg2   Option-specific argument 2.
      */
     public function stream_set_option($option, $arg1, $arg2): bool
     {
         return true; // no-op success — avoids "not implemented" warnings
     }
 
+    /** Close the stream, releasing the passthrough handle when one was opened for a non-input `php://` URI. */
     public function stream_close(): void
     {
         if (is_resource($this->fh)) {

--- a/src/CGI/WorkerPool.php
+++ b/src/CGI/WorkerPool.php
@@ -71,10 +71,24 @@ final class WorkerPool
     /** @var list<int> Idle worker indices — primary queue at boot + the fallback when no coroutine context. */
     private array $idleSync = [];
 
+    /** `true` after the sync idle queue has been migrated into `$idleChan` on the first coroutine dispatch. */
     private bool $channelPopulated = false;
+    /** `true` after `close()` has been called; prevents double-close and guards `dispatch()`. */
     private bool $closed = false;
+    /** Total number of worker slots allocated at construction (immutable after `__construct()`). */
     private readonly int $size;
 
+    /**
+     * Spawn `$size` worker subprocesses immediately. All workers are ready
+     * (READY signal received) before the constructor returns.
+     *
+     * @param int         $size                   Number of persistent worker subprocesses (pool concurrency).
+     * @param int         $maxRequestsPerWorker   Requests served before a worker is recycled (`pm.max_requests` parity).
+     * @param string|null $workerEntry            Absolute path to the pool worker entry script;
+     *                                            defaults to `src/pool_worker.php`.
+     * @throws \InvalidArgumentException When `$size < 1`.
+     * @throws \RuntimeException         When a worker subprocess fails to start or doesn't emit `READY` within 10 s.
+     */
     public function __construct(
         int $size = 4,
         private readonly int $maxRequestsPerWorker = 500,
@@ -452,6 +466,12 @@ final class WorkerPool
         ];
     }
 
+    /**
+     * Close all pipes for the worker at `$idx`, reap the subprocess via
+     * `proc_close()`, spawn a fresh replacement, and immediately return it
+     * to the idle pool. Called when a worker dies mid-request, hits its
+     * `$maxRequestsPerWorker` limit, or sends the `_exit` flag in its IPC frame.
+     */
     private function respawn(int $idx): void
     {
         $old = $this->workers[$idx];

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -19,6 +19,14 @@ use function ZealPHP\elog;
 class CLI
 {
     /**
+     * Parse `$argv`, execute any lifecycle sub-command, and return server-config overrides.
+     *
+     * Sub-commands (`stop`, `status`, `logs`, `restart`) are handled in-process and
+     * call `exit()` when done. The `start` / default path returns an array of
+     * OpenSwoole `$server->set()` override keys (`_host`, `_port`, `worker_num`,
+     * `daemonize`, etc.) that `App::run()` merges into its config. Returns an
+     * empty array when no overrides are needed.
+     *
      * @return array<string, mixed>
      */
     public static function parseCliArgs(): array
@@ -203,7 +211,17 @@ class CLI
     }
 
     /**
-     * @param array<string, mixed> $flags
+     * Resolve the PID file path for the given CLI flags.
+     *
+     * Resolution order (first match wins):
+     * 1. `--pid-file` flag (`$flags['pid_file']`).
+     * 2. `ZEALPHP_PID_FILE` environment variable.
+     * 3. `ZEALPHP_LOG_DIR` env var + `zealphp_{port}.pid`.
+     * 4. `resolve_log_dir()` result (per-user fallback) + `zealphp_{port}.pid`.
+     *
+     * Creates the parent directory when it does not exist.
+     *
+     * @param array<string, mixed> $flags Parsed CLI flags from `parseCliArgs()`.
      */
     public static function resolvePidFile(array $flags): string
     {
@@ -236,6 +254,10 @@ class CLI
         return "{$dir}/zealphp_{$port}.pid";
     }
 
+    /**
+     * Ensure `$dir` exists and is writable, creating it recursively if needed.
+     * Logs a warning via `elog()` when creation fails — never throws.
+     */
     private static function ensurePidDir(string $dir): void
     {
         if (!is_dir($dir)) {
@@ -391,6 +413,14 @@ class CLI
         return true;
     }
 
+    /**
+     * Stop the server identified by `$pidFile`.
+     *
+     * Sends `SIGTERM` to the process group (or PID), polls up to 10 s for graceful
+     * shutdown, then falls back to `SIGKILL`. Removes the PID file on success.
+     * When the PID file is missing or stale, calls `claimOrphanIfAny()` to handle
+     * a running-but-unregistered daemon. Output is suppressed when `$quiet` is `true`.
+     */
     private static function cliStop(string $pidFile, bool $quiet = false): void
     {
         $say = function (string $msg) use ($quiet): void {
@@ -447,6 +477,13 @@ class CLI
         @unlink($pidFile);
     }
 
+    /**
+     * Stop all running ZealPHP instances when no specific port is given.
+     *
+     * Globs `{logDir}/zealphp_*.pid`, verifies each PID with `processIsZealphp()`,
+     * and stops the lone instance automatically. When multiple instances are found,
+     * lists them and asks the user to specify a port with `-p PORT`.
+     */
     private static function cliStopAuto(): void
     {
         $logDir = getenv('ZEALPHP_LOG_DIR');
@@ -627,6 +664,10 @@ class CLI
         passthru($cmd);
     }
 
+    /**
+     * Print the `php app.php --help` usage text to stdout and return.
+     * The caller is responsible for calling `exit(0)` after this.
+     */
     private static function cliHelp(): void
     {
         echo <<<'HELP'

--- a/src/Counter/MemcachedCounterBackend.php
+++ b/src/Counter/MemcachedCounterBackend.php
@@ -49,6 +49,7 @@ final class MemcachedCounterBackend implements CounterBackend
         }
     }
 
+    /** Return the current integer value of counter `$name`, or `0` if the key does not exist. */
     public function get(string $name): int
     {
         /** @var mixed $r */
@@ -56,11 +57,16 @@ final class MemcachedCounterBackend implements CounterBackend
         return is_numeric($r) ? (int) $r : 0;
     }
 
+    /** Unconditionally set counter `$name` to `$value`. Returns `true` on success. */
     public function set(string $name, int $value): bool
     {
         return $this->client->set($this->key($name), $value);
     }
 
+    /**
+     * Set counter `$name` to `$value` only when the key does not already exist
+     * (`Memcached::add()` SETNX semantics). Returns `false` when the key already exists.
+     */
     public function setIfAbsent(string $name, int $value): bool
     {
         // Memcached::add only sets when the key doesn't exist — perfect
@@ -68,6 +74,10 @@ final class MemcachedCounterBackend implements CounterBackend
         return $this->client->add($this->key($name), $value);
     }
 
+    /**
+     * Atomically increment counter `$name` by `$by` and return the new value.
+     * Lazily initialises the key to `0` on first call (two round-trips cold, one hot).
+     */
     public function incr(string $name, int $by = 1): int
     {
         $k = $this->key($name);
@@ -84,6 +94,10 @@ final class MemcachedCounterBackend implements CounterBackend
         return is_numeric($r) ? (int) $r : 0;
     }
 
+    /**
+     * Atomically decrement counter `$name` by `$by` and return the new value.
+     * Lazily initialises the key to `0` on first call (same two-round-trip cold path as `incr()`).
+     */
     public function decr(string $name, int $by = 1): int
     {
         $k = $this->key($name);
@@ -94,6 +108,10 @@ final class MemcachedCounterBackend implements CounterBackend
         return is_numeric($r) ? (int) $r : 0;
     }
 
+    /**
+     * Atomically compare-and-swap counter `$name` using `Memcached::gets()` + `cas()`.
+     * Returns `false` when the current value differs from `$expected` or the CAS token race is lost.
+     */
     public function compareAndSet(string $name, int $expected, int $new): bool
     {
         $k = $this->key($name);
@@ -106,6 +124,11 @@ final class MemcachedCounterBackend implements CounterBackend
         return $this->client->cas($cas, $k, $new);
     }
 
+    /**
+     * Increment `$name` by `$by` only when the result would not exceed `$maxBound`.
+     * Implemented as a CAS retry loop (max 100 attempts). Returns the new value, or
+     * `null` when the bound would be exceeded or contention exhausted all attempts.
+     */
     public function incrBounded(string $name, int $by, int $maxBound): ?int
     {
         // CAS retry loop. Bounded at 100 attempts to avoid infinite spin
@@ -131,6 +154,11 @@ final class MemcachedCounterBackend implements CounterBackend
         return null;
     }
 
+    /**
+     * Set a TTL of `$seconds` on counter `$name` via `Memcached::touch()`.
+     * Returns `false` when the key does not exist. Note: `incr()`/`decr()` do not
+     * accept a TTL parameter in the Memcached protocol, so TTL applies only on first creation.
+     */
     public function expire(string $name, int $seconds): bool
     {
         // Memcached::touch sets a new TTL on an existing key. Returns
@@ -139,6 +167,13 @@ final class MemcachedCounterBackend implements CounterBackend
         return $this->client->touch($this->key($name), $seconds);
     }
 
+    /**
+     * Increment multiple counters sequentially. Memcached has no native multi-increment;
+     * for high-throughput bulk increments prefer the Redis backend.
+     *
+     * @param  array<string, int> $deltas  Counter name → increment amount.
+     * @return array<string, int> Counter name → new value after increment.
+     */
     public function mincr(array $deltas): array
     {
         // Sequential — Memcached has no native MINCR. Pipelining wouldn't
@@ -151,11 +186,13 @@ final class MemcachedCounterBackend implements CounterBackend
         return $out;
     }
 
+    /** Reset counter `$name` to `0`. Creates the key if it does not exist. */
     public function reset(string $name): void
     {
         $this->client->set($this->key($name), 0);
     }
 
+    /** Build the namespaced Memcached key for counter `$name` using the configured `$prefix`. */
     private function key(string $name): string
     {
         return $this->prefix . ':counter:' . $name;

--- a/src/G.php
+++ b/src/G.php
@@ -6,6 +6,7 @@
 // exists so PSR-4 autoloading still finds the old name and triggers the
 // canonical class to load.
 
-// `G` for `$GLOBALS` (coroutine safe) - just a backwards compatibility alias for `RequestContext`.
+// `G` (mnemonic: "globals", coroutine-safe) — a backward-compatibility alias
+// for `RequestContext`. New code should use `RequestContext` directly.
 
 require_once __DIR__ . '/RequestContext.php';

--- a/src/HTTP.php
+++ b/src/HTTP.php
@@ -50,13 +50,15 @@ final class HTTPResponse
  * For the common case — JSON request/response, short timeout, a handful
  * of headers — this is one call:
  *
- *     $r = HTTP::get('https://api.example.com/users', ['Authorization' => 'Bearer ...']);
- *     if ($r->ok()) { return $r->json(); }
+ * ```php
+ * $r = HTTP::get('https://api.example.com/users', ['Authorization' => 'Bearer ...']);
+ * if ($r->ok()) { return $r->json(); }
  *
- *     $r = HTTP::post('https://hooks.slack.com/...', json: ['text' => 'hi']);
+ * $r = HTTP::post('https://hooks.slack.com/...', body: ['text' => 'hi']);
+ * ```
  *
- * For concurrent fan-out (N requests in parallel), use HTTP::all() —
- * built on App::parallel().
+ * For concurrent fan-out (N requests in parallel), use `HTTP::all()` —
+ * built on `App::parallel()`.
  *
  * For complex multipart uploads / streaming bodies, drop down to
  * `OpenSwoole\Coroutine\Http\Client` directly — this wrapper is

--- a/src/HTTP/Client/NetworkException.php
+++ b/src/HTTP/Client/NetworkException.php
@@ -4,8 +4,23 @@ namespace ZealPHP\HTTP\Client;
 use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * PSR-18 `NetworkExceptionInterface` implementation.
+ *
+ * Thrown (or returned as the `$error` field of `HTTPResponse`) when an
+ * outbound HTTP request fails at the transport layer — DNS resolution
+ * failure, TCP connect timeout, TLS handshake error, etc. — before any
+ * HTTP response status is received. Carries the originating `RequestInterface`
+ * so callers can inspect or retry the failed request.
+ */
 class NetworkException extends \RuntimeException implements NetworkExceptionInterface
 {
+    /**
+     * @param RequestInterface $request  The request that triggered the network failure.
+     * @param string           $message  Human-readable error description.
+     * @param int              $code     Optional error code (defaults to `0`).
+     * @param \Throwable|null  $previous Underlying cause, if any.
+     */
     public function __construct(
         private RequestInterface $request,
         string $message = '',
@@ -15,6 +30,7 @@ class NetworkException extends \RuntimeException implements NetworkExceptionInte
         parent::__construct($message, $code, $previous);
     }
 
+    /** Returns the request that triggered this network exception. */
     public function getRequest(): RequestInterface
     {
         return $this->request;

--- a/src/HTTP/Factory/UriFactory.php
+++ b/src/HTTP/Factory/UriFactory.php
@@ -5,8 +5,22 @@ use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 use OpenSwoole\Core\Psr\Uri;
 
+/**
+ * PSR-17 `UriFactoryInterface` implementation backed by `OpenSwoole\Core\Psr\Uri`.
+ *
+ * Registered with the PSR-17 container so ZealPHP's middleware stack and
+ * internal helpers can create `UriInterface` instances without depending on a
+ * third-party HTTP factory library.
+ */
 class UriFactory implements UriFactoryInterface
 {
+    /**
+     * Create a new `UriInterface` instance from a URI string.
+     *
+     * An empty string produces a URI with all components unset (the
+     * `OpenSwoole\Core\Psr\Uri` default). Delegates parsing to
+     * `OpenSwoole\Core\Psr\Uri`.
+     */
     public function createUri(string $uri = ''): UriInterface
     {
         return new Uri($uri);

--- a/src/Learn/ChatHistory.php
+++ b/src/Learn/ChatHistory.php
@@ -1,9 +1,23 @@
 <?php
 namespace ZealPHP\Learn;
 
+/**
+ * Data-access helpers for the `chat_history` table used by the Learn module.
+ *
+ * Each row stores one conversational turn: a `role` (`"user"` or `"assistant"`),
+ * an array of content `items` (serialised as JSON), and a `thread_id` that groups
+ * turns into a logical conversation. All methods are stateless static helpers
+ * that accept a `\PDO` instance so callers control the connection lifetime.
+ */
 class ChatHistory
 {
-    /** @param array<int, array<string, mixed>> $items */
+    /**
+     * Append one conversational turn to the `chat_history` table.
+     *
+     * @param array<int, array<string, mixed>> $items  Content items for this turn
+     *                                                  (e.g. text blocks, tool results).
+     * @return int  The auto-increment id of the inserted row.
+     */
     public static function append(\PDO $db, int $userId, string $threadId, string $role, array $items): int
     {
         $stmt = $db->prepare('INSERT INTO chat_history (user_id, thread_id, role, items_json, created_at) VALUES (?, ?, ?, ?, ?)');
@@ -11,7 +25,11 @@ class ChatHistory
         return (int) $db->lastInsertId();
     }
 
-    /** @return array<int, array<string, mixed>> */
+    /**
+     * Fetch all turns for a thread in chronological order.
+     *
+     * @return array<int, array<string, mixed>>  Rows ordered by `created_at ASC, id ASC`.
+     */
     public static function forThread(\PDO $db, int $userId, string $threadId): array
     {
         $stmt = $db->prepare('SELECT id, role, items_json, created_at FROM chat_history WHERE user_id = ? AND thread_id = ? ORDER BY created_at ASC, id ASC');
@@ -20,7 +38,14 @@ class ChatHistory
         return $stmt->fetchAll();
     }
 
-    /** @return array<int, array<string, mixed>> */
+    /**
+     * List the most recent threads for a user, newest first.
+     *
+     * Each row contains `thread_id`, `last_at` (Unix timestamp of the latest turn),
+     * and `turns` (total turn count for that thread).
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public static function threads(\PDO $db, int $userId, int $limit = 10): array
     {
         $stmt = $db->prepare('SELECT thread_id, MAX(created_at) AS last_at, COUNT(*) AS turns FROM chat_history WHERE user_id = ? GROUP BY thread_id ORDER BY last_at DESC LIMIT ?');

--- a/src/Learn/Chatroom.php
+++ b/src/Learn/Chatroom.php
@@ -89,6 +89,7 @@ final class Chatroom
         ];
     }
 
+    /** Coerce a mixed PDO column value to `int`, returning `0` on non-numeric input. */
     private static function asInt(mixed $v): int
     {
         if (is_int($v))                          { return $v; }
@@ -97,6 +98,7 @@ final class Chatroom
         return 0;
     }
 
+    /** Coerce a mixed PDO column value to `string`, returning `''` on non-scalar input. */
     private static function asString(mixed $v): string
     {
         if (is_string($v))    { return $v; }
@@ -127,7 +129,13 @@ final class Chatroom
     }
 
     /**
-     * @return array{0:string,1:string,2:string}  trimmed room/username/body
+     * Trim and clamp all three string inputs.
+     *
+     * `$room` defaults to `'general'` when empty; `$username` defaults to
+     * `'anonymous'`. Both `$username` and `$body` are truncated to
+     * `MAX_USERNAME_LEN` and `MAX_MESSAGE_LEN` characters respectively.
+     *
+     * @return array{0:string,1:string,2:string} Trimmed `[room, username, body]`.
      */
     private static function normalize(string $room, string $username, string $body): array
     {
@@ -146,12 +154,13 @@ final class Chatroom
     }
 
     /**
-     * Fan-out helper: iterate the cluster-wide fd map and push to every fd whose
-     * row's `room` matches. Works across workers (any worker can $server->push
-     * any fd) AND across the cluster when the Store backend is Redis (the table
-     * iteration spans every node — federated chat for free).
+     * Fan-out helper: iterate the cluster-wide `chatroom_fds` Store table and
+     * push to every fd whose row's `room` matches. Works across workers (any
+     * worker can call `$server->push($fd, ...)` for any fd) AND across the
+     * cluster when the Store backend is Redis (the table iteration spans every
+     * node — federated chat for free).
      *
-     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $payload JSON-serialisable message payload.
      */
     public static function broadcast_to_room(mixed $server, string $room, array $payload, int $excludeFd = 0): void
     {

--- a/src/Learn/Notes.php
+++ b/src/Learn/Notes.php
@@ -1,8 +1,27 @@
 <?php
 namespace ZealPHP\Learn;
 
+/**
+ * Data-access helpers for the `notes` table used by the Learn module.
+ *
+ * Provides CRUD + search operations for per-user notes. All methods are
+ * stateless static helpers that accept a `\PDO` instance so callers control
+ * the connection lifetime. Input validation (title length, body size, per-user
+ * note cap) is enforced here rather than at the API layer.
+ *
+ * The per-user note cap defaults to `256` and is overridden by the
+ * `ZEALPHP_LEARN_MAX_NOTES` environment variable.
+ */
 class Notes
 {
+    /**
+     * Create a new note for `$userId`.
+     *
+     * Returns the new note's auto-increment id, or `null` when validation fails:
+     * - `$title` is empty or exceeds 200 characters.
+     * - `$body` exceeds 4096 bytes.
+     * - The user already has `ZEALPHP_LEARN_MAX_NOTES` (default `256`) notes.
+     */
     public static function create(\PDO $db, int $userId, string $title, string $body): ?int
     {
         $title = trim($title);
@@ -18,7 +37,11 @@ class Notes
         return (int) $db->lastInsertId();
     }
 
-    /** @return array<int, array<string, mixed>> */
+    /**
+     * List all notes for `$userId`, most recently updated first.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public static function list(\PDO $db, int $userId): array
     {
         $stmt = $db->prepare('SELECT id, title, body, created_at, updated_at FROM notes WHERE user_id = ? ORDER BY updated_at DESC');
@@ -27,7 +50,13 @@ class Notes
         return $stmt->fetchAll();
     }
 
-    /** @return array<string, mixed>|null */
+    /**
+     * Fetch a single note by id, scoped to `$userId`.
+     *
+     * Returns `null` when the note does not exist or belongs to a different user.
+     *
+     * @return array<string, mixed>|null
+     */
     public static function read(\PDO $db, int $userId, int $noteId): ?array
     {
         $stmt = $db->prepare('SELECT id, title, body, created_at, updated_at FROM notes WHERE id = ? AND user_id = ?');
@@ -38,6 +67,13 @@ class Notes
         return $r;
     }
 
+    /**
+     * Update a note's title and/or body.
+     *
+     * Pass `null` for either field to keep the existing value. Applies the same
+     * validation as `create()` (title length, body size). Returns `false` when
+     * the note does not exist, belongs to a different user, or validation fails.
+     */
     public static function update(\PDO $db, int $userId, int $noteId, ?string $title, ?string $body): bool
     {
         $existing = self::read($db, $userId, $noteId);
@@ -54,6 +90,11 @@ class Notes
         return $stmt->rowCount() > 0;
     }
 
+    /**
+     * Delete a note by id, scoped to `$userId`.
+     *
+     * Returns `true` when a row was deleted, `false` when no matching row existed.
+     */
     public static function delete(\PDO $db, int $userId, int $noteId): bool
     {
         $stmt = $db->prepare('DELETE FROM notes WHERE id = ? AND user_id = ?');
@@ -61,7 +102,13 @@ class Notes
         return $stmt->rowCount() > 0;
     }
 
-    /** @return array<int, array<string, mixed>> */
+    /**
+     * Full-text `LIKE` search across `title` and `body` for `$userId`.
+     *
+     * Returns up to `$limit` notes (default `10`), ordered by `updated_at DESC`.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public static function search(\PDO $db, int $userId, string $query, int $limit = 10): array
     {
         $q = '%' . $query . '%';

--- a/src/Learn/TicTacToe.php
+++ b/src/Learn/TicTacToe.php
@@ -10,12 +10,21 @@ use ZealPHP\Store;
 /**
  * Tic-tac-toe multiplayer helpers (Build-the-App capstone).
  *
- * Moved verbatim out of route/learn.php so the route file stays function-free
+ * Moved verbatim out of `route/learn.php` so the route file stays function-free
  * and hot-reloadable. Behaviour is unchanged — the same room sanitiser, winner
- * detector, and state-broadcast helpers the /ws/tictactoe handler calls.
+ * detector, and state-broadcast helpers the `/ws/tictactoe` handler calls.
+ *
+ * Game state is stored in the `ws_tictactoe_rooms` and `ws_tictactoe_clients`
+ * `Store` tables, which must be created before `App::run()`.
  */
 class TicTacToe
 {
+    /**
+     * Sanitise a room name to a safe, lowercase slug.
+     *
+     * Lowercases, strips anything that is not `[a-z0-9-]`, and truncates to
+     * 32 characters so the result is safe as a `Store` key.
+     */
     public static function ttt_sanitize_room(string $room): string
     {
         $room = strtolower($room);
@@ -24,6 +33,14 @@ class TicTacToe
     }
 
     /**
+     * Detect a winner on the given 9-character board string.
+     *
+     * The board is indexed `0`–`8` left-to-right, top-to-bottom; each cell holds
+     * `'X'`, `'O'`, or `'_'` (empty). Returns a two-element tuple:
+     * - `[winner_symbol, winning_indices]` when a winning line is found
+     *   (e.g. `['X', [0, 1, 2]]`).
+     * - `[null, null]` when there is no winner yet.
+     *
      * @return array{0: ?string, 1: ?array<int, int>}
      */
     public static function ttt_detect_winner(string $board): array
@@ -39,13 +56,24 @@ class TicTacToe
         return [null, null];
     }
 
+    /**
+     * Broadcast the current room state to all connected clients in `$room`.
+     *
+     * Reads the room row from the `ws_tictactoe_rooms` `Store` table and pushes
+     * a `"state"` JSON message to every `fd` found in `ws_tictactoe_clients`.
+     */
     public static function ttt_broadcast_state(string $room): void
     {
         self::broadcast($room, []);
     }
 
     /**
-     * @param array<string, mixed> $extras
+     * Broadcast the current room state merged with `$extras`.
+     *
+     * Use this variant to piggyback additional fields (e.g. `"event"`,
+     * `"winner_line"`) onto the standard state payload in a single push.
+     *
+     * @param array<string, mixed> $extras  Extra key-value pairs merged into the payload.
      */
     public static function ttt_broadcast_state_with(string $room, array $extras): void
     {
@@ -53,10 +81,11 @@ class TicTacToe
     }
 
     /**
-     * Shared fan-out core for ttt_broadcast_state / _with — builds the state
-     * payload (optionally merged with $extras) and pushes it to every fd in
-     * the room. Single implementation so the two public entry points can't
-     * drift in payload shape.
+     * Shared fan-out core for `ttt_broadcast_state()` / `ttt_broadcast_state_with()`.
+     *
+     * Builds the state payload (optionally merged with `$extras`) and pushes it to
+     * every `fd` in the room. Single implementation so the two public entry points
+     * can't drift in payload shape.
      *
      * @param array<string, mixed> $extras
      */
@@ -104,6 +133,12 @@ class TicTacToe
         }
     }
 
+    /**
+     * Coerce a mixed `Store` value to `int`.
+     *
+     * `Store` columns return `string` on read even for `TYPE_INT` columns.
+     * Returns `0` for non-numeric values.
+     */
     private static function asInt(mixed $v): int
     {
         if (is_int($v))                      { return $v; }

--- a/src/Middleware/CacheControlMiddleware.php
+++ b/src/Middleware/CacheControlMiddleware.php
@@ -18,7 +18,7 @@ use ZealPHP\RequestContext;
  *
  * Apache equivalent:
  *
- * ```
+ * ```apache
  * <FilesMatch "\.(css|js|jpe?g|png|gif|svg|ico|woff2?)$">
  *     Header set Cache-Control "max-age=2628000, public"
  * </FilesMatch>
@@ -26,7 +26,7 @@ use ZealPHP\RequestContext;
  *
  * nginx equivalent:
  *
- * ```
+ * ```nginx
  * location ~* \.(css|js|jpe?g|png|gif|svg|ico|woff2?)$ {
  *     expires 30d;
  *     add_header Cache-Control "public, max-age=2628000";
@@ -59,7 +59,7 @@ use ZealPHP\RequestContext;
  */
 class CacheControlMiddleware implements MiddlewareInterface
 {
-    /** ~30 days in seconds — Apache's classic "ExpiresDefault A2628000" value. */
+    /** ~30 days in seconds — Apache's classic `ExpiresDefault A2628000` value. */
     private const DEFAULT_MAX_AGE = 2_628_000;
 
     /** @var array<string, int> */
@@ -83,17 +83,24 @@ class CacheControlMiddleware implements MiddlewareInterface
         'wasm'  => self::DEFAULT_MAX_AGE,
     ];
 
-    /** @var array<string, int> */
+    /** @var array<string, int> Extension → max-age-seconds map used at runtime. */
     private array $map;
 
     /**
-     * @param array<string, int>|null $map  ext => seconds; null uses defaults
+     * @param array<string, int>|null $map          Extension → seconds map; `null` uses the built-in defaults.
+     * @param bool                    $publicCache  `true` emits `public`, `false` emits `private`.
      */
     public function __construct(?array $map = null, private bool $publicCache = true)
     {
         $this->map = $this->normaliseMap($map ?? self::DEFAULT_MAP);
     }
 
+    /**
+     * Append `Cache-Control: max-age=N, public|private` to static-asset responses.
+     *
+     * Skips responses that already carry a `Cache-Control` header, error responses
+     * (status >= `400`), and paths whose extension is not in the configured map.
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
@@ -124,8 +131,10 @@ class CacheControlMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param array<string, int> $map
-     * @return array<string, int>
+     * Normalise extension keys to lowercase without a leading dot.
+     *
+     * @param array<string, int> $map Raw extension → seconds map.
+     * @return array<string, int>     Normalised extension → seconds map.
      */
     private function normaliseMap(array $map): array
     {

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -11,29 +11,37 @@ use Psr\Http\Server\RequestHandlerInterface;
 use ZealPHP\RequestContext;
 
 /**
- * CSRF Protection Middleware
+ * CSRF Protection Middleware.
  *
- * Generates a per-session CSRF token on safe requests (GET/HEAD/OPTIONS)
- * and validates it on state-changing requests (POST/PUT/PATCH/DELETE).
+ * Generates a per-session CSRF token on safe requests (`GET`/`HEAD`/`OPTIONS`)
+ * and validates it on state-changing requests (`POST`/`PUT`/`PATCH`/`DELETE`).
  *
  * Token sources checked (first match wins):
  *   1. `$_POST['_csrf_token']` (form hidden field)
  *   2. `X-CSRF-Token` request header (AJAX/htmx)
  *
- * Token is stored in `$g->session['_csrf_token']` and exposed via
+ * The token is stored in `$g->session['_csrf_token']` and exposed via
  * `$g->memo['csrf_token']` for templates to read.
  *
- * Usage:
- *   $app->addMiddleware(new CsrfMiddleware());
+ * Usage in `app.php`:
+ * ```php
+ * $app->addMiddleware(new CsrfMiddleware());
+ * ```
  *
  * In templates:
- *   <input type="hidden" name="_csrf_token" value="<?= $g->memo['csrf_token'] ?>">
+ * ```php
+ * <input type="hidden" name="_csrf_token" value="<?= $g->memo['csrf_token'] ?>">
+ * ```
  *
  * With htmx:
- *   <body hx-headers='{"X-CSRF-Token": "<?= $g->memo['csrf_token'] ?>"}'>
+ * ```php
+ * <body hx-headers='{"X-CSRF-Token": "<?= $g->memo['csrf_token'] ?>"}'>
+ * ```
  *
  * To exempt paths (e.g. webhooks):
- *   $app->addMiddleware(new CsrfMiddleware(exempt: ['/api/webhook', '/api/stripe']));
+ * ```php
+ * $app->addMiddleware(new CsrfMiddleware(exempt: ['/api/webhook', '/api/stripe']));
+ * ```
  */
 final class CsrfMiddleware implements MiddlewareInterface
 {
@@ -42,15 +50,25 @@ final class CsrfMiddleware implements MiddlewareInterface
     private const FIELD_NAME = '_csrf_token';
     private const HEADER_NAME = 'X-CSRF-Token';
 
-    /** @var list<string> */
+    /** @var list<string> URL path prefixes that skip CSRF validation. */
     private array $exempt;
 
-    /** @param list<string> $exempt URL prefixes to skip validation */
+    /**
+     * @param list<string> $exempt URL prefixes to skip validation (e.g. `['/api/webhook']`).
+     */
     public function __construct(array $exempt = [])
     {
         $this->exempt = $exempt;
     }
 
+    /**
+     * Generate or validate the CSRF token for the current request.
+     *
+     * Safe methods (`GET`/`HEAD`/`OPTIONS`) and exempt path prefixes pass through
+     * without validation. All other methods require a matching token submitted
+     * via the `_csrf_token` POST field or the `X-CSRF-Token` header; a mismatch
+     * or missing token returns a `403` response immediately.
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $g = RequestContext::instance();

--- a/src/Middleware/HealthCheckMiddleware.php
+++ b/src/Middleware/HealthCheckMiddleware.php
@@ -11,31 +11,38 @@ use Psr\Http\Server\RequestHandlerInterface;
 use ZealPHP\App;
 
 /**
- * Health Check Middleware
+ * Health Check Middleware — short-circuits on configured paths and returns
+ * `App::stats()` as JSON. Designed for load-balancer probes, Kubernetes
+ * liveness/readiness, and monitoring agents.
  *
- * Short-circuits on configured paths (default: `/healthz`) and returns
- * JSON from `App::stats()`. Designed for load balancer probes, Kubernetes
- * liveness/readiness, and monitoring.
+ * Basic usage (intercepts `/healthz`):
  *
- * Usage:
- *   $app->addMiddleware(new HealthCheckMiddleware());
+ * ```php
+ * $app->addMiddleware(new HealthCheckMiddleware());
+ * ```
  *
  * Custom paths:
- *   $app->addMiddleware(new HealthCheckMiddleware(
- *       paths: ['/healthz', '/readyz', '/_health']
- *   ));
  *
- * With a custom check (e.g., verify Redis/DB reachable):
- *   $app->addMiddleware(new HealthCheckMiddleware(
- *       check: function(): ?string {
- *           try { \ZealPHP\Store::get('_ping', '_ping'); return null; }
- *           catch (\Throwable $e) { return 'store unreachable'; }
- *       }
- *   ));
+ * ```php
+ * $app->addMiddleware(new HealthCheckMiddleware(
+ *     paths: ['/healthz', '/readyz', '/_health']
+ * ));
+ * ```
  *
- * Response:
- *   200 {"status":"ok", "uptime_sec":123, ...}
- *   503 {"status":"unhealthy", "reason":"store unreachable", ...}
+ * With a custom readiness check (e.g., verify Redis/DB reachable):
+ *
+ * ```php
+ * $app->addMiddleware(new HealthCheckMiddleware(
+ *     check: function(): ?string {
+ *         try { \ZealPHP\Store::get('_ping', '_ping'); return null; }
+ *         catch (\Throwable $e) { return 'store unreachable'; }
+ *     }
+ * ));
+ * ```
+ *
+ * Response shapes:
+ * - `200` `{"status":"ok", "uptime_sec":123, ...}` — healthy
+ * - `503` `{"status":"unhealthy", "reason":"store unreachable", ...}` — unhealthy
  */
 final class HealthCheckMiddleware implements MiddlewareInterface
 {
@@ -46,8 +53,8 @@ final class HealthCheckMiddleware implements MiddlewareInterface
     private $check;
 
     /**
-     * @param list<string>              $paths  URL paths to intercept
-     * @param (callable(): ?string)|null $check  Returns null if healthy, error string if not
+     * @param list<string>               $paths URL paths to intercept (default `['/healthz']`).
+     * @param (callable(): ?string)|null $check Returns `null` if healthy, an error string if not.
      */
     public function __construct(array $paths = ['/healthz'], ?callable $check = null)
     {
@@ -55,6 +62,13 @@ final class HealthCheckMiddleware implements MiddlewareInterface
         $this->check = $check;
     }
 
+    /**
+     * Intercept health-check paths and return a JSON status payload.
+     *
+     * Non-matching paths are forwarded to `$handler` unchanged. When the
+     * optional `$check` callable returns a non-null string, the response
+     * status is `503` and the string is included as `"reason"` in the body.
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $path = $request->getUri()->getPath();

--- a/src/Middleware/HostRouterMiddleware.php
+++ b/src/Middleware/HostRouterMiddleware.php
@@ -19,21 +19,26 @@ use ZealPHP\RequestContext;
  * array → JSON, int → status code).
  *
  * nginx equivalent:
- *   `server { server_name a.com; location / { ... } }`
- *   `server { server_name b.com; location / { ... } }`
+ *
+ * ```
+ * server { server_name a.com; location / { ... } }
+ * server { server_name b.com; location / { ... } }
+ * ```
  *
  * If no host matches and no `'*'` (catch-all) handler is registered, the
  * middleware **passes through** to the next handler. This lets you mix
  * host-routed and host-agnostic apps inside one ZealPHP instance:
  *
- *   `$app->addMiddleware(new \ZealPHP\Middleware\HostRouterMiddleware([`
- *       `'docs.example.com'  => fn() => 'docs landing page',`
- *       `'api.example.com'   => fn() => ['status' => 'ok'],`
- *       `'*.example.com'     => fn() => 'subdomain fallback',`
- *       `'www.*'             => fn() => 'trailing-wildcard catch',`
- *       `'~^admin\..+'       => fn() => 'regex match',`
- *       `'*'                 => fn() => 'default site',`
- *   `]));`
+ * ```php
+ * $app->addMiddleware(new \ZealPHP\Middleware\HostRouterMiddleware([
+ *     'docs.example.com'  => fn() => 'docs landing page',
+ *     'api.example.com'   => fn() => ['status' => 'ok'],
+ *     '*.example.com'     => fn() => 'subdomain fallback',
+ *     'www.*'             => fn() => 'trailing-wildcard catch',
+ *     '~^admin\..+'       => fn() => 'regex match',
+ *     '*'                 => fn() => 'default site',
+ * ]));
+ * ```
  *
  * Host matching is case-insensitive and ignores port (`example.com:8080`
  * matches the rule `example.com`). IPv6 literals (`[::1]:80`) are parsed

--- a/src/Middleware/MergeSlashesMiddleware.php
+++ b/src/Middleware/MergeSlashesMiddleware.php
@@ -26,6 +26,14 @@ use ZealPHP\RequestContext;
  */
 class MergeSlashesMiddleware implements MiddlewareInterface
 {
+    /**
+     * Collapse consecutive slashes in the request path and pass the request on.
+     *
+     * Mutates `$g->server['REQUEST_URI']` in place (path portion only; query
+     * string is left untouched) so the router sees the normalised path. The
+     * PSR-7 `$request` object is passed to the next handler unchanged — routing
+     * reads `REQUEST_URI` directly.
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $g = RequestContext::instance();

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -11,33 +11,58 @@ use OpenSwoole\Coroutine as co;
 use ZealPHP\Session\Handler\FileSessionHandler;
 use ZealPHP\RequestContext;
 
+/**
+ * Per-coroutine session lifecycle manager (coroutine / `superglobals(false)` mode).
+ *
+ * Registered as the OpenSwoole `onRequest` handler in coroutine mode. For each
+ * inbound request it:
+ * 1. Creates a per-coroutine `RequestContext` (`G`) instance and populates
+ *    `$g->openswoole_request` / `$g->openswoole_response` / `$g->zealphp_request` /
+ *    `$g->zealphp_response`.
+ * 2. Optionally starts a session (lazy — only when the client already holds a
+ *    `PHPSESSID` cookie, unless `SessionStartMiddleware` is registered).
+ * 3. Invokes the PSR-15 middleware stack (`$this->middleware`).
+ * 4. Writes and closes the session in the `finally` block, then runs the
+ *    per-request isolation resets for `coroutine-legacy` mode
+ *    (`zealphp_reset_request_rtcaches`, `zealphp_reset_request_statics`,
+ *    `zealphp_reset_request_class_statics`) when `App::$silent_redeclare` is active.
+ *
+ * The session handler is resolved once per worker from `App::$session_handler`:
+ * `null` → `TableSessionHandler` (default, concurrent-safe);
+ * `'file'` → `FileSessionHandler`;
+ * `'redis'` → `RedisSessionHandler`;
+ * or any `\SessionHandlerInterface` instance passed directly.
+ *
+ * IMPORTANT: do not call `session_start()` / `session_write_close()` directly —
+ * use the `zeal_session_*` uopz-overridden wrappers so state routes through
+ * `$g->session` rather than the process-wide `$_SESSION`.
+ */
 class CoSessionManager
 {
     /**
+     * The PSR-15 middleware stack entry point (wrapped as a callable).
+     *
      * @var callable
      */
     protected $middleware;
 
     /**
+     * Session-id generator: either a callable or the string name of a built-in
+     * function such as `'session_create_id'`.
+     *
      * @var string|callable
      */
     protected $idGenerator;
 
+    /** Whether to read/write the session id via a cookie (`session.use_cookies`). */
     protected bool $useCookies;
 
+    /** Whether to refuse session ids passed in query-string (`session.use_only_cookies`). */
     protected bool $useOnlyCookies;
 
     /**
-     * Inject dependencies
-     *
-     * @param callable $middleware function (\Swoole\Http\Request $request, \Swoole\Http\Response $response)
-     * @param callable $idGenerator
-     * @param bool|null $useCookies
-     * @param bool|null $useOnlyCookies
-     */
-    /**
-     * Resolve the session handler from App::$session_handler. CoSessionManager
-     * runs in coroutine mode, so the default (null) is TableSessionHandler —
+     * Resolve the session handler from `App::$session_handler`. `CoSessionManager`
+     * runs in coroutine mode, so the default (`null`) is `TableSessionHandler` —
      * concurrent-safe via 3-way merge + Atomic CAS + file backing.
      */
     private static function resolveHandler(): ?\SessionHandlerInterface
@@ -57,8 +82,15 @@ class CoSessionManager
         }
     }
 
-    /** Skip cleanup when an app autoloader is registered (its lazy-loaded
-     * classes would be cleaned but require_once cache persists). */
+    /**
+     * Returns `true` when it is safe to run `zealphp_process_state_clean()`.
+     *
+     * The cleanup is unsafe when a Composer autoloader maps classes inside
+     * `App::$document_root` — those lazily-loaded classes would have their
+     * statics reset while the `require_once` cache still considers them loaded,
+     * causing a mismatch on the next request. When such an autoloader is
+     * detected, cleanup is skipped for the whole worker.
+     */
     private static function safeForFunctionIsolation(): bool
     {
         $docRoot = \ZealPHP\App::$document_root;
@@ -88,7 +120,13 @@ class CoSessionManager
     }
 
     /**
-     * @param string|callable $idGenerator
+     * Inject the middleware stack callable and session configuration.
+     *
+     * @param callable         $middleware      The PSR-15 stack entry point — called with
+     *                                          `(ZealPHP\HTTP\Request, ZealPHP\HTTP\Response)`.
+     * @param string|callable  $idGenerator     Session-id generator; defaults to `'session_create_id'`.
+     * @param bool|null        $useCookies      Override `session.use_cookies`; `null` reads the ini.
+     * @param bool|null        $useOnlyCookies  Override `session.use_only_cookies`; `null` reads the ini.
      */
     public function __construct(
         callable $middleware,
@@ -103,7 +141,11 @@ class CoSessionManager
     }
 
     /**
-     * Delegate execution to the underlying middleware wrapping it into the session start/stop calls
+     * Handle one HTTP request: set up `RequestContext`, optionally start the
+     * session, invoke the middleware stack, then close the session and run
+     * per-request isolation resets in the `finally` block.
+     *
+     * Called directly by OpenSwoole's `onRequest` event — do not call manually.
      */
     public function __invoke(\OpenSwoole\Http\Request $request, \OpenSwoole\Http\Response $response): void
     {

--- a/src/Session/Handler/FileSessionHandler.php
+++ b/src/Session/Handler/FileSessionHandler.php
@@ -4,11 +4,34 @@ namespace ZealPHP\Session\Handler;
 
 use OpenSwoole\Coroutine as co;
 
+/**
+ * File-backed `\SessionHandlerInterface` for ZealPHP.
+ *
+ * Stores session data as flat files named `sess_{sessionId}` inside `$savePath`
+ * (defaults to `/var/lib/php/sessions`, matching the PHP-FPM convention).
+ * This handler is a direct coroutine-mode replacement for PHP's built-in file
+ * session handler — it performs standard blocking file I/O, which is
+ * coroutine-hooked under `Runtime::HOOK_ALL` and yields transparently.
+ *
+ * IMPORTANT: not suitable for high-concurrency coroutine mode without an
+ * external file lock. For concurrent workloads use `TableSessionHandler`
+ * (the default in coroutine mode) or `RedisSessionHandler`. Use this handler
+ * only when you need filesystem-compatible session files, e.g. when sharing
+ * sessions with a PHP-FPM process on the same host.
+ *
+ * Register via `App::$session_handler = 'file'` or by passing an instance
+ * to `session_set_save_handler()` before `App::run()`.
+ */
 class FileSessionHandler implements \SessionHandlerInterface
 {
+    /** Absolute path to the session-file directory, resolved in `open()`. */
     private string $savePath;
 
-    // Open session
+    /**
+     * Open the session storage at `$savePath`, creating the directory if absent.
+     *
+     * Falls back to `/var/lib/php/sessions` when `$savePath` is empty.
+     */
     public function open($savePath, $sessionName): bool
     {
         // if (!$savePath) {
@@ -23,7 +46,11 @@ class FileSessionHandler implements \SessionHandlerInterface
         return true;
     }
 
-    // Read session data
+    /**
+     * Read and return the raw session data string for `$sessionId`.
+     *
+     * Returns an empty string when the session file does not exist (new session).
+     */
     public function read($sessionId): string
     {
         $file = $this->savePath . '/sess_' . basename((string) $sessionId);
@@ -34,14 +61,22 @@ class FileSessionHandler implements \SessionHandlerInterface
         return '';
     }
 
-    // Write session data
+    /**
+     * Write serialised `$sessionData` to the session file for `$sessionId`.
+     *
+     * The file is named `sess_{sessionId}` inside `$savePath`. Returns `false`
+     * only when `file_put_contents()` fails.
+     */
     public function write($sessionId, $sessionData): bool
     {
         $file = $this->savePath . '/sess_' . basename((string) $sessionId);
         return file_put_contents($file, $sessionData) !== false;
     }
 
-    // Destroy a session
+    /**
+     * Delete the session file for `$sessionId`. Always returns `true` —
+     * a missing file is treated as already-destroyed (idempotent).
+     */
     public function destroy($sessionId): bool
     {
         $file = $this->savePath . '/sess_' . basename((string) $sessionId);
@@ -51,13 +86,22 @@ class FileSessionHandler implements \SessionHandlerInterface
         return true;
     }
 
-    // Close the session
+    /**
+     * Close the session — no-op for file sessions; always returns `true`.
+     */
     public function close(): bool
     {
         return true;
     }
 
-    // Garbage collection
+    /**
+     * Garbage-collect session files older than `$maxLifetime` seconds.
+     *
+     * Scans `$savePath/sess_*` and unlinks files whose `mtime` is older than
+     * `time() - $maxLifetime`. Returns `0` (PHP's `\SessionHandlerInterface`
+     * contract accepts any non-negative int as "number of deleted sessions";
+     * we return `0` rather than counting for performance).
+     */
     public function gc($maxLifetime): int
     {
         $files = glob("$this->savePath/sess_*") ?: [];

--- a/src/Session/Handler/RedisSessionHandler.php
+++ b/src/Session/Handler/RedisSessionHandler.php
@@ -32,13 +32,27 @@ namespace ZealPHP\Session\Handler;
  */
 class RedisSessionHandler implements \SessionHandlerInterface
 {
+    /** Redis host (default `'127.0.0.1'`). */
     private string $host;
+
+    /** Redis port (default `6379`). */
     private int $port;
+
+    /** Key prefix used for session entries (default `'PHPREDIS_SESSION:'`). */
     private string $prefix;
+
+    /** Session TTL in seconds (default `1440`). */
     private int $ttl;
+
     /** Single connection used outside coroutine context (CLI / tests). */
     private ?\Redis $fallback = null;
 
+    /**
+     * @param string $host   Redis host.
+     * @param int    $port   Redis port.
+     * @param string $prefix Key prefix; use the phpredis default (`'PHPREDIS_SESSION:'`) for cross-handler compatibility.
+     * @param int    $ttl    Session TTL in seconds.
+     */
     public function __construct(string $host = '127.0.0.1', int $port = 6379, string $prefix = 'PHPREDIS_SESSION:', int $ttl = 1440)
     {
         $this->host = $host;
@@ -51,6 +65,9 @@ class RedisSessionHandler implements \SessionHandlerInterface
         $this->fallback = $this->connect();
     }
 
+    /**
+     * Open a new `\Redis` connection to `$this->host:$this->port`.
+     */
     private function connect(): \Redis
     {
         $redis = new \Redis();
@@ -59,9 +76,13 @@ class RedisSessionHandler implements \SessionHandlerInterface
     }
 
     /**
-     * Per-coroutine Redis connection. Each coroutine gets its own socket so
-     * concurrent session I/O never crosses frames (#16). Outside a coroutine,
-     * the construction-time fallback connection is reused.
+     * Per-coroutine Redis connection.
+     *
+     * Each coroutine gets its own socket so concurrent session I/O never crosses
+     * frames (issue #16). The connection is stored in the coroutine context under
+     * the key `'__zeal_redis_session'` and is reaped automatically when the
+     * coroutine ends. Outside a coroutine, the construction-time `$fallback`
+     * connection is reused.
      */
     private function redis(): \Redis
     {
@@ -78,19 +99,38 @@ class RedisSessionHandler implements \SessionHandlerInterface
         return $conn;
     }
 
+    /**
+     * Verify that the Redis connection is alive. Called by PHP's session manager
+     * before the first `read()`.
+     */
     public function open($savePath, $sessionName): bool
     {
         return $this->redis()->isConnected();
     }
 
+    /**
+     * No-op: per-coroutine connections are reaped by the coroutine context,
+     * not by the session manager lifecycle.
+     */
     public function close(): bool
     {
         return true;
     }
 
-    /** @var array<string, string> Per-coroutine read snapshot for 3-way merge on conflict. */
+    /**
+     * Per-coroutine read snapshot for 3-way merge on write conflict.
+     *
+     * @var array<string, string>
+     */
     private array $baseData = [];
 
+    /**
+     * Read and return the serialised session data for `$sessionId`.
+     *
+     * Also `WATCH`es the key so a concurrent write is detected during the
+     * subsequent `write()` call; stores the baseline data in `$baseData` for
+     * the 3-way merge.
+     */
     public function read($sessionId): string
     {
         $redis = $this->redis();
@@ -102,6 +142,14 @@ class RedisSessionHandler implements \SessionHandlerInterface
         return $base;
     }
 
+    /**
+     * Persist serialised session data for `$sessionId` with optimistic locking.
+     *
+     * Uses `WATCH`/`MULTI`/`EXEC` and retries up to 3 times on conflict. When
+     * a concurrent writer is detected, performs a 3-way merge (base = original
+     * `read()` snapshot, local = intended write, remote = current Redis value)
+     * before retrying. Returns `false` if all 3 attempts fail.
+     */
     public function write($sessionId, $sessionData): bool
     {
         $redis = $this->redis();
@@ -129,9 +177,10 @@ class RedisSessionHandler implements \SessionHandlerInterface
 
     /**
      * 3-way merge for serialised PHP session strings.
+     *
      * Gives leaf-level granularity — concurrent writes to disjoint leaf
-     * paths under the same top-level key (e.g. $_SESSION['cart']['item1']
-     * vs $_SESSION['cart']['item2']) both survive.
+     * paths under the same top-level key (e.g. `$_SESSION['cart']['item1']`
+     * vs `$_SESSION['cart']['item2']`) both survive.
      */
     private function merge3Sessions(string $base, string $local, string $remote): string
     {
@@ -142,7 +191,15 @@ class RedisSessionHandler implements \SessionHandlerInterface
         return self::serializeSession($merged);
     }
 
-    /** @return array<mixed,mixed> */
+    /**
+     * Parse a PHP session-encoded string into a key→value array.
+     *
+     * Uses the `php` serialisation format (`key|serialized_value`). Unknown or
+     * malformed entries are silently skipped. Only `stdClass` objects are
+     * allowed in `unserialize()` (matches the whitelist in `src/Session/utils.php`).
+     *
+     * @return array<mixed,mixed>
+     */
     public static function parseSession(string $data): array
     {
         if ($data === '') return [];
@@ -166,7 +223,11 @@ class RedisSessionHandler implements \SessionHandlerInterface
         return $result;
     }
 
-    /** @param array<mixed,mixed> $data */
+    /**
+     * Serialise a key→value array back to the PHP session-encoded string format.
+     *
+     * @param array<mixed,mixed> $data
+     */
     public static function serializeSession(array $data): string
     {
         $out = '';
@@ -177,6 +238,16 @@ class RedisSessionHandler implements \SessionHandlerInterface
     }
 
     /**
+     * Recursive 3-way array merge.
+     *
+     * Strategy: remote is the baseline result; for each key in local:
+     * - If the key is new in local (not in base), add it to the result.
+     * - If both local and remote are arrays, recurse.
+     * - If local changed from base, local wins.
+     * Keys deleted locally (present in base, absent in local) are removed from
+     * the result only when the remote value is still the base value (i.e. nobody
+     * else changed it).
+     *
      * @param array<mixed,mixed> $base
      * @param array<mixed,mixed> $local
      * @param array<mixed,mixed> $remote
@@ -209,18 +280,31 @@ class RedisSessionHandler implements \SessionHandlerInterface
         return $result;
     }
 
+    /**
+     * Delete the session key from Redis and return `true`.
+     */
     public function destroy($sessionId): bool
     {
         $this->redis()->del($this->prefix . $sessionId);
         return true;
     }
 
+    /**
+     * Garbage collection — Redis TTL handles expiry server-side, so this is a no-op.
+     *
+     * Returns `0` (zero sessions collected) to satisfy the `SessionHandlerInterface` contract.
+     */
     public function gc($maxlifetime): int|false
     {
         return 0;
     }
 
-    /** The Redis connection for the current coroutine (or the fallback). */
+    /**
+     * Expose the Redis connection for the current coroutine (or the fallback).
+     *
+     * Useful for inspecting connection state in tests or running additional
+     * Redis commands in the same per-coroutine socket.
+     */
     public function getRedis(): \Redis
     {
         return $this->redis();

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -19,40 +19,55 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * OpenSwoole `onRequest` handler for superglobals mode (`App::superglobals(true)`).
+ *
+ * Invoked as a callable (via `__invoke()`) for every inbound HTTP request on the
+ * worker. Responsible for:
+ * - Resetting per-request `RequestContext` state (error/exception/shutdown stacks).
+ * - Optionally managing the PHP session lifecycle (`session_start()` → inner
+ *   middleware stack → `session_write_close()`), gated on `App::$session_lifecycle`
+ *   and `App::cgiOwnsSessions()`.
+ * - Wrapping the raw OpenSwoole request/response in `ZealPHP\HTTP\Request` /
+ *   `ZealPHP\HTTP\Response` and storing them on `RequestContext`.
+ * - Running the per-request isolation cleanup hooks from `ext-zealphp` when
+ *   `coroutine-legacy` mode is active (`zealphp_reset_request_rtcaches`,
+ *   `zealphp_reset_request_statics`, `zealphp_reset_request_class_statics`).
+ *
+ * The coroutine-mode equivalent is `CoSessionManager`.
+ */
 class SessionManager
 {
     /**
+     * The inner middleware callable — the PSR-15 stack entry point.
+     *
      * @var callable
      */
     protected $middleware;
 
     /**
+     * Session ID generator: a callable or the string `'session_create_id'`.
+     *
      * @var string|callable
      */
     protected $idGenerator;
 
+    /** Whether to read/write the session ID via cookies. */
     protected bool $useCookies;
 
+    /** Whether cookies are the only allowed transport for the session ID. */
     protected bool $useOnlyCookies;
 
+    /** Snapshot of the `RequestContext` singleton at construction time. */
     public \ZealPHP\RequestContext $g;
 
     /**
-     * Inject dependencies
+     * Returns `false` when running `zealphp_process_state_clean()` would be unsafe.
      *
-     * @param callable $middleware function (\Swoole\Http\Request $request, \Swoole\Http\Response $response)
-     * @param callable $idGenerator
-     * @param bool|null $useCookies
-     * @param bool|null $useOnlyCookies
-     */
-    /**
-     * Check if function isolation cleanup is safe for the current state.
-     *
-     * Returns false if any registered spl_autoload callback resolves to a
-     * class file under App::documentRoot() — that means an app has its own
-     * Composer autoloader registered, and cleanup would orphan its lazy-
-     * loaded classes (the require_once cache stays but the classes get
-     * removed). For autoloader-based apps, use Mode 1 (CGI Pool) instead.
+     * Checks registered `spl_autoload` callbacks: if any `Composer\Autoload\ClassLoader`
+     * maps classes under `App::$document_root`, cleaning function/class state would
+     * orphan those lazily-loaded classes. In that case the caller should skip the
+     * cleanup and rely on `legacy-cgi` (process-isolated) mode instead.
      */
     private static function safeForFunctionIsolation(): bool
     {
@@ -83,7 +98,12 @@ class SessionManager
     }
 
     /**
-     * @param string|callable $idGenerator
+     * Inject dependencies for the session manager.
+     *
+     * @param callable        $middleware      The inner PSR-15 middleware stack entry point.
+     * @param string|callable $idGenerator     Session ID generator; defaults to `'session_create_id'`.
+     * @param bool|null       $useCookies      When `null`, inherits `session.use_cookies` ini value.
+     * @param bool|null       $useOnlyCookies  When `null`, inherits `session.use_only_cookies` ini value.
      */
     public function __construct(
         callable $middleware,
@@ -103,10 +123,23 @@ class SessionManager
     // }
 
     /**
-     * Delegate execution to the underlying middleware wrapping it into the session start/stop calls
+     * Handle one inbound OpenSwoole request: set up session + context, run the middleware stack, then clean up.
      *
-     * @param \OpenSwoole\Http\Request  $request
-     * @param \OpenSwoole\Http\Response $response
+     * Sequence (when session management is active):
+     * 1. Reset per-request `RequestContext` state (error/shutdown stacks, streaming flags).
+     * 2. Resolve the session ID from cookie or query string; call `session_start()`.
+     * 3. Wrap raw OpenSwoole objects in `ZealPHP\HTTP\Request` / `ZealPHP\HTTP\Response`.
+     * 4. Invoke the inner middleware stack via `call_user_func($this->middleware, ...)`.
+     * 5. In the `finally` block: `session_write_close()`, isolation cleanup hooks
+     *    (`zealphp_reset_request_rtcaches`, `zealphp_reset_request_statics`,
+     *    `zealphp_reset_request_class_statics`), and constant/globals cleanup.
+     *
+     * When `App::$session_lifecycle` is `false` or `App::cgiOwnsSessions()` returns
+     * `true`, the session lifecycle steps are skipped — context setup and cleanup
+     * hooks still run.
+     *
+     * @param \OpenSwoole\Http\Request  $request  Raw OpenSwoole request object.
+     * @param \OpenSwoole\Http\Response $response Raw OpenSwoole response object.
      */
     public function __invoke($request, $response): void
     {

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -4,36 +4,38 @@ namespace ZealPHP\Session;
 use ZealPHP\RequestContext;
 
 /**
- * Decode PHP 'php' session serialize format (key|serialized_value;key|...).
- * Falls back to unserialize() for php_serialize handler format.
+ * Session utility functions for ZealPHP's coroutine-safe session layer.
  *
- * SECURITY: every `unserialize()` call in this file is narrowly scoped to
- * an explicit class whitelist — currently `['stdClass']`. Sessions are
+ * These functions are registered via `uopz_set_return()` at startup to replace
+ * PHP's built-in `session_*()` family. They read and write to
+ * `RequestContext::instance()->session` (coroutine-isolated storage) rather
+ * than the process-global `$_SESSION`, making session operations safe under
+ * OpenSwoole coroutine concurrency.
+ *
+ * SECURITY: every `unserialize()` call in this file passes an explicit class
+ * whitelist — currently `['allowed_classes' => ['stdClass']]`. Sessions are
  * user-controlled storage (tampered cookie, compromised Redis); allowing
- * arbitrary class instantiation here would let an attacker trigger
- * `__wakeup()` / `__destruct()` gadgets in any class on the autoload
- * graph (the vulnerability commit c43da63 originally fixed by passing
- * `allowed_classes => false`).
+ * arbitrary class instantiation would let an attacker trigger `__wakeup()` /
+ * `__destruct()` gadgets in any class on the autoload graph.
  *
  * Why `stdClass` is on the whitelist (added v0.2.26, issue #15):
- *   - `stdClass` has zero methods — no `__wakeup`, no `__destruct`, no
- *     `__get`/`__set`/`__call`. There is no gadget to chain.
- *   - `json_decode($x)` (the default mode without the second arg) returns
- *     a `stdClass` graph, and apps routinely stash that result in
- *     `$_SESSION['oauth_token']`, `$_SESSION['api_profile']`, etc.
- *     Refusing to round-trip it broke real apps in v0.2.25 (issue #15).
+ * - `stdClass` has zero methods — no `__wakeup`, no `__destruct`, no
+ *   `__get`/`__set`/`__call`. There is no gadget to chain.
+ * - `json_decode($x)` (without the second arg) returns a `stdClass` graph,
+ *   and apps routinely stash that result in `$_SESSION['oauth_token']`,
+ *   `$_SESSION['api_profile']`, etc. Refusing to round-trip it broke real
+ *   apps in v0.2.25 (issue #15).
  *
- * Adding more classes to the whitelist requires a SECURITY review for
- * each one: any magic method that runs on unserialize (`__wakeup`,
- * `__unserialize`) or destruct (`__destruct`) can be turned into a
- * gadget. `DateTime` for example has `__wakeup` and is therefore
- * deliberately excluded.
- *
+ * Adding more classes to the whitelist requires a security review for each
+ * one: any magic method that runs on unserialize (`__wakeup`, `__unserialize`)
+ * or on destruct (`__destruct`) can be turned into a gadget. `DateTime` for
+ * example has `__wakeup` and is therefore deliberately excluded.
  */
+
 /**
- * Encode an array into PHP's native 'php' session serialize format
- * (key|serialized_value for each key). This matches the format produced by
- * session.serialize_handler = php (the default in mod_php / phpredis).
+ * Encode an array into PHP's native `php` session serialize format
+ * (`key|serialized_value` for each key). Matches the format produced by
+ * `session.serialize_handler = php` (the default in mod_php / phpredis).
  *
  * @param array<string, mixed> $data
  */
@@ -47,6 +49,13 @@ function php_session_encode_from_array(array $data): string
 }
 
 /**
+ * Decode a PHP session string back to an associative array.
+ *
+ * Tries `unserialize()` first (handles the `php_serialize` handler format),
+ * then falls back to parsing the native `php` format (`key|serialized_value`
+ * pairs). All `unserialize()` calls use `['allowed_classes' => ['stdClass']]`
+ * — see the file-level security note above.
+ *
  * @return array<string, mixed>
  */
 function php_session_decode_to_array(string $data): array
@@ -88,7 +97,21 @@ function php_session_decode_to_array(string $data): array
 }
 
 /**
- * Start a new session or resume existing one
+ * Start a new session or resume an existing one.
+ *
+ * Coroutine-safe replacement for PHP's `session_start()`. Reads the session
+ * ID from the `PHPSESSID` cookie (or generates one for new visitors),
+ * loads session data from the file backend or a registered
+ * `\SessionHandlerInterface`, and stores it in `$g->session`.
+ *
+ * In superglobals mode (`App::$superglobals = true`) the data is also
+ * mirrored to `$_SESSION` (or bound via reference in coroutine-isolated
+ * superglobals mode). Emits a `Set-Cookie` header for first-time visitors
+ * when `App::$session_lifecycle` is `true` and the response is still
+ * writable.
+ *
+ * The `ZEALPHP_SESSION_SECURE` env var overrides the `secure` cookie flag
+ * (otherwise auto-detected from `X-Forwarded-Proto` / `HTTPS` / port `443`).
  */
 function zeal_session_start(): bool
 {
@@ -292,10 +315,16 @@ function zeal_valid_session_id(string $id): bool
 }
 
 /**
- * Get or set the session ID
+ * Get or set the session ID.
  *
- * @param string|null $id
- * @return string|false
+ * With no argument: reads the `PHPSESSID` (or custom session name) cookie
+ * from `$g->cookie`. When no cookie is present a fresh ID is generated via
+ * `session_create_id()` and stashed in `$g->cookie`. A malformed inbound ID
+ * (path traversal, NUL, oversized) is silently replaced with a fresh one
+ * (`session.use_strict_mode` parity).
+ *
+ * @param string|null $id  Pass a string to set the session ID explicitly.
+ * @return string|false  The current (or newly-set) session ID.
  */
 function zeal_session_id($id = null)
 {
@@ -337,6 +366,14 @@ function zeal_session_id($id = null)
     }
 }
 
+/**
+ * Return the current session status (`PHP_SESSION_ACTIVE` or `PHP_SESSION_NONE`).
+ *
+ * Mode-aware: in superglobals mode inspects `$GLOBALS['_SESSION']`; in
+ * coroutine mode checks whether the typed `$g->session` slot is initialised
+ * (it is `unset()` by `zeal_session_write_close()` / `zeal_session_destroy()`
+ * to mark a session inactive).
+ */
 function zeal_session_status(): int {
     // In superglobals mode the canonical "is session active?" signal is
     // $_SESSION's existence — the declared typed $g->session property is
@@ -357,10 +394,12 @@ function zeal_session_status(): int {
 
 
 /**
- * Get or set the session name
+ * Get or set the session name (the cookie name, e.g. `'PHPSESSID'`).
  *
- * @param string|null $name
- * @return string
+ * Stored per-request in `$g->session_params['name']`.
+ *
+ * @param string|null $name  Pass `null` to read the current value.
+ * @return string  The current (or newly-set) session name.
  */
 function zeal_session_name($name = null)
 {
@@ -376,7 +415,18 @@ function zeal_session_name($name = null)
 }
 
 /**
- * Write session data and close the session
+ * Write session data to the backing store and mark the session inactive.
+ *
+ * Coroutine-safe replacement for PHP's `session_write_close()`. Performs a
+ * read-merge-write under `flock(LOCK_EX)` (file backend) or an optimistic
+ * `WATCH`/`MULTI`/`EXEC` retry loop (custom `\SessionHandlerInterface`) to
+ * guard against concurrent-coroutine last-write-wins data loss on the same
+ * session ID. The merge is shallow — top-level keys added by a concurrent
+ * request survive, but conflicting nested arrays are last-write-wins.
+ *
+ * After writing, `$g->session` (coroutine mode) or `$GLOBALS['_SESSION']`
+ * (superglobals mode) is `unset()` so `zeal_session_status()` returns
+ * `PHP_SESSION_NONE` for the remainder of the request.
  */
 function zeal_session_write_close(): bool
 {
@@ -514,7 +564,11 @@ function zeal_session_write_close(): bool
 }
 
 /**
- * Destroy the session
+ * Destroy the session and delete its backing storage.
+ *
+ * Deletes the session file (or calls `\SessionHandlerInterface::destroy()` for
+ * custom backends), removes `$g->session` and `$_SESSION`, and clears the
+ * session cookie from `$g->cookie`. Sets `$g->_session_started` to `false`.
  */
 function zeal_session_destroy(): bool
 {
@@ -553,7 +607,11 @@ function zeal_session_destroy(): bool
 }
 
 /**
- * Unset all session variables
+ * Unset all session variables without destroying the session.
+ *
+ * Resets `$g->session` to `[]` and, in superglobals mode, also clears
+ * `$GLOBALS['_SESSION']`. The session file / backend entry is NOT deleted —
+ * call `zeal_session_destroy()` to remove it entirely.
  */
 function zeal_session_unset(): void
 {
@@ -565,9 +623,15 @@ function zeal_session_unset(): void
 }
 
 /**
- * Regenerate session ID
+ * Regenerate the session ID, optionally deleting the old session.
  *
- * @param bool $delete_old_session
+ * Coroutine-safe replacement for PHP's `session_regenerate_id()`. Copies the
+ * current in-memory session data to the new ID via the active backend (custom
+ * `\SessionHandlerInterface` or file), then emits a fresh `Set-Cookie` header
+ * so the client switches to the new ID. Gated by `App::$session_lifecycle`
+ * and `session.use_cookies` — same guards as `zeal_session_start()`.
+ *
+ * @param bool $delete_old_session  When `true`, the old session file/entry is deleted.
  */
 function zeal_session_regenerate_id($delete_old_session = false): bool
 {
@@ -644,7 +708,10 @@ function zeal_session_regenerate_id($delete_old_session = false): bool
 }
 
 /**
- * Get session cookie parameters
+ * Get the current session cookie parameters.
+ *
+ * Returns the array stored in `$g->session_params['cookie_params']`, falling
+ * back to safe defaults (`path='/'`, `httponly=true`, `samesite='Lax'`).
  *
  * @return array{lifetime: int, path: string, domain: string, secure: bool, httponly: bool, samesite?: string}
  */
@@ -667,10 +734,14 @@ function zeal_session_get_cookie_params(): array
 }
 
 /**
- * Set session cookie parameters. Accepts either positional args (PHP < 8.0)
- * or an options array (PHP 8.0+).
+ * Set session cookie parameters.
  *
- * @param int|array<string, mixed> $lifetime_or_options
+ * Accepts either the positional-args form (PHP < 8.0 style) or an options
+ * array (PHP 8.0+ `session_set_cookie_params(array $options)` style). Both
+ * are merged over the defaults `['lifetime'=>0, 'path'=>'/', 'domain'=>'',
+ * 'secure'=>false, 'httponly'=>false, 'samesite'=>'Lax']`.
+ *
+ * @param int|array<string, mixed> $lifetime_or_options  Integer lifetime in seconds, or an options array.
  * @param string $path
  * @param string $domain
  * @param bool   $secure
@@ -691,7 +762,11 @@ function zeal_session_set_cookie_params($lifetime_or_options, $path = '/', $doma
 }
 
 /**
- * @param string|null $cache_limiter
+ * Get or set the session cache limiter (e.g. `'nocache'`, `'public'`, `'private'`).
+ *
+ * Stored per-request in `$g->cache_limiter`. Defaults to `'nocache'`.
+ *
+ * @param string|null $cache_limiter  Pass `null` to read the current value.
  */
 function zeal_session_cache_limiter($cache_limiter = null): string
 {
@@ -705,13 +780,23 @@ function zeal_session_cache_limiter($cache_limiter = null): string
     }
 }
 
+/**
+ * Alias for `zeal_session_write_close()` — write session data and close.
+ *
+ * Mirrors PHP's `session_commit()`, which is itself an alias of
+ * `session_write_close()`.
+ */
 function zeal_session_commit(): bool
 {
     return zeal_session_write_close();
 }
 
 /**
- * @param int|null $cache_expire
+ * Get or set the session cache expiry in minutes.
+ *
+ * Stored per-request in `$g->cache_expire`. Defaults to `180` when not set.
+ *
+ * @param int|null $cache_expire  Pass `null` to read the current value.
  */
 function zeal_session_cache_expire($cache_expire = null): int
 {
@@ -725,6 +810,13 @@ function zeal_session_cache_expire($cache_expire = null): int
     }
 }
 
+/**
+ * Discard in-memory session changes and reload session data from the file.
+ *
+ * Mirrors PHP's `session_abort()`: any writes to `$g->session` or
+ * `$_SESSION` since the last `session_start()` are thrown away, and the
+ * session data is re-read from the session file on disk. Returns `true` always.
+ */
 function zeal_session_abort(): bool
 {
     $g = RequestContext::instance();
@@ -770,6 +862,12 @@ function zeal_session_abort(): bool
     return true;
 }
 
+/**
+ * Encode the current session data to PHP's `php` serialize format string.
+ *
+ * Reads from `$GLOBALS['_SESSION']` in superglobals mode, or from
+ * `RequestContext::instance()->session` in coroutine mode.
+ */
 function zeal_session_encode(): string
 {
     $data = \ZealPHP\App::$superglobals
@@ -780,6 +878,14 @@ function zeal_session_encode(): string
     return php_session_encode_from_array($narrowed);
 }
 
+/**
+ * Decode a session data string and populate the active session.
+ *
+ * Mirrors PHP's `session_decode()`: parses `$data` via
+ * `php_session_decode_to_array()` and stores the result in both `$g->session`
+ * and `$GLOBALS['_SESSION']` (in superglobals mode). Returns `false` when
+ * `$data` is empty or decodes to an empty array.
+ */
 function zeal_session_decode(string $data): bool
 {
     if ($data === '') {
@@ -797,8 +903,12 @@ function zeal_session_decode(string $data): bool
 }
 
 /**
- * @param string $prefix
- * @return string|false
+ * Create a new session ID, optionally with a `$prefix`.
+ *
+ * Thin wrapper around PHP's `session_create_id()`.
+ *
+ * @param string $prefix  Optional prefix prepended to the generated ID.
+ * @return string|false  The new session ID, or `false` on failure.
  */
 function zeal_session_create_id($prefix = '')
 {
@@ -806,8 +916,13 @@ function zeal_session_create_id($prefix = '')
 }
 
 /**
- * @param string|null $path
- * @return string
+ * Get or set the session save path.
+ *
+ * Stored per-request in `$g->session_params['save_path']`. Defaults to
+ * `'/var/lib/php/sessions'` when not set.
+ *
+ * @param string|null $path  Pass `null` to read the current value.
+ * @return string  The current (or newly-set) save path.
  */
 function zeal_session_save_path($path = null)
 {
@@ -823,7 +938,13 @@ function zeal_session_save_path($path = null)
 }
 
 /**
- * @param string|null $module
+ * Get or set the session module name (e.g. `'files'`, `'redis'`).
+ *
+ * Stored per-request in `$g->session_module_name`. Defaults to `'files'`
+ * when not set. This is a ZealPHP-internal tracking field; the actual
+ * backend is determined by the registered `\SessionHandlerInterface`.
+ *
+ * @param string|null $module  Pass `null` to read the current value.
  */
 function zeal_session_module_name($module = null): string
 {

--- a/src/Store/DriverPreference.php
+++ b/src/Store/DriverPreference.php
@@ -6,21 +6,33 @@ namespace ZealPHP\Store;
 
 /**
  * Type-safe enum for `RedisClient`'s driver selection. Accepted by
- * `Store::defaultBackend()` via the `prefer` opt and by
- * `RedisClient::__construct`'s opts.
+ * `Store::defaultBackend()` via the `'prefer'` opt and by
+ * `RedisClient::__construct()`'s opts array.
  *
- *   Store::defaultBackend(StoreBackendKind::Redis, [
- *       'prefer' => DriverPreference::Predis,        // ← typed
- *   ]);
- *   // or the BC string form:
- *   Store::defaultBackend('redis', ['prefer' => 'predis']);
+ * ```php
+ * Store::defaultBackend(StoreBackendKind::Redis, [
+ *     'prefer' => DriverPreference::Predis,   // typed form
+ * ]);
+ * // or the BC string form:
+ * Store::defaultBackend('redis', ['prefer' => 'predis']);
+ * ```
  */
 enum DriverPreference: string
 {
+    /** Auto-detect: prefer `ext-redis` (phpredis) when loaded, fall back to predis. */
     case Auto     = 'auto';
+    /** Force the `ext-redis` (phpredis) extension. Throws if not loaded. */
     case Phpredis = 'phpredis';
+    /** Force the pure-PHP predis library. */
     case Predis   = 'predis';
 
+    /**
+     * Coerce a string or existing `DriverPreference` case to a `DriverPreference`.
+     *
+     * Accepts `'auto'`, `'phpredis'`, or `'predis'` (case-insensitive).
+     *
+     * @throws \InvalidArgumentException on an unrecognised string.
+     */
     public static function coerce(self|string $pref): self
     {
         if ($pref instanceof self) { return $pref; }

--- a/src/Store/MemcachedBackend.php
+++ b/src/Store/MemcachedBackend.php
@@ -60,6 +60,12 @@ final class MemcachedBackend implements StoreBackend
         }
     }
 
+    /**
+     * Register a named table with its column schema. `$maxRows` is informational
+     * only — Memcached is a global pool with server-side LRU eviction; no hard
+     * cap is enforced here. Pass `$opts['ttl']` (int seconds, default `0` = no
+     * expiry) to set a per-table TTL applied on every `set()` call.
+     */
     public function make(string $name, int $maxRows, array $columns, array $opts = []): void
     {
         if ($columns === []) {
@@ -73,6 +79,11 @@ final class MemcachedBackend implements StoreBackend
         $this->tableOpts[$name] = ['ttl' => $ttl];
     }
 
+    /**
+     * Serialize and store a row in Memcached. The row is stored as a single
+     * serialized value at `{prefix}:{table}:{key}`. The table-level TTL
+     * (set via `make()` `$opts['ttl']`) is applied; `0` means no expiry.
+     */
     public function set(string $name, string $key, array $row): bool
     {
         $this->assertMade($name);
@@ -80,6 +91,11 @@ final class MemcachedBackend implements StoreBackend
         return $this->client->set($this->rowKey($name, $key), $row, $ttl);
     }
 
+    /**
+     * Retrieve a row or a single field from Memcached. Returns `null` on
+     * miss. When `$field` is provided, returns the scalar value of that
+     * column or `null` if the column is absent.
+     */
     public function get(string $name, string $key, ?string $field = null): mixed
     {
         $this->assertMade($name);
@@ -92,12 +108,14 @@ final class MemcachedBackend implements StoreBackend
         return $raw;
     }
 
+    /** Delete a row from Memcached. Returns `true` when the key existed and was removed. */
     public function del(string $name, string $key): bool
     {
         $this->assertMade($name);
         return $this->client->delete($this->rowKey($name, $key));
     }
 
+    /** Return `true` when a row exists in Memcached for the given key. */
     public function exists(string $name, string $key): bool
     {
         $this->assertMade($name);
@@ -109,6 +127,12 @@ final class MemcachedBackend implements StoreBackend
         return $r !== false;
     }
 
+    /**
+     * Read-modify-write increment of column `$col` by `$by`.
+     * NOT atomic across concurrent workers — Memcached has no native hash
+     * `HINCRBY` equivalent. For cross-node atomic counters use `Counter`
+     * with a `RedisCounterBackend` instead.
+     */
     public function incr(string $name, string $key, string $col, int|float $by = 1): int|float
     {
         $this->assertMade($name);
@@ -135,11 +159,17 @@ final class MemcachedBackend implements StoreBackend
         return $new;
     }
 
+    /** Decrement column `$col` by `$by` via `incr()` with a negated delta. Not atomic — see `incr()`. */
     public function decr(string $name, string $key, string $col, int|float $by = 1): int|float
     {
         return $this->incr($name, $key, $col, -$by);
     }
 
+    /**
+     * Not supported — Memcached has no native SCAN.
+     * Throws `StoreException`. Use the Redis backend for iteration workloads,
+     * or maintain your own cardinality counter.
+     */
     public function count(string $name): int
     {
         throw new StoreException(
@@ -148,6 +178,10 @@ final class MemcachedBackend implements StoreBackend
         );
     }
 
+    /**
+     * Not supported — Memcached has no native SCAN.
+     * Throws `StoreException`. Use the Redis backend for iterable Store tables.
+     */
     public function iterate(string $name): \Generator
     {
         throw new StoreException(
@@ -156,6 +190,10 @@ final class MemcachedBackend implements StoreBackend
         );
     }
 
+    /**
+     * Not supported — Memcached has no native SCAN.
+     * Throws `StoreException`. Use the Redis backend for paginated Store iteration.
+     */
     public function iteratePaged(string $name, string $cursor = '0', int $count = 100): array
     {
         throw new StoreException(
@@ -164,6 +202,11 @@ final class MemcachedBackend implements StoreBackend
         );
     }
 
+    /**
+     * Not supported — tracking every written key would be required.
+     * Throws `StoreException`. Use the `flush_all` Memcached admin command,
+     * or set per-table TTLs via `make()` and let entries expire naturally.
+     */
     public function clear(string $name): void
     {
         throw new StoreException(
@@ -172,11 +215,16 @@ final class MemcachedBackend implements StoreBackend
         );
     }
 
+    /** Return the names of all tables registered via `make()`. */
     public function names(): array
     {
         return array_keys($this->schemas);
     }
 
+    /**
+     * Bulk read multiple rows in one `getMulti()` round-trip.
+     * Missing keys are returned as `null` in the result map.
+     */
     public function mget(string $name, array $keys): array
     {
         $this->assertMade($name);
@@ -195,6 +243,11 @@ final class MemcachedBackend implements StoreBackend
         return $out;
     }
 
+    /**
+     * Bulk write multiple rows via one `setMulti()` round-trip.
+     * Atomicity is per-key (not across all keys). Returns `true` when
+     * all writes succeeded.
+     */
     public function mset(string $name, array $rows): bool
     {
         $this->assertMade($name);
@@ -209,6 +262,10 @@ final class MemcachedBackend implements StoreBackend
         return $this->client->setMulti($batch, $ttl);
     }
 
+    /**
+     * Ping the Memcached cluster. Returns `true` when at least one server
+     * responded to `getStats()`. Returns `false` when all servers are unreachable.
+     */
     public function ping(): bool
     {
         // getStats() returns the per-server stats map. PHPStan's stub
@@ -217,10 +274,17 @@ final class MemcachedBackend implements StoreBackend
         return $this->client->getStats() !== [];
     }
 
+    /** Return the underlying `\Memcached` client instance for direct use. */
     public function client(): \Memcached { return $this->client; }
+
+    /** Return the key prefix used for all Memcached keys (e.g. `zealstore`). */
     public function prefix(): string { return $this->prefix; }
 
     /**
+     * Parse a comma-separated host[:port] server list into an array of
+     * `[host, port]` pairs. Defaults to port `11211` when omitted.
+     * Falls back to `['127.0.0.1', 11211]` when `$servers` is empty.
+     *
      * @return list<array{0:string, 1:int}>
      */
     private static function parseServers(string $servers): array
@@ -236,6 +300,10 @@ final class MemcachedBackend implements StoreBackend
         return $out;
     }
 
+    /**
+     * Build the Memcached key for a row. Keeps composite keys within
+     * Memcached's 250-character limit by SHA1-hashing keys longer than 240 chars.
+     */
     private function rowKey(string $table, string $key): string
     {
         // Memcached key max is 250 chars and bans control chars. Hash long
@@ -245,6 +313,10 @@ final class MemcachedBackend implements StoreBackend
     }
 
     /**
+     * Coerce a raw deserialized row to `array<string, scalar>`, dropping
+     * any non-scalar values (which can't arise from `set()` but may appear
+     * from external writes or future schema changes).
+     *
      * @param  array<int|string, mixed> $row
      * @return array<string, scalar>
      */
@@ -257,6 +329,11 @@ final class MemcachedBackend implements StoreBackend
         return $out;
     }
 
+    /**
+     * Assert that a table has been registered via `make()`.
+     * Throws `StoreException` when the table is unknown, surfacing the "call
+     * `Store::make()` before `App::run()`" contract violation clearly.
+     */
     private function assertMade(string $name): void
     {
         if (!isset($this->schemas[$name])) {

--- a/src/Store/PhpredisDriver.php
+++ b/src/Store/PhpredisDriver.php
@@ -15,6 +15,11 @@ final class PhpredisDriver implements RedisDriver
     /** Original URL kept so subscribe() can spawn fresh per-coroutine clients. */
     private string $url;
 
+    /**
+     * Connect to the Redis server at `$url` using the `phpredis` extension.
+     * Throws `StoreException` when `ext-redis` is not loaded, or when the
+     * connection attempt fails.
+     */
     public function __construct(string $url)
     {
         if (!extension_loaded('redis')) {
@@ -82,8 +87,13 @@ final class PhpredisDriver implements RedisDriver
         ];
     }
 
+    /** Return the driver identifier string `'phpredis'`. */
     public function name(): string { return 'phpredis'; }
 
+    /**
+     * Set a plain string key. Applies `EX $ttlSeconds` when provided.
+     * Returns `true` on success.
+     */
     public function set(string $key, string $value, ?int $ttlSeconds = null): bool
     {
         try {
@@ -94,6 +104,7 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Get a plain string key. Returns `null` on miss or when the key doesn't exist. */
     public function get(string $key): ?string
     {
         try {
@@ -106,6 +117,10 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Delete one or more keys. Returns the number of keys that were removed.
+     * No-op (returns `0`) when called with an empty list.
+     */
     public function del(string ...$keys): int
     {
         if ($keys === []) { return 0; }
@@ -113,6 +128,7 @@ final class PhpredisDriver implements RedisDriver
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Return `true` when the key exists in Redis. */
     public function exists(string $key): bool
     {
         try {
@@ -121,12 +137,19 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Set an expiry of `$ttlSeconds` on `$key` via Redis `EXPIRE`. Returns `true` on success. */
     public function expire(string $key, int $ttlSeconds): bool
     {
         try { return $this->c->expire($key, $ttlSeconds); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Set multiple hash fields via `HMSET`. Returns the number of fields written.
+     * No-op (returns `0`) when `$fields` is empty.
+     *
+     * @param array<string, string> $fields
+     */
     public function hset(string $key, array $fields): int
     {
         if ($fields === []) { return 0; }
@@ -136,6 +159,12 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Return all fields and values of a hash via `HGETALL`.
+     * Returns an empty array when the key does not exist.
+     *
+     * @return array<string, string>
+     */
     public function hgetall(string $key): array
     {
         try {
@@ -145,6 +174,13 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Return the values of specific hash `$fields` via `HMGET`. Missing fields
+     * are returned as `null` at the corresponding index position.
+     *
+     * @param array<int, string> $fields
+     * @return array<int, string|null>
+     */
     public function hmget(string $key, array $fields): array
     {
         if ($fields === []) { return []; }
@@ -162,18 +198,24 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Atomically increment a hash field by `$by` (integer) via `HINCRBY`. Returns the new value. */
     public function hincrby(string $key, string $field, int $by): int
     {
         try { return $this->c->hIncrBy($key, $field, $by); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Atomically increment a hash field by `$by` (float) via `HINCRBYFLOAT`. Returns the new value. */
     public function hincrbyfloat(string $key, string $field, float $by): float
     {
         try { return $this->c->hIncrByFloat($key, $field, $by); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Delete one or more hash fields via `HDEL`. Returns the number of fields removed.
+     * No-op (returns `0`) when called with an empty list.
+     */
     public function hdel(string $key, string ...$fields): int
     {
         if ($fields === []) { return 0; }
@@ -181,6 +223,12 @@ final class PhpredisDriver implements RedisDriver
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Add members to a Redis Set via `SADD`. Returns the number of members actually added
+     * (existing members are ignored). No-op (returns `0`) when `$members` is empty.
+     *
+     * @param array<int, string> $members
+     */
     public function sadd(string $key, array $members): int
     {
         if ($members === []) { return 0; }
@@ -188,6 +236,12 @@ final class PhpredisDriver implements RedisDriver
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Remove members from a Redis Set via `SREM`. Returns the number of members removed.
+     * No-op (returns `0`) when `$members` is empty.
+     *
+     * @param array<int, string> $members
+     */
     public function srem(string $key, array $members): int
     {
         if ($members === []) { return 0; }
@@ -195,12 +249,19 @@ final class PhpredisDriver implements RedisDriver
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Return the cardinality of a Redis Set via `SCARD`. O(1). */
     public function scard(string $key): int
     {
         try { return $this->c->sCard($key); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Full set scan via `SSCAN`. Yields string members one at a time across
+     * all scan batches. Use `sscanCursor()` for paginated access.
+     *
+     * @return \Generator<int, string>
+     */
     public function sscan(string $key, int $batch = 100): \Generator
     {
         try {
@@ -213,6 +274,14 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Single-batch `SSCAN` with cursor. Returns `[next-cursor, members]`.
+     * A returned cursor of `'0'` signals end-of-scan. `phpredis` takes the
+     * cursor by reference (int|null) — this method drives it exactly once
+     * and coerces the result to the string-cursor contract.
+     *
+     * @return array{0:string, 1:list<string>}
+     */
     public function sscanCursor(string $key, string $cursor, int $count): array
     {
         try {
@@ -229,24 +298,40 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Atomically increment a plain string counter key by `$by` via `INCRBY`. Returns the new value. */
     public function incrby(string $key, int $by): int
     {
         try { return $this->c->incrBy($key, $by); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Atomically decrement a plain string counter key by `$by` via `DECRBY`. Returns the new value. */
     public function decrby(string $key, int $by): int
     {
         try { return $this->c->decrBy($key, $by); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Execute a Lua script server-side via `EVAL`. Server-atomic — no other
+     * command interleaves during execution. `$keys` are the `KEYS[n]` values
+     * (cluster-routing hint); `$args` are the `ARGV[n]` values.
+     *
+     * @param array<int, string> $keys
+     * @param array<int, string> $args
+     */
     public function evalScript(string $script, array $keys, array $args): mixed
     {
         try { return $this->c->eval($script, array_merge($keys, $args), count($keys)); }
         catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Full keyspace scan matching `$match` via `SCAN`. Yields string keys one
+     * at a time across all batches. Use `scanCursor()` for paginated access.
+     *
+     * @return \Generator<int, string>
+     */
     public function scanKeys(string $match, int $batch = 200): \Generator
     {
         try {
@@ -259,6 +344,12 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Single-batch keyspace `SCAN` with cursor. Returns `[next-cursor, keys]`.
+     * A returned cursor of `'0'` signals end-of-scan.
+     *
+     * @return array{0:string, 1:list<string>}
+     */
     public function scanCursor(string $match, string $cursor, int $count): array
     {
         try {
@@ -271,6 +362,7 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Ping the Redis server. Returns `true` when the server responds with `PONG`. */
     public function ping(): bool
     {
         try {
@@ -279,6 +371,10 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Close the underlying `\Redis` connection. Tolerant on failure —
+     * logs at `debug` level via `elog()` rather than throwing (H9 hardening).
+     */
     public function close(): void
     {
         try {
@@ -295,6 +391,14 @@ final class PhpredisDriver implements RedisDriver
         }
     }
 
+    /**
+     * Execute a batch of commands in a single pipelined round-trip via
+     * `Redis::PIPELINE`. The `$batch` callable receives the pipeline object
+     * and queues commands on it; results are returned as a flat list in
+     * command order.
+     *
+     * @return list<mixed>
+     */
     public function pipeline(callable $batch): array
     {
         try {
@@ -305,6 +409,13 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Pipelined `HGETALL` for multiple keys (H3 hardening). Returns a list of
+     * hash maps in the same order as `$keys`; empty arrays for non-existent keys.
+     *
+     * @param  array<int, string>             $keys
+     * @return array<int, array<string, string>>
+     */
     public function mhgetall(array $keys): array
     {
         if ($keys === []) { return []; }
@@ -327,6 +438,13 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Pipelined bulk write: `HMSET` each row, optionally `EXPIRE` it, and
+     * optionally `SADD` its membership key to `$setKey` — all in a single
+     * pipeline round-trip (H3 hardening). Used by `RedisBackend::mset()`.
+     *
+     * @param array<int, array{rk:string, fields:array<string,string>, sk?:string}> $writes
+     */
     public function mhsetWithMembership(array $writes, ?string $setKey = null, ?int $ttl = null): void
     {
         if ($writes === []) { return; }
@@ -350,6 +468,11 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Asynchronously delete keys via `UNLINK` (non-blocking reclaim, unlike `DEL`).
+     * Returns the number of keys that existed. No-op (returns `0`) when called
+     * with an empty list.
+     */
     public function unlink(string ...$keys): int
     {
         if ($keys === []) { return 0; }
@@ -362,6 +485,10 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Publish `$payload` to a Redis pub/sub `$channel` via `PUBLISH`.
+     * Returns the number of subscribers that received the message.
+     */
     public function publish(string $channel, string $payload): int
     {
         try {
@@ -446,6 +573,13 @@ final class PhpredisDriver implements RedisDriver
         }
     }
 
+    /**
+     * Append an entry to a Redis Stream via `XADD`. Returns the auto-generated
+     * entry ID (e.g. `'1710000000000-0'`). Applies `MAXLEN ~` trimming when
+     * `$maxLen` is provided. Throws `StoreException` when `$fields` is empty.
+     *
+     * @param array<string, string> $fields
+     */
     public function xadd(string $stream, array $fields, ?int $maxLen = null): string
     {
         if ($fields === []) { throw new StoreException('xadd(): fields must be non-empty'); }
@@ -458,6 +592,12 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Create a consumer group on `$stream` starting at `$id` (default `'$'` = only
+     * new entries). When `$mkStream` is `true`, creates the stream if it doesn't
+     * exist. Returns `true` on success, `false` when the group already exists
+     * (`BUSYGROUP` — treated as idempotent).
+     */
     public function xgroupCreate(string $stream, string $group, string $id = '$', bool $mkStream = true): bool
     {
         try {
@@ -471,6 +611,14 @@ final class PhpredisDriver implements RedisDriver
         }
     }
 
+    /**
+     * Read new entries from one or more streams via `XREADGROUP`. Blocks for
+     * up to `$blockMs` milliseconds when no new entries are available.
+     * Returns a map of stream name → list of `{id, payload}` entries.
+     *
+     * @param  array<int, string> $streams
+     * @return array<string, list<array{id: string, payload: array<string, string>}>>
+     */
     public function xreadGroup(string $group, string $consumer, array $streams, int $count, int $blockMs): array
     {
         if ($streams === []) { return []; }
@@ -498,6 +646,11 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Acknowledge one or more stream entries via `XACK`, removing them from
+     * the consumer group's pending-entries list. Returns the number of entries
+     * successfully acknowledged. No-op (returns `0`) when called with no IDs.
+     */
     public function xack(string $stream, string $group, string ...$ids): int
     {
         if ($ids === []) { return 0; }
@@ -507,6 +660,13 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Claim pending stream entries that have been idle for at least `$minIdleMs`
+     * milliseconds via `XAUTOCLAIM`. Used to recover messages from dead consumers.
+     * Returns `[next-cursor, entries]`; iterate until cursor is `'0-0'` to drain.
+     *
+     * @return array{0:string, 1:list<array{id:string, payload:array<string, string>}>}
+     */
     public function xautoclaim(
         string $stream,
         string $group,
@@ -538,6 +698,7 @@ final class PhpredisDriver implements RedisDriver
         } catch (\RedisException $e) { throw $this->wrap($e); }
     }
 
+    /** Wrap a `\RedisException` in a `StoreException` with a `phpredis:` prefix for uniform error handling. */
     private function wrap(\RedisException $e): StoreException
     {
         return new StoreException('phpredis: ' . $e->getMessage(), 0, $e);

--- a/src/Store/PredisDriver.php
+++ b/src/Store/PredisDriver.php
@@ -286,11 +286,16 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /** Disconnect from Redis, silently swallowing any errors (tolerant close). */
     public function close(): void
     {
         try { $this->c->disconnect(); } catch (\Throwable $e) { /* tolerant */ }
     }
 
+    /**
+     * Publish a message to a Redis pub/sub channel. Returns the number of subscribers
+     * that received the message.
+     */
     public function publish(string $channel, string $payload): int
     {
         try {
@@ -300,6 +305,11 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Enter a blocking pub/sub loop, dispatching each received message to `$consumer($payload, $channel, $pattern)`.
+     * Exact channels use `SUBSCRIBE`; pattern channels use `PSUBSCRIBE`. Throw `PubSubStopException`
+     * from inside `$consumer` to cleanly exit the loop.
+     */
     public function subscribe(array $exactChannels, array $patternChannels, callable $consumer): void
     {
         if ($exactChannels === [] && $patternChannels === []) {
@@ -329,6 +339,11 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Append an entry to a Redis Stream (`XADD`). Returns the auto-generated entry ID.
+     * When `$maxLen` is set, trims the stream to approximately that length (`MAXLEN ~`).
+     * Throws `StoreException` when `$fields` is empty.
+     */
     public function xadd(string $stream, array $fields, ?int $maxLen = null): string
     {
         if ($fields === []) {
@@ -345,6 +360,11 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Create a consumer group (`XGROUP CREATE`). Returns `true` on success, `false` when the
+     * group already exists (`BUSYGROUP` — idempotent). When `$mkStream` is `true`, the stream
+     * is created if absent (`MKSTREAM`).
+     */
     public function xgroupCreate(string $stream, string $group, string $id = '$', bool $mkStream = true): bool
     {
         try {
@@ -360,6 +380,11 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Read new entries from one or more streams as a consumer group member (`XREADGROUP GROUP … BLOCK`).
+     * Returns `array<streamName, list<array{id:string, payload:array<string,string>}>>`.
+     * Returns `[]` on timeout (blocking expired with no messages) or empty `$streams`.
+     */
     public function xreadGroup(string $group, string $consumer, array $streams, int $count, int $blockMs): array
     {
         if ($streams === []) { return []; }
@@ -399,6 +424,10 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Acknowledge one or more processed stream entries (`XACK`). Returns the number of entries
+     * successfully acknowledged. Unrecognised IDs are silently ignored by Redis.
+     */
     public function xack(string $stream, string $group, string ...$ids): int
     {
         if ($ids === []) { return 0; }
@@ -411,6 +440,12 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Claim pending stream entries idle for at least `$minIdleMs` milliseconds (`XAUTOCLAIM`).
+     * Returns `[nextCursor, list<array{id:string, payload:array<string,string>}>]`.
+     * Iterate until `nextCursor === '0-0'` to drain all orphan entries. Compatible with
+     * Redis 6 (2-element response) and Redis 7 (3-element response with deleted IDs).
+     */
     public function xautoclaim(
         string $stream,
         string $group,
@@ -452,6 +487,11 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Execute a batch of Redis commands in a single pipeline round-trip.
+     * `$batch` receives the predis `Pipeline` object; queue commands on it.
+     * Returns an indexed array of raw responses in command order.
+     */
     public function pipeline(callable $batch): array
     {
         try {
@@ -464,6 +504,13 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Pipelined batch `HGETALL` for multiple hash keys. Returns an indexed array (same
+     * order as `$keys`) where each element is an `array<string,string>` of field→value pairs
+     * (empty array for a missing key). Uses `Predis\Command\RawCommand` to keep PHPStan happy
+     * on the pipeline surface; pairs the flat multi-bulk response into assoc form for both
+     * old and new predis response shapes.
+     */
     public function mhgetall(array $keys): array
     {
         if ($keys === []) { return []; }
@@ -509,6 +556,12 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Pipelined batch `HMSET` with optional per-key TTL and optional set-membership tracking.
+     * Each entry in `$writes` is `array{rk: string, fields: array<string,string>, sk?: string}`:
+     * `rk` is the hash key, `fields` are the field→value pairs, `sk` (when `$setKey` is set)
+     * is the member to add to the tracking `SET`. All commands run in a single pipeline round-trip.
+     */
     public function mhsetWithMembership(array $writes, ?string $setKey = null, ?int $ttl = null): void
     {
         if ($writes === []) { return; }
@@ -538,6 +591,10 @@ final class PredisDriver implements RedisDriver
         } catch (PredisException $e) { throw $this->wrap($e); }
     }
 
+    /**
+     * Non-blocking key deletion via `UNLINK` (async reclaim, unlike `DEL`).
+     * Returns the number of keys scheduled for deletion. Returns `0` for empty input.
+     */
     public function unlink(string ...$keys): int
     {
         if ($keys === []) { return 0; }
@@ -552,6 +609,10 @@ final class PredisDriver implements RedisDriver
 
     // ── narrowing helpers ─────────────────────────────────────────────────
 
+    /**
+     * Return `true` when the raw Redis response equals `$expect` (string comparison,
+     * with `__toString` fallback for predis status objects like `Status::get('OK')`).
+     */
     private function isOkStatus(mixed $r, string $expect = 'OK'): bool
     {
         if (is_string($r)) { return $r === $expect; }
@@ -559,6 +620,10 @@ final class PredisDriver implements RedisDriver
         return false;
     }
 
+    /**
+     * Narrow a mixed Redis response to `int`. Accepts numeric strings.
+     * Throws `StoreException` with the `$op` context when the value is neither.
+     */
     private function asInt(mixed $r, string $op): int
     {
         if (is_int($r)) { return $r; }
@@ -566,6 +631,10 @@ final class PredisDriver implements RedisDriver
         throw new StoreException("predis $op: expected int, got " . get_debug_type($r));
     }
 
+    /**
+     * Narrow a mixed Redis response to `string`. Accepts scalars and objects with `__toString`.
+     * Throws `StoreException` with the `$op` context for non-stringable values.
+     */
     private function asString(mixed $r, string $op): string
     {
         if (is_string($r)) { return $r; }
@@ -595,6 +664,7 @@ final class PredisDriver implements RedisDriver
         return [(int) $cursor, $items];
     }
 
+    /** Wrap a `PredisException` in a `StoreException` for uniform error handling across drivers. */
     private function wrap(PredisException $e): StoreException
     {
         return new StoreException('predis: ' . $e->getMessage(), 0, $e);

--- a/src/Store/PubSubStopException.php
+++ b/src/Store/PubSubStopException.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace ZealPHP\Store;
 
 /**
- * Sentinel thrown from inside a SUBSCRIBE consumer to signal clean
- * shutdown. The driver's `subscribe()` MUST catch this exception,
+ * Sentinel thrown from inside a `SUBSCRIBE` consumer to signal clean shutdown.
+ *
+ * The driver's `subscribe()` implementation MUST catch this exception,
  * unsubscribe, and return without rethrowing.
  *
- * Used by `RedisPubSub::stop()` and `RedisStreams::stop()` to wake
- * the runner cor out of a blocking read.
+ * Used by `RedisPubSub::stop()` and `RedisStreams::stop()` to wake the runner
+ * coroutine out of a blocking read.
  */
 final class PubSubStopException extends \RuntimeException
 {

--- a/src/Store/RedisBackend.php
+++ b/src/Store/RedisBackend.php
@@ -7,31 +7,45 @@ namespace ZealPHP\Store;
 use OpenSwoole\Table;
 
 /**
- * Redis/Valkey-backed StoreBackend.
+ * Redis/Valkey-backed `StoreBackend`.
  *
  * Row layout: HASH at `{prefix}:{table}:{key}` (columns → hash fields).
  * Membership (tracked mode): SET at `{prefix}:{table}:__keys__`.
  *
- * Two modes chosen at make():
- *  - 'tracked' (default) — SET-backed; count() is O(1) via SCARD,
- *    iterate() via SSCAN. No TTL (an expired key cannot fire SREM
+ * Two modes chosen at `make()`:
+ *  - `'tracked'` (default) — SET-backed; `count()` is O(1) via `SCARD`,
+ *    `iterate()` via `SSCAN`. No TTL (an expired key cannot fire `SREM`
  *    on the membership set, which would drift).
- *  - 'ttl' — per-key expiry via SETEX-style; count() / iterate() use
- *    SCAN MATCH (O(N)) because tracked membership isn't viable. Pick
- *    one per table; the trade-off is documented in CLAUDE.md.
+ *  - `'ttl'` — per-key expiry via `EXPIRE`; `count()` / `iterate()` use
+ *    `SCAN MATCH` (O(N)) because tracked membership isn't viable. Pick
+ *    one per table; the trade-off is documented in `CLAUDE.md`.
  *
- * Every op goes through RedisConnectionPool::with() so concurrent
+ * Every op goes through `RedisConnectionPool::with()` so concurrent
  * coroutines never share a socket.
  */
 final class RedisBackend implements StoreBackend
 {
-    /** @var array<string, array<string, array{0:int, 1?:int}>> */
+    /**
+     * Per-table column schemas: `table name → column name → [TYPE, size?]`.
+     *
+     * @var array<string, array<string, array{0:int, 1?:int}>>
+     */
     private array $schemas = [];
-    /** @var array<string, array{mode:string, ttl:int}> */
+
+    /**
+     * Per-table options: `table name → ['mode' => 'tracked'|'ttl', 'ttl' => int]`.
+     *
+     * @var array<string, array{mode:string, ttl:int}>
+     */
     private array $tableOpts = [];
 
+    /** Encodes/decodes PHP scalars to/from Redis hash field strings. */
     private TypeCodec $codec;
 
+    /**
+     * @param RedisConnectionPool $pool   Coroutine-safe connection pool.
+     * @param string              $prefix Key namespace prefix (default `'zealstore'`).
+     */
     public function __construct(
         private RedisConnectionPool $pool,
         private string $prefix = 'zealstore',
@@ -39,6 +53,23 @@ final class RedisBackend implements StoreBackend
         $this->codec = new TypeCodec();
     }
 
+    /**
+     * Register a table schema on the Redis backend.
+     *
+     * Must be called before any `set`/`get`/`del`/`incr`/`count`/`iterate`
+     * operations on the named table. Accepts the same `$columns` shape as
+     * `TableBackend::make()` (`column => [TYPE, size?]`). `$maxRows` is
+     * advisory only — Redis has no hard cap; use `maxmemory` +
+     * `maxmemory-policy` server-side instead.
+     *
+     * `$opts` accepts:
+     * - `'mode'` — `'tracked'` (default) or `'ttl'`. See class docblock.
+     * - `'ttl'`  — TTL in seconds; required and >= 1 when `mode = 'ttl'`.
+     *
+     * @param array<string, array{0:int, 1?:int}> $columns Column definitions.
+     * @param array<string, mixed>                 $opts    Table options.
+     * @throws StoreException When mode is unknown, `'tracked'` + `ttl > 0`, or `'ttl'` mode with `ttl < 1`.
+     */
     public function make(string $name, int $maxRows, array $columns, array $opts = []): void
     {
         if ($columns === []) {
@@ -68,6 +99,13 @@ final class RedisBackend implements StoreBackend
         $this->tableOpts[$name] = ['mode' => $mode, 'ttl' => $ttl];
     }
 
+    /**
+     * Write a row to the named table. Creates or overwrites the Redis HASH at
+     * `{prefix}:{name}:{key}` and, in `'tracked'` mode, adds `$key` to the
+     * membership SET. Applies `EXPIRE` in `'ttl'` mode.
+     *
+     * @param array<string, bool|float|int|string> $row Column values to store.
+     */
     public function set(string $name, string $key, array $row): bool
     {
         $this->assertMade($name);
@@ -89,6 +127,14 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /**
+     * Fetch a row or a single field from the named table.
+     *
+     * When `$field` is `null`, returns the full decoded row as
+     * `array<string, mixed>` or `null` when the key does not exist.
+     * When `$field` is provided, returns only that field's decoded value
+     * (or `null` on miss).
+     */
     public function get(string $name, string $key, ?string $field = null): mixed
     {
         $this->assertMade($name);
@@ -105,6 +151,12 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /**
+     * Delete a row from the named table.
+     *
+     * In `'tracked'` mode also removes `$key` from the membership SET.
+     * Returns `true` when the key existed and was deleted, `false` otherwise.
+     */
     public function del(string $name, string $key): bool
     {
         $this->assertMade($name);
@@ -120,6 +172,7 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /** Returns `true` when the row for `$key` exists in the named table. */
     public function exists(string $name, string $key): bool
     {
         $this->assertMade($name);
@@ -127,6 +180,15 @@ final class RedisBackend implements StoreBackend
         return (bool) $this->pool->with(fn(RedisClient $c): bool => $c->exists($rk));
     }
 
+    /**
+     * Atomically increment a numeric column in a row.
+     *
+     * Uses `HINCRBY` for `TYPE_INT` columns and `HINCRBYFLOAT` for `TYPE_FLOAT`.
+     * Creates the row if it does not exist. In `'tracked'` mode, adds the key to
+     * the membership SET on first creation. Applies `EXPIRE` in `'ttl'` mode.
+     *
+     * @return int|float The new value after incrementing.
+     */
     public function incr(string $name, string $key, string $col, int|float $by = 1): int|float
     {
         $this->assertMade($name);
@@ -151,11 +213,22 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /**
+     * Atomically decrement a numeric column — delegates to `incr()` with `-$by`.
+     *
+     * @return int|float The new value after decrementing.
+     */
     public function decr(string $name, string $key, string $col, int|float $by = 1): int|float
     {
         return $this->incr($name, $key, $col, -$by);
     }
 
+    /**
+     * Return the number of rows in the named table.
+     *
+     * In `'tracked'` mode: O(1) via `SCARD` on the membership SET.
+     * In `'ttl'` mode: O(N) via `SCAN MATCH` (see `countViaScan()`).
+     */
     public function count(string $name): int
     {
         $this->assertMade($name);
@@ -166,6 +239,17 @@ final class RedisBackend implements StoreBackend
         return $this->pool->with(fn(RedisClient $c): int => $c->scard($sk));
     }
 
+    /**
+     * Yield every row in the named table as `$key => $row`.
+     *
+     * In `'tracked'` mode, iterates the membership SET via `SSCAN` then
+     * fetches each row with `HGETALL`. In `'ttl'` mode, uses `SCAN MATCH`
+     * across the keyspace. Acquires a dedicated connection from the pool for
+     * the duration of iteration — do not hold the generator open longer than
+     * necessary.
+     *
+     * @return \Generator<string, array<string, scalar>>
+     */
     public function iterate(string $name): \Generator
     {
         $this->assertMade($name);
@@ -195,6 +279,25 @@ final class RedisBackend implements StoreBackend
         } finally { $this->pool->release($client); }
     }
 
+    /**
+     * Cursor-based paginated iteration of the named table.
+     *
+     * Returns one Redis `SCAN`/`SSCAN` batch at a time. Each call costs 2
+     * round-trips: one `SCAN`/`SSCAN` + one pipelined `HGETALL` batch via
+     * `mhgetall()`. Pass the returned `'cursor'` value as the next call's
+     * `$cursor`; iteration is complete when the returned cursor is `'0'`.
+     *
+     * ```php
+     * $cursor = '0';
+     * do {
+     *     ['cursor' => $cursor, 'rows' => $rows] =
+     *         Store::iteratePaged('my_table', $cursor, 50);
+     *     foreach ($rows as $key => $row) { // ... }
+     * } while ($cursor !== '0');
+     * ```
+     *
+     * @return array{cursor: string, rows: array<string, array<string, scalar>>}
+     */
     public function iteratePaged(string $name, string $cursor = '0', int $count = 100): array
     {
         $this->assertMade($name);
@@ -232,6 +335,13 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /**
+     * Delete every row in the named table.
+     *
+     * Uses `UNLINK` (non-blocking key reclaim, Redis 4.0+) in batches of 100
+     * to avoid blocking the Redis event loop on large tables. In `'tracked'`
+     * mode also deletes the membership SET key.
+     */
     public function clear(string $name): void
     {
         $this->assertMade($name);
@@ -262,11 +372,26 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /**
+     * Return the names of all tables registered on this backend via `make()`.
+     *
+     * @return list<string>
+     */
     public function names(): array
     {
         return array_keys($this->schemas);
     }
 
+    /**
+     * Fetch multiple rows in a single pipelined round-trip.
+     *
+     * Returns a map of `key → decoded row` for every key in `$keys`. Missing
+     * keys map to `null`. Uses `mhgetall()` (pipelined `HGETALL`) internally —
+     * O(1) round-trips regardless of batch size.
+     *
+     * @param list<string> $keys
+     * @return array<string, array<string, scalar>|null>
+     */
     public function mget(string $name, array $keys): array
     {
         $this->assertMade($name);
@@ -289,6 +414,16 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /**
+     * Write multiple rows in a single pipelined round-trip.
+     *
+     * Uses `mhsetWithMembership()` internally — one pipeline for all `HMSET` +
+     * optional `EXPIRE` + a single `SADD` for tracked-mode membership.
+     * Idempotent on existing keys (tracked SET ignores duplicate members).
+     * Returns `true` on success.
+     *
+     * @param array<string, array<string, bool|float|int|string>> $rows Key → column-value map.
+     */
     public function mset(string $name, array $rows): bool
     {
         $this->assertMade($name);
@@ -325,7 +460,7 @@ final class RedisBackend implements StoreBackend
         });
     }
 
-    /** Health check via PING — `Store::ping()` (Task 11) delegates here. */
+    /** Health check via `PING` — `Store::ping()` delegates here. */
     public function ping(): bool
     {
         return (bool) $this->pool->with(fn(RedisClient $c): bool => $c->ping());
@@ -339,6 +474,12 @@ final class RedisBackend implements StoreBackend
     // members) instead of a full table scan. The keys are NOT prefixed by
     // this backend's `$prefix` — caller fully owns the namespace.
 
+    /**
+     * Add one or more members to a Redis SET at the given absolute `$key`.
+     *
+     * The key is NOT prefixed — callers own the namespace (used by `Room`).
+     * Returns the number of NEW members added (existing members are ignored).
+     */
     public function sadd(string $key, string ...$members): int
     {
         if ($members === []) { return 0; }
@@ -346,6 +487,11 @@ final class RedisBackend implements StoreBackend
         return $this->pool->with(fn(RedisClient $c): int => $c->sadd($key, $list));
     }
 
+    /**
+     * Remove one or more members from a Redis SET at the given absolute `$key`.
+     *
+     * Returns the number of members that were actually removed.
+     */
     public function srem(string $key, string ...$members): int
     {
         if ($members === []) { return 0; }
@@ -353,42 +499,69 @@ final class RedisBackend implements StoreBackend
         return $this->pool->with(fn(RedisClient $c): int => $c->srem($key, $list));
     }
 
+    /**
+     * Return the cardinality (number of members) of a Redis SET at the given
+     * absolute `$key`. O(1). Returns `0` when the key does not exist.
+     */
     public function scard(string $key): int
     {
         return $this->pool->with(fn(RedisClient $c): int => $c->scard($key));
     }
 
-    /** @return array{0:string, 1:list<string>} */
+    /**
+     * Cursor-based `SSCAN` on an absolute SET key — one batch per call.
+     *
+     * @return array{0:string, 1:list<string>} `[nextCursor, members]`
+     */
     public function sscanCursor(string $key, string $cursor, int $count): array
     {
         return $this->pool->with(fn(RedisClient $c): array => $c->sscanCursor($key, $cursor, $count));
     }
 
+    /**
+     * Delete an absolute Redis SET key via `UNLINK` (non-blocking reclaim).
+     *
+     * Returns `true` when the key was present and unlinked.
+     */
     public function sdel(string $key): bool
     {
         return (bool) $this->pool->with(fn(RedisClient $c): bool => $c->unlink($key) > 0);
     }
 
-    /** Pub/sub publish through the pool; returns receivers Redis delivered to. */
+    /**
+     * Pub/sub publish through the pool. Returns the number of subscribers
+     * Redis delivered the message to.
+     */
     public function publish(string $channel, string $payload): int
     {
         return $this->pool->with(fn(RedisClient $c): int => $c->publish($channel, $payload));
     }
 
     /**
-     * Streams append. Auto-MAXLEN-trims when $maxLen is set. Payload is
-     * stored under the 'payload' field; matches the consumer-side
-     * convention in RedisStreams.
+     * Append a message to a Redis Stream via `XADD`. Auto-trims to `$maxLen`
+     * entries when set. The payload is stored under the `'payload'` field,
+     * matching the consumer-side convention in `RedisStreams`.
+     *
+     * @return string The Redis-generated message id (e.g. `'1626300000000-0'`).
      */
     public function publishReliable(string $stream, string $payload, ?int $maxLen = null): string
     {
         return $this->pool->with(fn(RedisClient $c): string => $c->xadd($stream, ['payload' => $payload], $maxLen));
     }
 
+    /** Returns the Redis connection URL this backend was constructed with. */
     public function url(): string { return $this->pool->url(); }
+
+    /** Returns the underlying `RedisConnectionPool` instance. */
     public function pool(): RedisConnectionPool { return $this->pool; }
+
+    /** Returns the key namespace prefix (e.g. `'zealstore'`). */
     public function prefix(): string { return $this->prefix; }
 
+    /**
+     * Count rows in `'ttl'` mode via `SCAN MATCH` — O(N).
+     * Only called from `count()` when the table mode is `'ttl'`.
+     */
     private function countViaScan(string $name): int
     {
         $sk     = $this->setKey($name);
@@ -403,16 +576,23 @@ final class RedisBackend implements StoreBackend
         });
     }
 
+    /** Build the Redis HASH key for a specific row: `{prefix}:{table}:{key}`. */
     private function rowKey(string $table, string $key): string
     {
         return $this->prefix . ':' . $table . ':' . $key;
     }
 
+    /** Build the Redis SET key for the membership index: `{prefix}:{table}:__keys__`. */
     private function setKey(string $table): string
     {
         return $this->prefix . ':' . $table . ':__keys__';
     }
 
+    /**
+     * Assert that `$name` was registered via `make()`, throwing `StoreException` otherwise.
+     *
+     * @throws StoreException When the table has not been registered.
+     */
     private function assertMade(string $name): void
     {
         if (!isset($this->schemas[$name])) {

--- a/src/Store/RedisClient.php
+++ b/src/Store/RedisClient.php
@@ -15,14 +15,27 @@ namespace ZealPHP\Store;
  */
 final class RedisClient
 {
+    /** Active driver — either `PhpredisDriver` or `PredisDriver`, selected at construction time. */
     private RedisDriver $driver;
 
-    /** @param array{prefer?: 'auto'|'phpredis'|'predis'} $opts */
+    /**
+     * Connect to `$url` using the best available driver. Pass
+     * `$opts['prefer']` as `'phpredis'`, `'predis'`, or `'auto'`
+     * (default) to control driver selection explicitly.
+     *
+     * @param array{prefer?: 'auto'|'phpredis'|'predis'} $opts
+     */
     public function __construct(string $url, array $opts = [])
     {
         $this->driver = self::pickDriver($url, $opts['prefer'] ?? 'auto');
     }
 
+    /**
+     * Select and instantiate the appropriate `RedisDriver` based on `$prefer`
+     * and the extensions available at runtime. Throws `StoreException` when
+     * `$prefer` is not one of `'auto'`, `'phpredis'`, or `'predis'`, or when
+     * `'auto'` is chosen but neither ext-redis nor predis is available.
+     */
     private static function pickDriver(string $url, string $prefer): RedisDriver
     {
         if ($prefer === 'phpredis') {
@@ -45,13 +58,19 @@ final class RedisClient
         );
     }
 
+    /** Return the active driver name — `'phpredis'` or `'predis'`. Useful for diagnostics and feature guards. */
     public function driverName(): string { return $this->driver->name(); }
 
     // ── string keys ─────────────────────────────────────────────────────
+    /** Set a plain string key, optionally with a TTL in seconds. Returns `true` on success. */
     public function set(string $key, string $value, ?int $ttlSeconds = null): bool { return $this->driver->set($key, $value, $ttlSeconds); }
+    /** Get a plain string key. Returns `null` on miss. */
     public function get(string $key): ?string { return $this->driver->get($key); }
+    /** Delete one or more keys. Returns the count of keys that were removed. */
     public function del(string ...$keys): int { return $this->driver->del(...$keys); }
+    /** Return `true` when `$key` exists in Redis. */
     public function exists(string $key): bool { return $this->driver->exists($key); }
+    /** Set a TTL of `$ttlSeconds` on `$key` via `EXPIRE`. Returns `true` on success. */
     public function expire(string $key, int $ttlSeconds): bool { return $this->driver->expire($key, $ttlSeconds); }
 
     // ── hashes ──────────────────────────────────────────────────────────
@@ -64,8 +83,11 @@ final class RedisClient
      * @return array<int, string|null>
      */
     public function hmget(string $key, array $fields): array { return $this->driver->hmget($key, $fields); }
+    /** Atomically increment hash field by `$by` (int) via `HINCRBY`. Returns the new value. */
     public function hincrby(string $key, string $field, int $by): int { return $this->driver->hincrby($key, $field, $by); }
+    /** Atomically increment hash field by `$by` (float) via `HINCRBYFLOAT`. Returns the new value. */
     public function hincrbyfloat(string $key, string $field, float $by): float { return $this->driver->hincrbyfloat($key, $field, $by); }
+    /** Delete one or more hash fields via `HDEL`. Returns the number of fields removed. */
     public function hdel(string $key, string ...$fields): int { return $this->driver->hdel($key, ...$fields); }
 
     // ── sets ────────────────────────────────────────────────────────────
@@ -80,7 +102,9 @@ final class RedisClient
     public function sscanCursor(string $key, string $cursor, int $count): array { return $this->driver->sscanCursor($key, $cursor, $count); }
 
     // ── counters ────────────────────────────────────────────────────────
+    /** Atomically increment a plain string counter by `$by` via `INCRBY`. Returns the new value. */
     public function incrby(string $key, int $by): int { return $this->driver->incrby($key, $by); }
+    /** Atomically decrement a plain string counter by `$by` via `DECRBY`. Returns the new value. */
     public function decrby(string $key, int $by): int { return $this->driver->decrby($key, $by); }
 
     // ── scripting + scan + lifecycle ────────────────────────────────────
@@ -95,7 +119,9 @@ final class RedisClient
     /** @return array{0:string, 1:list<string>} */
     public function scanCursor(string $match, string $cursor, int $count): array { return $this->driver->scanCursor($match, $cursor, $count); }
 
+    /** Ping the Redis server. Returns `true` when the server is reachable. */
     public function ping(): bool { return $this->driver->ping(); }
+    /** Close the underlying driver connection and release resources. */
     public function close(): void { $this->driver->close(); }
     /** @return list<mixed> */
     public function pipeline(callable $batch): array { return $this->driver->pipeline($batch); }
@@ -113,9 +139,11 @@ final class RedisClient
         $this->driver->mhsetWithMembership($writes, $setKey, $ttl);
     }
 
+    /** Asynchronously delete keys via `UNLINK` (non-blocking, unlike `DEL`). Returns the count of keys removed. */
     public function unlink(string ...$keys): int { return $this->driver->unlink(...$keys); }
 
     // ── pub/sub ─────────────────────────────────────────────────────────
+    /** Publish `$payload` to a pub/sub `$channel`. Returns the number of subscribers that received it. */
     public function publish(string $channel, string $payload): int { return $this->driver->publish($channel, $payload); }
 
     /**
@@ -131,6 +159,11 @@ final class RedisClient
     public function xadd(string $stream, array $fields, ?int $maxLen = null): string
     { return $this->driver->xadd($stream, $fields, $maxLen); }
 
+    /**
+     * Create a Redis Stream consumer group. Returns `true` on success, `false`
+     * when the group already exists (`BUSYGROUP` — idempotent). Creates the
+     * stream when `$mkStream` is `true` and the stream doesn't yet exist.
+     */
     public function xgroupCreate(string $stream, string $group, string $id = '$', bool $mkStream = true): bool
     { return $this->driver->xgroupCreate($stream, $group, $id, $mkStream); }
 
@@ -141,6 +174,7 @@ final class RedisClient
     public function xreadGroup(string $group, string $consumer, array $streams, int $count, int $blockMs): array
     { return $this->driver->xreadGroup($group, $consumer, $streams, $count, $blockMs); }
 
+    /** Acknowledge stream entries via `XACK`, removing them from the consumer group's pending list. Returns the count acknowledged. */
     public function xack(string $stream, string $group, string ...$ids): int
     { return $this->driver->xack($stream, $group, ...$ids); }
 

--- a/src/Store/RedisConnectionPool.php
+++ b/src/Store/RedisConnectionPool.php
@@ -8,26 +8,41 @@ use OpenSwoole\Coroutine;
 use OpenSwoole\Coroutine\Channel;
 
 /**
- * Per-worker pool of RedisClient connections.
+ * Per-worker pool of `RedisClient` connections.
  *
  * Two coroutines sharing one phpredis/predis socket interleave RESP frames
  * and corrupt the stream — so each op must acquire a private client from
- * this pool, use it, and release it back. The pool is sized N (default 8)
- * per worker; the OpenSwoole channel blocks until a client is available.
+ * this pool, use it, and release it back. The pool is sized N (default `8`)
+ * per worker; the `OpenSwoole\Coroutine\Channel` blocks until a client is available.
  *
- * Outside a coroutine context (sync mode, e.g. superglobals(true)), the
+ * Outside a coroutine context (sync mode, e.g. `superglobals(true)`), the
  * pool degrades to a single lazily-built client used sequentially — the
- * channel pop would block the worker indefinitely otherwise.
+ * channel `pop()` would block the worker indefinitely otherwise.
  */
 final class RedisConnectionPool
 {
-    /** Channel + its pre-fill are created lazily inside a coroutine — Channel::push throws otherwise. */
+    /**
+     * The coroutine channel holding available `RedisClient` instances.
+     *
+     * Created lazily on the first `acquire()` inside a coroutine context
+     * because `Channel::push()` throws outside the scheduler.
+     */
     private ?Channel $ch = null;
+
+    /** Configured pool capacity (minimum `1`). */
     private int $size;
+
+    /** Single `RedisClient` used in sync (non-coroutine) mode. */
     private ?RedisClient $syncClient = null;
+
+    /** Per-worker counters (`pool_acquires_total`, `pool_acquire_timeouts_total`, `pool_clients_created_total`). */
     private Stats $stats;
 
-    /** @param array{prefer?: 'auto'|'phpredis'|'predis'} $opts */
+    /**
+     * @param string                                       $url  Redis connection URL (e.g. `redis://127.0.0.1:6379`).
+     * @param int                                          $size Maximum pool size per worker (default `8`).
+     * @param array{prefer?: 'auto'|'phpredis'|'predis'}  $opts Driver preference options.
+     */
     public function __construct(
         private string $url,
         int $size = 8,
@@ -93,7 +108,10 @@ final class RedisConnectionPool
         finally { $this->release($c); }
     }
 
+    /** Return the configured pool capacity. */
     public function size(): int { return $this->size; }
+
+    /** Return the Redis connection URL this pool connects to. */
     public function url(): string { return $this->url; }
 
     /**
@@ -125,6 +143,12 @@ final class RedisConnectionPool
         $this->ch = null;
     }
 
+    /**
+     * Lazily initialise the `Channel` and pre-fill it with `$size` clients.
+     *
+     * IMPORTANT: must be called inside a coroutine — `Channel::push()` throws
+     * outside the scheduler.
+     */
     private function ensureChannel(): Channel
     {
         if ($this->ch !== null) { return $this->ch; }

--- a/src/Store/RedisPubSub.php
+++ b/src/Store/RedisPubSub.php
@@ -25,13 +25,23 @@ namespace ZealPHP\Store;
  */
 final class RedisPubSub
 {
-    /** @var array<string, list<callable>> */
+    /**
+     * Exact-channel handlers keyed by channel name.
+     *
+     * @var array<string, list<callable>>
+     */
     private array $exactHandlers = [];
-    /** @var array<string, list<callable>> */
+    /**
+     * Pattern handlers keyed by PSUBSCRIBE pattern (contains `*`).
+     *
+     * @var array<string, list<callable>>
+     */
     private array $patternHandlers = [];
-    /** Atomic so cross-coroutine mutation by stop() is visible to the runner. */
+    /** Atomic flag (`1` = running, `0` = stopped). Cross-coroutine visibility via `OpenSwoole\Atomic`. */
     private \OpenSwoole\Atomic $running;
+    /** Private sentinel channel used by `stop()` to wake the subscriber loop cleanly. */
     private string $stopChannel;
+    /** Per-worker counters exposed via `stats()`. */
     private Stats $stats;
 
     /**
@@ -70,11 +80,24 @@ final class RedisPubSub
         }
     }
 
-    /** @return list<string> */
+    /**
+     * Return the exact channel names with registered handlers.
+     *
+     * @return list<string>
+     */
     public function exactChannels(): array { return array_keys($this->exactHandlers); }
-    /** @return list<string> */
+
+    /**
+     * Return the PSUBSCRIBE pattern strings with registered handlers.
+     *
+     * @return list<string>
+     */
     public function patternChannels(): array { return array_keys($this->patternHandlers); }
+
+    /** Return the private stop-sentinel channel name (used by `stop()` internally). */
     public function stopChannel(): string { return $this->stopChannel; }
+
+    /** Return `true` when the runner coroutine is active. */
     public function isRunning(): bool { return $this->running->get() === 1; }
 
     /**
@@ -105,6 +128,16 @@ final class RedisPubSub
         } catch (\Throwable) { /* tolerant; runner will see connection drop and exit */ }
     }
 
+    /**
+     * Main subscriber loop running inside its own coroutine.
+     *
+     * Connects a dedicated `RedisClient`, subscribes to all registered exact
+     * channels + PSUBSCRIBE patterns + the private `$stopChannel`, then reads
+     * messages in a blocking loop. On `PubSubStopException` (sentinel received
+     * via `stop()`) the loop exits cleanly. On `StoreException` (connection
+     * drop) it applies bounded exponential backoff and reconnects, up to
+     * `$maxAttempts` times (0 = unlimited).
+     */
     private function runner(): void
     {
         $attempt = 0;
@@ -144,6 +177,13 @@ final class RedisPubSub
         }
     }
 
+    /**
+     * Fan out an inbound message to all matching handlers via `go()`.
+     *
+     * Each handler runs in its own coroutine so a slow handler cannot block
+     * the next message read. Exceptions thrown by handlers are caught,
+     * counted in `pubsub_handler_errors_total`, and logged via `error_log()`.
+     */
     private function dispatch(string $payload, string $channel, ?string $pattern): void
     {
         $handlers = [];
@@ -163,13 +203,25 @@ final class RedisPubSub
         }
     }
 
-    /** Backoff: 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 5.0 (capped) seconds. */
+    /**
+     * Compute the reconnect wait time for a given attempt number.
+     *
+     * Uses bounded exponential backoff: `0.1 × 2^attempt` seconds, capped
+     * at `5.0` s. Sequence: `0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 5.0, 5.0, …`
+     */
     private static function backoffSeconds(int $attempt): float
     {
         return min(0.1 * (2 ** $attempt), 5.0);
     }
 
-    /** Indirect read defeats PHPStan flow analysis on the loop condition. */
+    /**
+     * Read `$a->get() === 0` via an out-of-line method.
+     *
+     * An indirect read prevents PHPStan from constant-folding the
+     * `while ($this->running->get() === 1)` loop condition when it can
+     * prove `running` was set to `1` just above — which would eliminate
+     * the loop body entirely under strict flow analysis.
+     */
     private static function atomicIsZero(\OpenSwoole\Atomic $a): bool
     {
         return $a->get() === 0;

--- a/src/Store/Stats.php
+++ b/src/Store/Stats.php
@@ -23,22 +23,29 @@ final class Stats
     /** @var array<string, int> */
     private array $counters = [];
 
+    /** Increment counter `$key` by `$by` (default `1`). Creates the key with value `$by` if absent. */
     public function inc(string $key, int $by = 1): void
     {
         $this->counters[$key] = ($this->counters[$key] ?? 0) + $by;
     }
 
+    /** Read the current value of counter `$key`, returning `0` when the key has never been incremented. */
     public function get(string $key): int
     {
         return $this->counters[$key] ?? 0;
     }
 
-    /** @return array<string, int> */
+    /**
+     * Return a copy of all counters as a `string→int` map.
+     *
+     * @return array<string, int>
+     */
     public function snapshot(): array
     {
         return $this->counters;
     }
 
+    /** Reset all counters to zero by discarding the internal map. */
     public function reset(): void
     {
         $this->counters = [];

--- a/src/Store/StoreBackend.php
+++ b/src/Store/StoreBackend.php
@@ -28,7 +28,13 @@ interface StoreBackend
      */
     public function make(string $name, int $maxRows, array $columns, array $opts = []): void;
 
-    /** @param array<string, scalar> $row */
+    /**
+     * Write a row into table `$name` under `$key`. Overwrites any existing row.
+     * Returns `true` on success, or `false` when the backend cannot store the entry
+     * (e.g. the `OpenSwoole\Table` is full).
+     *
+     * @param array<string, scalar> $row Column-name → value map. All declared columns must be present.
+     */
     public function set(string $name, string $key, array $row): bool;
 
     /**
@@ -40,10 +46,25 @@ interface StoreBackend
      */
     public function get(string $name, string $key, ?string $field = null): mixed;
 
+    /** Delete the row at `$key` from table `$name`. Returns `true` on success, `false` if the key did not exist. */
     public function del(string $name, string $key): bool;
+
+    /** Return `true` when table `$name` contains a row with key `$key`. */
     public function exists(string $name, string $key): bool;
+
+    /**
+     * Atomically increment column `$col` of row `$key` in table `$name` by `$by`.
+     * Returns the new column value. Creates the row with the column set to `$by` when it does not exist.
+     */
     public function incr(string $name, string $key, string $col, int|float $by = 1): int|float;
+
+    /**
+     * Atomically decrement column `$col` of row `$key` in table `$name` by `$by`.
+     * Returns the new column value. Creates the row with the column set to `-$by` when it does not exist.
+     */
     public function decr(string $name, string $key, string $col, int|float $by = 1): int|float;
+
+    /** Return the number of rows currently stored in table `$name`. */
     public function count(string $name): int;
 
     /** @return \Generator<string, array<string, scalar>> */

--- a/src/Store/TableBackend.php
+++ b/src/Store/TableBackend.php
@@ -21,6 +21,12 @@ final class TableBackend implements StoreBackend
     /** @var array<string, array<string, array{0:int, 1?:int}>> */
     private array $schemas = [];
 
+    /**
+     * Create a named `OpenSwoole\Table` with the given schema. Each column in
+     * `$columns` is `[TYPE_*, $size]`. When `$columns` is empty, a single
+     * `'value'` column of type `TYPE_STRING(256)` is created. `$opts` is
+     * accepted for interface compatibility but unused by this backend.
+     */
     public function make(string $name, int $maxRows, array $columns, array $opts = []): void
     {
         $t = new Table($maxRows);
@@ -39,6 +45,11 @@ final class TableBackend implements StoreBackend
         $this->schemas[$name] = $columns;
     }
 
+    /**
+     * Write a row to the named table. Returns `false` when the table doesn't
+     * exist or when `OpenSwoole\Table::set()` raises an exception (e.g. row
+     * too large for the allocated slot).
+     */
     public function set(string $name, string $key, array $row): bool
     {
         $t = $this->tables[$name] ?? null;
@@ -47,6 +58,11 @@ final class TableBackend implements StoreBackend
         catch (\OpenSwoole\Exception) { return false; }
     }
 
+    /**
+     * Read a row or a single field from the named table. Returns `null` when
+     * the table or key doesn't exist. When `$field` is provided, returns the
+     * field's scalar value or `null` if absent.
+     */
     public function get(string $name, string $key, ?string $field = null): mixed
     {
         $t = $this->tables[$name] ?? null;
@@ -55,16 +71,23 @@ final class TableBackend implements StoreBackend
         return $v === false ? null : $v;
     }
 
+    /** Delete a row by key. Returns `false` when the table doesn't exist or the key was already absent. */
     public function del(string $name, string $key): bool
     {
         return (bool) (($this->tables[$name] ?? null)?->del($key) ?? false);
     }
 
+    /** Return `true` when the named table contains a row with the given key. */
     public function exists(string $name, string $key): bool
     {
         return (bool) (($this->tables[$name] ?? null)?->exists($key) ?? false);
     }
 
+    /**
+     * Atomically increment column `$col` by `$by` (coerced to int — `OpenSwoole\Table`
+     * does not support float increment; use `RedisBackend` for `HINCRBYFLOAT`).
+     * Returns `0` when the table doesn't exist.
+     */
     public function incr(string $name, string $key, string $col, int|float $by = 1): int
     {
         $t = $this->tables[$name] ?? null;
@@ -74,6 +97,10 @@ final class TableBackend implements StoreBackend
         return $t->incr($key, $col, (int) $by);
     }
 
+    /**
+     * Atomically decrement column `$col` by `$by` (coerced to int).
+     * Returns `0` when the table doesn't exist.
+     */
     public function decr(string $name, string $key, string $col, int|float $by = 1): int
     {
         $t = $this->tables[$name] ?? null;
@@ -81,11 +108,19 @@ final class TableBackend implements StoreBackend
         return $t->decr($key, $col, (int) $by);
     }
 
+    /** Return the number of rows in the named table, or `0` when the table doesn't exist. */
     public function count(string $name): int
     {
         return ($this->tables[$name] ?? null)?->count() ?? 0;
     }
 
+    /**
+     * Iterate all rows in the named table as a `Generator`. Yields string keys
+     * mapped to `array<string, scalar>` row arrays. Returns immediately when
+     * the table doesn't exist.
+     *
+     * @return \Generator<string, array<string, scalar>>
+     */
     public function iterate(string $name): \Generator
     {
         $t = $this->tables[$name] ?? null;
@@ -125,6 +160,11 @@ final class TableBackend implements StoreBackend
         return ['cursor' => '0', 'rows' => $rows];
     }
 
+    /**
+     * Delete all rows from the named table by iterating and deleting each
+     * key individually (no native bulk-delete on `OpenSwoole\Table`).
+     * No-op when the table doesn't exist.
+     */
     public function clear(string $name): void
     {
         $t = $this->tables[$name] ?? null;
@@ -134,11 +174,17 @@ final class TableBackend implements StoreBackend
         foreach ($keys as $k) { $t->del($k); }
     }
 
+    /** Return the names of all tables registered via `make()`. */
     public function names(): array
     {
         return array_keys($this->tables);
     }
 
+    /**
+     * Bulk read multiple rows. Missing keys are returned as `null` in
+     * the result map. Non-scalar column values are silently skipped
+     * (they cannot arise from a normal `set()` call on this backend).
+     */
     public function mget(string $name, array $keys): array
     {
         $out = [];
@@ -158,6 +204,11 @@ final class TableBackend implements StoreBackend
         return $out;
     }
 
+    /**
+     * Bulk write multiple rows by calling `set()` for each entry in sequence.
+     * Returns `true` when all writes succeeded; `false` when any single write
+     * failed (the rest still proceed — no rollback).
+     */
     public function mset(string $name, array $rows): bool
     {
         $allOk = true;
@@ -189,9 +240,10 @@ final class TableBackend implements StoreBackend
     }
 
     /**
-     * Translate Store::TYPE_* (which alias OpenSwoole\Table::TYPE_* — see
-     * Task 10's facade constants) so the schema map is backend-neutral.
-     * Existing code passing Table::TYPE_* directly still works.
+     * Translate `Store::TYPE_*` constants (which alias `OpenSwoole\Table::TYPE_*` —
+     * see the facade constant declarations in `Store.php`) so the schema map
+     * stays backend-neutral. Existing code passing `Table::TYPE_*` directly
+     * still works because the numeric values are identical.
      */
     private function mapType(int $type): int
     {

--- a/src/Store/TieredBackend.php
+++ b/src/Store/TieredBackend.php
@@ -33,11 +33,18 @@ final class TieredBackend implements StoreBackend
 {
     private const CACHED_AT = '__cached_at';
 
-    /** Origin tag stamped on every invalidation publish — the receiver skips messages
-     *  that originated from itself so writers don't re-evict their own freshly-written L1. */
+    /**
+     * Origin tag stamped on every invalidation publish — the receiver skips messages
+     * that originated from itself so writers don't re-evict their own freshly-written L1.
+     */
     private string $originId;
-    /** Per-table set of channels we've registered an invalidation subscriber on. */
-    /** @var array<string, true> */
+
+    /**
+     * Channels (`__l1_invalidate:{table}`) for which a subscriber has been registered
+     * on the `$invalidationRunner`.
+     *
+     * @var array<string, true>
+     */
     private array $invalidationChannels = [];
     private ?RedisPubSub $invalidationRunner = null;
     /**
@@ -73,9 +80,16 @@ final class TieredBackend implements StoreBackend
         return $this->invalidationSecret !== null;
     }
 
+    /** Return the L1 `TableBackend` instance (in-process shared-memory tier). */
     public function l1(): TableBackend { return $this->l1; }
+
+    /** Return the L2 `RedisBackend` instance (cross-node source-of-truth tier). */
     public function l2(): RedisBackend { return $this->l2; }
+
+    /** Return the configured L1 TTL in seconds (maximum staleness window for L1 reads). */
     public function l1Ttl(): int       { return $this->l1Ttl; }
+
+    /** Return the origin ID string stamped on invalidation publishes (hostname + PID + random suffix). */
     public function originId(): string { return $this->originId; }
 
     /**
@@ -100,6 +114,12 @@ final class TieredBackend implements StoreBackend
         $this->invalidationRunner->start();
     }
 
+    /**
+     * Stop the cross-node L1 invalidation subscriber coroutine.
+     * After this call, peer writes will no longer evict local L1 entries;
+     * L1 staleness reverts to the `$l1Ttl` window. Safe to call when no
+     * invalidation runner is active (no-op).
+     */
     public function stopInvalidation(): void
     {
         if ($this->invalidationRunner === null) { return; }
@@ -174,11 +194,20 @@ final class TieredBackend implements StoreBackend
         return substr(hash_hmac('sha256', "$table|$key|$origin", $secret), 0, 16);
     }
 
+    /** Build the Redis pub/sub channel name for L1 invalidation of `$table`. */
     private function channel(string $table): string
     {
         return '__l1_invalidate:' . $table;
     }
 
+    /**
+     * Create a named table in both L1 and L2 backends.
+     *
+     * The L1 schema receives a synthetic `__cached_at` `INT` column appended
+     * to `$columns` for staleness bookkeeping; user-facing `get()` strips it.
+     * Registers the invalidation channel for the new table; if `enableInvalidation()`
+     * has already been called, the subscriber is registered immediately.
+     */
     public function make(string $name, int $maxRows, array $columns, array $opts = []): void
     {
         $l1Columns = $columns + [self::CACHED_AT => [Table::TYPE_INT, 8]];
@@ -192,6 +221,11 @@ final class TieredBackend implements StoreBackend
         }
     }
 
+    /**
+     * Write-through: persist `$row` to L2 first (source of truth), then refresh
+     * the L1 entry and publish an invalidation so peers evict their stale copies.
+     * Returns `false` only when the L2 write itself fails.
+     */
     public function set(string $name, string $key, array $row): bool
     {
         $ok = $this->l2->set($name, $key, $row);
@@ -202,6 +236,14 @@ final class TieredBackend implements StoreBackend
         return $ok;
     }
 
+    /**
+     * Read from L1 if the entry is fresh (within `$l1Ttl` seconds); otherwise
+     * fetch from L2, repopulate L1, and return. The synthetic `__cached_at`
+     * column is stripped before returning the row.
+     *
+     * Returns `null` (field lookup) or `false` (full row) on miss, matching
+     * `TableBackend::get()` semantics.
+     */
     public function get(string $name, string $key, ?string $field = null): mixed
     {
         $now = time();
@@ -241,6 +283,10 @@ final class TieredBackend implements StoreBackend
         return $out;
     }
 
+    /**
+     * Delete `$key` from both L1 and L2, then publish an invalidation to peers.
+     * Returns the L2 delete result (`true` when the key existed and was removed).
+     */
     public function del(string $name, string $key): bool
     {
         $this->l1->del($name, $key);
@@ -249,6 +295,11 @@ final class TieredBackend implements StoreBackend
         return $ok;
     }
 
+    /**
+     * Authoritative existence check — always defers to L2.
+     * L1 may hold a stale entry for a key that has since been deleted on another
+     * node; only L2 is the source of truth.
+     */
     public function exists(string $name, string $key): bool
     {
         // L1 might lie about existence (stale entry); always defer to L2.
@@ -281,6 +332,10 @@ final class TieredBackend implements StoreBackend
         return $this->l2->exists($name, $key);
     }
 
+    /**
+     * Increment `$col` in L2 (authoritative), evict the stale L1 entry so the
+     * next `get()` re-fetches the updated value, and publish an invalidation to peers.
+     */
     public function incr(string $name, string $key, string $col, int|float $by = 1): int|float
     {
         $new = $this->l2->incr($name, $key, $col, $by);
@@ -291,6 +346,10 @@ final class TieredBackend implements StoreBackend
         return $new;
     }
 
+    /**
+     * Decrement `$col` in L2 (authoritative), evict the stale L1 entry, and
+     * publish an invalidation to peers. Mirror of `incr()`.
+     */
     public function decr(string $name, string $key, string $col, int|float $by = 1): int|float
     {
         $new = $this->l2->decr($name, $key, $col, $by);
@@ -299,35 +358,56 @@ final class TieredBackend implements StoreBackend
         return $new;
     }
 
+    /**
+     * Return the authoritative row count from L2. L1 is a partial cache and
+     * must not be counted (it holds only a subset of the L2 key space).
+     */
     public function count(string $name): int
     {
         // L1 is a partial cache, not authoritative. Always count L2.
         return $this->l2->count($name);
     }
 
+    /**
+     * Yield all rows from L2 (authoritative and complete).
+     * L1 is not iterated — it holds only a hot subset of the L2 key space.
+     */
     public function iterate(string $name): \Generator
     {
         // Iterate L2 — it's authoritative and complete.
         yield from $this->l2->iterate($name);
     }
 
+    /**
+     * Return a cursor-paginated page of rows from L2.
+     * Same reasoning as `iterate()`: L2 is the authoritative source.
+     */
     public function iteratePaged(string $name, string $cursor = '0', int $count = 100): array
     {
         // Defer to L2 — same reasoning as iterate(): authoritative + complete.
         return $this->l2->iteratePaged($name, $cursor, $count);
     }
 
+    /** Clear all rows from both L1 and L2 for the given table. */
     public function clear(string $name): void
     {
         $this->l1->clear($name);
         $this->l2->clear($name);
     }
 
+    /** Return the list of table names known to L2 (the authoritative registry). */
     public function names(): array
     {
         return $this->l2->names();
     }
 
+    /**
+     * Batch get: serve L1-fresh entries from the cache tier and fetch the rest
+     * from L2 in one round-trip, populating L1 on the way back.
+     *
+     * Returns an array keyed by the original `$keys`; values are the row arrays
+     * (with `__cached_at` stripped) or `null` for keys not found in either tier.
+     */
     public function mget(string $name, array $keys): array
     {
         $now = time();
@@ -360,6 +440,10 @@ final class TieredBackend implements StoreBackend
         return $out;
     }
 
+    /**
+     * Batch set: write all rows to L2, then repopulate L1 with `__cached_at`
+     * timestamps. Returns `true` only when the L2 bulk write succeeds.
+     */
     public function mset(string $name, array $rows): bool
     {
         $ok = $this->l2->mset($name, $rows);

--- a/src/Store/TypeCodec.php
+++ b/src/Store/TypeCodec.php
@@ -68,6 +68,11 @@ final class TypeCodec
         return $this->coerce($type, $raw);
     }
 
+    /**
+     * Coerce a raw Redis wire string (or `null` for a missing field) to the
+     * PHP type declared by `$type` (`Table::TYPE_INT`, `Table::TYPE_FLOAT`,
+     * or `Table::TYPE_STRING`). Returns the zero-value for the type on `null`.
+     */
     private function coerce(int $type, ?string $raw): int|float|string
     {
         if ($raw === null) {

--- a/src/WS/CapacityException.php
+++ b/src/WS/CapacityException.php
@@ -12,20 +12,25 @@ use ZealPHP\Store\StoreException;
  * with a clear "server at capacity" close to the WebSocket client
  * (close code 1013 — "Try Again Later" — is the standard).
  *
- * Extends StoreException so existing `catch (StoreException)` blocks
+ * Extends `StoreException` so existing `catch (StoreException)` blocks
  * still work; new code that wants to react specifically to capacity
  * (vs. transient Redis failures) catches this typed subclass.
  *
- *     try {
- *         WSRouter::own($clientId, $fd);
- *     } catch (\ZealPHP\WS\CapacityException $e) {
- *         $server->disconnect($fd, 1013, 'server at capacity');
- *         return;
- *     }
+ * ```php
+ * try {
+ *     WSRouter::own($clientId, $fd);
+ * } catch (\ZealPHP\WS\CapacityException $e) {
+ *     $server->disconnect($fd, 1013, 'server at capacity');
+ *     return;
+ * }
+ * ```
  *
  * Bump capacity via:
- *     WSRouter::initOptions(ownerCapacity: 200_000, roomMembersCapacity: 1_000_000);
- *     WSRouter::init();
+ *
+ * ```php
+ * WSRouter::initOptions(ownerCapacity: 200_000, roomMembersCapacity: 1_000_000);
+ * WSRouter::init();
+ * ```
  */
 final class CapacityException extends StoreException
 {

--- a/src/WSRouter.php
+++ b/src/WSRouter.php
@@ -110,42 +110,67 @@ final class WSRouter
     private static int $clientRateLimitWindowSec = 60;
     /** Per-channel HMAC secret (WS-3) — null disables. Set via `setChannelHmacSecret`. */
     private static ?string $channelHmacSecret = null;
-    /** Per-worker counter struct. Surfaced via `WSRouter::stats()`. */
+    /** Per-worker counter struct. Surfaced via `WSRouter::stats()`. Lazily initialised on first access. */
     private static ?\ZealPHP\Store\Stats $stats = null;
 
+    /** Cluster-unique server identifier — defaults to `hostname:pid`. Set by `init()`. */
     private static string $serverId = '';
-    /** @var array<string, array{fd:int, conn_id:string}> client_id → {fd, conn_id} */
+
+    /**
+     * Per-worker map of locally-owned WebSocket connections.
+     * `client_id → ['fd' => int, 'conn_id' => string]`
+     *
+     * @var array<string, array{fd:int, conn_id:string}>
+     */
     private static array $localFds = [];
-    /** @var ?callable(string $clientId, int $fd, string $payload): void */
+
+    /**
+     * Inbound-routed-message handler. Receives `($clientId, $fd, $payload)`
+     * and is responsible for pushing `$payload` to the local fd.
+     * Defaults to a backpressure-aware `$server->push()` installed by `init()`.
+     *
+     * @var ?callable(string $clientId, int $fd, string $payload): void
+     */
     private static $clientSink = null;
-    /** True once init() has wired the subscriber. */
+
+    /** `true` once `init()` has wired the pub/sub subscribers and lifecycle hooks. */
     private static bool $initialized = false;
 
     // Room state — per-worker.
     //
-    // $localRoomMembership[$room][$clientId] = true   (clients in this room
-    //   that ARE locally owned by this worker — push targets when a
-    //   message arrives). Populated via presence events delivered to the
-    //   pattern subscriber.
+    // `$localRoomMembership[$room][$clientId] = true` — clients in this room
+    //   that ARE locally owned by this worker (push targets when a message
+    //   arrives). Populated via presence events from the pattern subscriber.
     //
-    // $roomMessageHandlers[$room][] = callable    (user-registered)
-    // $roomPresenceHandlers[$room][] = callable   (user-registered)
-    /** @var array<string, array<string, true>> */
+    // `$roomMessageHandlers[$room][]` = callable    (user-registered)
+    // `$roomPresenceHandlers[$room][]` = callable   (user-registered)
+
+    /**
+     * Per-worker cache of locally-owned clients by room.
+     * `room → [client_id => true]`
+     *
+     * @var array<string, array<string, true>>
+     */
     private static array $localRoomMembership = [];
-    /** @var array<string, list<callable>> */
+
+    /**
+     * User-registered message handlers per room. Each callable receives
+     * `(array $msg, string $room)`.
+     *
+     * @var array<string, list<callable>>
+     */
     private static array $roomMessageHandlers = [];
-    /** @var array<string, list<callable>> */
+
+    /**
+     * User-registered presence (join/leave) handlers per room. Each callable
+     * receives `(array $event, string $room)`.
+     *
+     * @var array<string, list<callable>>
+     */
     private static array $roomPresenceHandlers = [];
 
     /**
-     * One-time setup. Pass a server id (defaults to hostname:pid) +
-     * an optional callable that handles inbound routed messages.
-     * The default sink looks up the local fd map and pushes via
-     * `App::getServer()->push($fd, $payload)` (skipping with elog
-     * when the client isn't local OR the fd is no longer established).
-     */
-    /**
-     * Bump the per-cluster capacity caps BEFORE init() — these size the
+     * Bump the per-cluster capacity caps BEFORE `init()` — these size the
      * underlying `OpenSwoole\Table` segments allocated at master fork.
      * Defaults (4096 owners / 16384 room members) are demo-grade; production
      * deployments should size these against expected peak.

--- a/src/ZealAPI.php
+++ b/src/ZealAPI.php
@@ -97,9 +97,11 @@ class ZealAPI extends REST
     private ?array $_undefinedMethodError = null;
 
     /**
-     * @param mixed  $request
-     * @param mixed  $response
-     * @param string $cwd
+     * Construct a `ZealAPI` dispatcher bound to the current request/response pair.
+     *
+     * @param mixed  $request  The current `ZealPHP\HTTP\Request` (or equivalent) object.
+     * @param mixed  $response The current `ZealPHP\HTTP\Response` (or equivalent) object.
+     * @param string $cwd      Absolute path to the application root (used to resolve `api/` files).
      */
     public function __construct($request, $response, $cwd)
     {
@@ -109,14 +111,16 @@ class ZealAPI extends REST
         parent::__construct($request, $response);                  // Init parent contructor
     }
 
-    /*
-    * Public method for access api.
-    * This method dynmically call the method based on the query string
-    *
-    */
     /**
-     * @param string      $module
-     * @param string|null $request
+     * Dispatch a file-based API request.
+     *
+     * Resolves `api/{$module}/{$request}.php`, selects a handler closure via the
+     * filename-match → per-method priority rules described in the class docblock,
+     * injects named parameters, applies any in-file `$middleware`, and returns the
+     * result through the universal return contract.
+     *
+     * @param string      $module  URL sub-path (e.g. `'device'` for `/api/device/list`)
+     * @param string|null $request Basename without `.php` (e.g. `'list'`)
      * @return mixed
      */
     public function processApi($module, $request=null)
@@ -422,9 +426,9 @@ class ZealAPI extends REST
     }
 
     /**
-     * Checks if all supplied parameters exists
+     * Return `true` when all named parameters in `$parms` are present in the current request input.
      *
-     * @param array<int, string> $parms Http Parameters
+     * @param array<int, string> $parms HTTP parameter names to check.
      * @return bool
      */
     public function paramsExists($parms = array())
@@ -581,6 +585,8 @@ class ZealAPI extends REST
     }
 
     /**
+     * JSON-encode `$data` with `JSON_PRETTY_PRINT`. Returns `'{}'` for non-array input.
+     *
      * @param mixed $data
      * @return string
      */

--- a/src/apache_shims.php
+++ b/src/apache_shims.php
@@ -1,54 +1,101 @@
 <?php
-// Apache+mod_php compatibility shims at GLOBAL namespace.
+// Apache + mod_php compatibility shims at GLOBAL namespace.
 //
 // These functions are defined by PHP only when running under mod_php (Apache
 // SAPI). In CLI / OpenSwoole / PHP-FPM they're missing, which makes legacy
 // code (WordPress, Drupal, classic PHP apps) fail with "Call to undefined
-// function". uopz_set_return cannot override functions that don't exist, so
+// function". `uopz_set_return()` cannot override functions that don't exist, so
 // we register conditional global shims that delegate to the namespaced
-// implementations in src/utils.php.
+// implementations in `src/utils.php`.
+//
+// Every shim is guarded by `function_exists()` so this file is safe to include
+// multiple times and in environments where the real Apache extensions ARE loaded.
 
 if (!function_exists('apache_request_headers')) {
-    /** @return array<string, string> */
+    /**
+     * Return all HTTP request headers as an associative array.
+     * Shim for `apache_request_headers()` / `getallheaders()` on non-Apache SAPIs.
+     *
+     * @return array<string, string>
+     */
     function apache_request_headers(): array {
         return \ZealPHP\apache_request_headers();
     }
 }
 
 if (!function_exists('getallheaders')) {
-    /** @return array<string, string> */
+    /**
+     * Alias for `apache_request_headers()` — both names exist under mod_php.
+     * This shim makes `getallheaders()` available on OpenSwoole / CLI SAPIs.
+     *
+     * @return array<string, string>
+     */
     function getallheaders(): array {
         return \ZealPHP\getallheaders();
     }
 }
 
 if (!function_exists('apache_response_headers')) {
-    /** @return array<string, string> */
+    /**
+     * Return all response headers queued for the current request.
+     * Delegates to `\ZealPHP\apache_response_headers()` which reads from the
+     * per-request `$g->zealphp_response` header list.
+     *
+     * @return array<string, string>
+     */
     function apache_response_headers(): array {
         return \ZealPHP\apache_response_headers();
     }
 }
 
 if (!function_exists('apache_setenv')) {
+    /**
+     * Set a named Apache subprocess environment variable.
+     * In ZealPHP this writes into the per-request `$g->server` bag under the
+     * conventional `HTTP_*` key so subsequent handler code sees the value.
+     *
+     * The `$walk_to_top` parameter is accepted for API compatibility but has
+     * no effect (there is no parent-request scope in OpenSwoole).
+     */
     function apache_setenv(string $variable, string $value, bool $walk_to_top = false): bool {
         return \ZealPHP\apache_setenv($variable, $value, $walk_to_top);
     }
 }
 
 if (!function_exists('apache_getenv')) {
-    /** @return string|false */
+    /**
+     * Retrieve a named Apache subprocess environment variable.
+     * Returns `false` when the variable is not set (matching Apache's behaviour).
+     *
+     * The `$walk_to_top` parameter is accepted for API compatibility but has
+     * no effect in ZealPHP.
+     *
+     * @return string|false
+     */
     function apache_getenv(string $variable, bool $walk_to_top = false) {
         return \ZealPHP\apache_getenv($variable, $walk_to_top);
     }
 }
 
 if (!function_exists('apache_note')) {
+    /**
+     * Get or set an Apache request note (named annotation attached to the request).
+     * When `$note_value` is `null`, returns the current value of the note.
+     * When `$note_value` is provided, sets it and returns the previous value (or
+     * an empty string when the note was not previously set).
+     */
     function apache_note(string $note_name, ?string $note_value = null): string {
         return \ZealPHP\apache_note($note_name, $note_value);
     }
 }
 
 if (!function_exists('virtual')) {
+    /**
+     * Perform an Apache internal sub-request for `$uri`.
+     * In ZealPHP this dispatches the URI through the framework's routing stack
+     * in-process (similar to Apache's `virtual()` / `mod_include` sub-request
+     * mechanism). Returns `true` on success, `false` on failure.
+     */
     function virtual(string $uri): bool {
         return \ZealPHP\virtual($uri);
     }

--- a/src/cgi_worker.php
+++ b/src/cgi_worker.php
@@ -87,6 +87,12 @@ foreach ($_FILES as $entry) {
 $__z_return_value = null;
 $__z_has_return   = false;
 
+/**
+ * Write the metadata frame (status, headers, cookies, optional return value) to `STDERR`
+ * as a single JSON line. Idempotent — subsequent calls are no-ops once `$__z_meta_sent`
+ * is `true`. Called by the `flush()` override and the shutdown function so the frame is
+ * always sent before the body, regardless of whether the included file streams or buffers.
+ */
 function __z_send_meta() {
     global $__z_headers, $__z_cookies, $__z_rawcookies, $__z_status, $__z_meta_sent,
            $__z_return_value, $__z_has_return;
@@ -290,6 +296,13 @@ if (function_exists('zealphp_override') || function_exists('uopz_set_return')) {
 // Apache mod_php functions are not defined in CLI SAPI; define them globally
 // here for the duration of the subprocess so legacy code runs unchanged.
 if (!function_exists('apache_request_headers')) {
+    /**
+     * Polyfill for `apache_request_headers()` in CLI SAPI.
+     * Reconstructs the canonical header map from `$_SERVER` `HTTP_*` keys plus
+     * `CONTENT_TYPE` and `CONTENT_LENGTH`, matching Apache `mod_php` behaviour.
+     *
+     * @return array<string, string> Map of header name → value.
+     */
     function apache_request_headers(): array {
         $out = [];
         foreach ($_SERVER as $name => $value) {
@@ -306,12 +319,23 @@ if (!function_exists('apache_request_headers')) {
 }
 
 if (!function_exists('getallheaders')) {
+    /**
+     * Polyfill for `getallheaders()` in CLI SAPI — delegates to `apache_request_headers()`.
+     *
+     * @return array<string, string> Map of header name → value.
+     */
     function getallheaders(): array {
         return apache_request_headers();
     }
 }
 
 if (!function_exists('apache_response_headers')) {
+    /**
+     * Polyfill for `apache_response_headers()` in CLI SAPI.
+     * Returns the response headers collected so far by the `header()` override.
+     *
+     * @return array<string, string> Map of header name → value.
+     */
     function apache_response_headers(): array {
         global $__z_headers;
         $out = [];
@@ -323,6 +347,10 @@ if (!function_exists('apache_response_headers')) {
 }
 
 if (!function_exists('apache_setenv')) {
+    /**
+     * Polyfill for `apache_setenv()` in CLI SAPI.
+     * Stores `$value` in the subprocess-local `$__z_apache_env` map (Apache `mod_env` parity).
+     */
     function apache_setenv(string $variable, string $value, bool $walk_to_top = false): bool {
         global $__z_apache_env;
         $__z_apache_env[$variable] = $value;
@@ -331,6 +359,10 @@ if (!function_exists('apache_setenv')) {
 }
 
 if (!function_exists('apache_getenv')) {
+    /**
+     * Polyfill for `apache_getenv()` in CLI SAPI.
+     * Reads from `$__z_apache_env`; returns `false` when the variable is not set.
+     */
     function apache_getenv(string $variable, bool $walk_to_top = false) {
         global $__z_apache_env;
         return $__z_apache_env[$variable] ?? false;
@@ -338,6 +370,10 @@ if (!function_exists('apache_getenv')) {
 }
 
 if (!function_exists('apache_note')) {
+    /**
+     * Polyfill for `apache_note()` in CLI SAPI.
+     * Gets/sets a named note in `$__z_apache_notes`. Returns the previous value (empty string if unset).
+     */
     function apache_note(string $note_name, ?string $note_value = null): string {
         global $__z_apache_notes;
         $previous = (string)($__z_apache_notes[$note_name] ?? '');
@@ -349,6 +385,10 @@ if (!function_exists('apache_note')) {
 }
 
 if (!function_exists('virtual')) {
+    /**
+     * Polyfill for `virtual()` in CLI SAPI.
+     * Internal sub-requests are not supported in the subprocess context — always returns `false`.
+     */
     function virtual(string $uri): bool {
         // No internal-subrequest support — silently return false.
         return false;

--- a/src/fork_master.php
+++ b/src/fork_master.php
@@ -32,8 +32,8 @@ declare(strict_types=1);
  * experimental cut (zero regression risk to the production pool); it will be
  * de-duplicated into a shared runtime once fork mode is validated.
  *
- * Requires: pcntl + posix. Env: ZEALPHP_FORK_SOCK (unix socket path),
- * ZEALPHP_FORK_MAX_CONCURRENT (live-child cap, default 16), ZEALPHP_CWD.
+ * Requires: `pcntl` + `posix`. Env: `ZEALPHP_FORK_SOCK` (unix socket path),
+ * `ZEALPHP_FORK_MAX_CONCURRENT` (live-child cap, default `16`), `ZEALPHP_CWD`.
  */
 
 ini_set('display_errors', 'stderr');
@@ -66,9 +66,13 @@ if ($sockPath === '') {
 $maxConcurrent = max(1, (int) (getenv('ZEALPHP_FORK_MAX_CONCURRENT') ?: '16'));
 
 // ── Per-request capture state (a child sets these, then exits) ──
+/** @var list<array{0:string,1:string}> $__fm_headers Accumulated response headers: [[name, value], …] */
 $__fm_headers    = [];
+/** @var list<array<string,mixed>> $__fm_cookies Structured cookie descriptors from `setcookie()` overrides. */
 $__fm_cookies    = [];
+/** @var list<array<string,mixed>> $__fm_rawcookies Structured cookie descriptors from `setrawcookie()` overrides. */
 $__fm_rawcookies = [];
+/** @var int $__fm_status HTTP status captured from `header()` / `http_response_code()` calls. */
 $__fm_status     = 200;
 
 // ── Capture overrides (header/cookie/output/upload). Same shape as
@@ -288,15 +292,21 @@ $__fm_running = true;
 /** @var array<int,float> live children: pid => fork start time. count() = $__fm_live. */
 $__fm_children = [];
 
-// Reap exited children and drop them from the live map (so count() is accurate).
+/**
+ * Reap all exited children non-blockingly via `WNOHANG` and remove them from
+ * `$__fm_children` so the backpressure cap reflects the true live count.
+ * Registered as the `SIGCHLD` handler and also called proactively each loop.
+ */
 $__fm_reap = function () use (&$__fm_children): void {
     while (($p = @pcntl_waitpid(-1, $st, WNOHANG)) > 0) {
         unset($__fm_children[$p]);
     }
 };
-// Watchdog: SIGKILL any child that has run past $forkTimeout (the proc/pool
-// modes kill a wedged subprocess on timeout; fork mode needs the same). The
-// reaper then drops it on the resulting SIGCHLD.
+/**
+ * Send `SIGKILL` to any live child that has exceeded `$forkTimeout` seconds.
+ * Mirrors the per-request deadline enforced by the `proc`/pool modes.
+ * `$__fm_reap` reclaims the slot when the resulting `SIGCHLD` fires.
+ */
 $__fm_watchdog = function () use (&$__fm_children, $forkTimeout): void {
     $now = microtime(true);
     foreach ($__fm_children as $pid => $started) {
@@ -305,7 +315,11 @@ $__fm_watchdog = function () use (&$__fm_children, $forkTimeout): void {
         }
     }
 };
-// True once our parent OpenSwoole worker has died (reparented to init).
+/**
+ * Return `true` when this process has been reparented to init (PID `1`).
+ * Indicates that the OpenSwoole worker that spawned us exited without sending
+ * `SIGTERM`. Used as an orphan guard so the master exits rather than leaking.
+ */
 $__fm_orphaned = static function (): bool {
     return function_exists('posix_getppid') && posix_getppid() === 1;
 };

--- a/src/pool_worker.php
+++ b/src/pool_worker.php
@@ -686,6 +686,26 @@ function pool_finish_request(mixed $result, ?\Throwable $error, mixed $prevCwd):
     ];
 }
 
+/**
+ * Reset all per-request state between pool iterations.
+ *
+ * Clears superglobals (`$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE`, `$_FILES`,
+ * `$_REQUEST`, `$_SESSION`), the raw input buffer, response capture state
+ * (`$__pw_headers`, `$__pw_cookies`, `$__pw_rawcookies`, `$__pw_status`),
+ * any queued shutdown functions, and all output buffers.
+ *
+ * Performs FPM-style `$GLOBALS` cleanup (unsets request-scope keys not in
+ * the boot snapshot) and, when `ext-zealphp` is loaded, calls
+ * `zealphp_process_state_clean()` to roll back constants, classes, functions,
+ * and included files to the boot baseline.
+ *
+ * When `ZEALPHP_POOL_FULL_RESET=1` is set, also resets op_array
+ * `run_time_cache`, function-local statics, and class static properties
+ * (mirrors `CoSessionManager`'s per-request reset stack from ext-zealphp 0.3.25).
+ *
+ * IMPORTANT: Must be called at GLOBAL SCOPE (not inside a function) so that
+ * `$_SESSION = null` and the superglobal resets take effect process-wide.
+ */
 function pool_reset_request_state(): void
 {
     global $__pw_headers, $__pw_cookies, $__pw_rawcookies, $__pw_status, $__pw_globals_snapshot, $__pw_shutdown_functions;

--- a/src/utils.php
+++ b/src/utils.php
@@ -9,6 +9,8 @@ use OpenSwoole\Coroutine as co;
 use Throwable;
 
 /**
+ * Read a value from `$_GET` by key.
+ *
  * @param string $key
  * @param mixed  $default
  * @return mixed
@@ -18,6 +20,13 @@ function get($key, $default = null)
     return $_GET[$key] ?? $default;
 }
 
+/**
+ * Read a boolean environment variable using ZealPHP's truthiness convention.
+ *
+ * Returns `$default` when the variable is unset or empty. Otherwise, returns
+ * `false` when the value is one of `'0'`, `'false'`, `'off'`, `'no'`, or
+ * `'none'` (case-insensitive); returns `true` for everything else.
+ */
 function env_flag(string $name, bool $default): bool
 {
     $value = getenv($name);
@@ -29,6 +38,12 @@ function env_flag(string $name, bool $default): bool
     return !in_array($value, ['0', 'false', 'off', 'no', 'none'], true);
 }
 
+/**
+ * Whether benchmark mode is active (`ZEALPHP_BENCH_MODE` env flag).
+ *
+ * Bench mode disables all logging to avoid I/O overhead skewing results.
+ * The result is memoised after the first call.
+ */
 function bench_mode_enabled(): bool
 {
     /** @var bool|null $enabled */
@@ -41,6 +56,17 @@ function bench_mode_enabled(): bool
     return $enabled;
 }
 
+/**
+ * Absolute base URL for the ZealPHP OSS site.
+ *
+ * Resolution order:
+ *   1. `ZEALPHP_SITE_URL` env var.
+ *   2. `ZEALPHP_SITE_HOST` env var (scheme `https://` prepended if absent).
+ *   3. Hard-coded fallback `https://php.zeal.ninja`.
+ *
+ * When `$path` is non-empty it is appended with a single `/` separator.
+ * The result is memoised after the first call.
+ */
 function site_url(string $path = ''): string
 {
     /** @var string|null $base */
@@ -69,6 +95,12 @@ function site_url(string $path = ''): string
     return $base . '/' . ltrim($path, '/');
 }
 
+/**
+ * Return just the host component of `site_url()`.
+ *
+ * Falls back to the full `site_url()` string when `parse_url()` cannot extract
+ * a host (e.g. a bare domain without scheme).
+ */
 function site_host(): string
 {
     $url = site_url();
@@ -80,6 +112,12 @@ function site_host(): string
     return $url;
 }
 
+/**
+ * Whether async (coroutine-channel-backed) logging is enabled.
+ *
+ * Controlled by the `ZEALPHP_LOG_ASYNC` env flag (default `true`).
+ * The result is memoised after the first call.
+ */
 function async_logging_enabled(): bool
 {
     /** @var bool|null $enabled */
@@ -96,19 +134,19 @@ function async_logging_enabled(): bool
  * Ordered list of directories ZealPHP will try for its logs + PID files, most
  * preferred first. Pure (no I/O, no memoization) so it is unit-testable; the
  * actual pick — the first candidate that is writable or creatable — happens in
- * resolve_log_dir().
+ * `resolve_log_dir()`.
  *
  * Order:
- *   1. $ZEALPHP_LOG_DIR — explicit override, when set.
- *   2. /tmp/zealphp — the shared default, kept first for BC (used whenever the
+ *   1. `$ZEALPHP_LOG_DIR` — explicit override, when set.
+ *   2. `/tmp/zealphp` — the shared default, kept first for BC (used whenever the
  *      current user can create/write it: single-user box, root, or fresh box).
- *   3. Per-user fallbacks for the collision case where /tmp/zealphp already
+ *   3. Per-user fallbacks for the collision case where `/tmp/zealphp` already
  *      exists owned by ANOTHER user (e.g. root started a server there first), so
- *      this user cannot write it: $XDG_RUNTIME_DIR/zealphp, then a uid/user-
- *      suffixed temp dir (sys_get_temp_dir()/zealphp-<uid>). These keep us off a
- *      non-writable /tmp/zealphp without polluting the project tree, and resolve
+ *      this user cannot write it: `$XDG_RUNTIME_DIR/zealphp`, then a uid/user-
+ *      suffixed temp dir (`sys_get_temp_dir()/zealphp-<uid>`). These keep us off a
+ *      non-writable `/tmp/zealphp` without polluting the project tree, and resolve
  *      deterministically so `start` and `stop`/`status` agree on the same dir.
- *   4. Project-tree last resorts (./tmp/zealphp, ./logs/zealphp).
+ *   4. Project-tree last resorts (`./tmp/zealphp`, `./logs/zealphp`).
  *
  * @return list<string>
  */
@@ -146,6 +184,13 @@ function zealphp_log_dir_candidates(): array
     return array_values(array_unique($candidates));
 }
 
+/**
+ * Resolve the first writable log directory from `zealphp_log_dir_candidates()`.
+ *
+ * Creates the directory (with `0775` permissions, recursively) if it does not
+ * yet exist. Memoises the result so the filesystem is only probed once per
+ * worker lifetime. Returns `null` when no candidate is writable or creatable.
+ */
 function resolve_log_dir(): ?string
 {
     /** @var string|null $resolved */
@@ -172,12 +217,12 @@ function resolve_log_dir(): ?string
 }
 
 /**
- * The container's CPU allowance from its cgroup CPU quota, or null when there
+ * The container's CPU allowance from its cgroup CPU quota, or `null` when there
  * is no quota (unlimited, or not running under a limited cgroup).
  *
- * Reads cgroup v2 (`/sys/fs/cgroup/cpu.max` = "quota period") first, then v1
+ * Reads cgroup v2 (`/sys/fs/cgroup/cpu.max` = `"quota period"`) first, then v1
  * (`cpu.cfs_quota_us` / `cpu.cfs_period_us`). Returns quota ÷ period as a float
- * (e.g. `6.0` for "600000 100000"); null for "max" / unset / unreadable.
+ * (e.g. `6.0` for `"600000 100000"`); `null` for `"max"` / unset / unreadable.
  */
 function cgroup_cpu_quota(): ?float
 {
@@ -216,7 +261,7 @@ function cgroup_cpu_quota(): ?float
  * Returns `max(1, min($preferred, floor(cgroup_quota)))`; when there is no
  * cgroup quota it returns the conservative `$preferred` (NOT the host count).
  *
- * @param int $preferred desired worker count when unconstrained (default 4)
+ * @param int $preferred desired worker count when unconstrained (default `4`)
  */
 function default_worker_count(int $preferred = 4): int
 {
@@ -228,6 +273,13 @@ function default_worker_count(int $preferred = 4): int
     return $preferred;
 }
 
+/**
+ * Whether debug logging is enabled.
+ *
+ * Always `false` in bench mode. Controlled by `ZEALPHP_DEBUG_LOG` or the legacy
+ * `ZEALPHP_ELOG` env var (default `true` when neither is set). The result is
+ * memoised after the first call.
+ */
 function debug_logging_enabled(): bool
 {
     /** @var bool|null $enabled */
@@ -256,6 +308,12 @@ function debug_logging_enabled(): bool
     return $enabled;
 }
 
+/**
+ * Whether access logging is enabled.
+ *
+ * Always `false` in bench mode. Controlled by the `ZEALPHP_ACCESS_LOG` env flag
+ * (default `true`). The result is memoised after the first call.
+ */
 function access_logging_enabled(): bool
 {
     /** @var bool|null $enabled */
@@ -273,6 +331,19 @@ function access_logging_enabled(): bool
     return $enabled;
 }
 
+/**
+ * Resolve the absolute path for a named log file.
+ *
+ * `$kind` is one of `'access'`, `'zlog'`, or `'debug'`. Checks (in order):
+ *   1. Kind-specific env var (`ZEALPHP_ACCESS_LOG_FILE`, `ZEALPHP_ZLOG_FILE`,
+ *      `ZEALPHP_DEBUG_LOG_FILE`).
+ *   2. `ZEALPHP_LOG_FILE` (generic override, all kinds).
+ *   3. `resolve_log_dir()` + kind-specific filename (`access.log`, `zlog.log`,
+ *      `debug.log`).
+ *
+ * Returns `null` when no writable log directory can be found.
+ * Results are memoised per kind.
+ */
 function log_file_for(string $kind): ?string
 {
     /** @var array<string, string|null> $cache */
@@ -313,6 +384,20 @@ function log_file_for(string $kind): ?string
     return $cache[$kind];
 }
 
+/**
+ * Return (or create) the async `Channel`-backed log sink for `$path`.
+ *
+ * When async logging is enabled and a coroutine scheduler is running, this
+ * function returns an `OpenSwoole\Coroutine\Channel` that a background `go()`
+ * consumer drains to the file at `$path`. Callers push log lines onto the
+ * channel; the consumer does the actual `fwrite()` without blocking the request.
+ *
+ * Returns `null` when async logging is disabled, no scheduler is running, or
+ * `go()` is unavailable — callers fall back to a synchronous `fopen`/`fwrite`.
+ *
+ * The consumer goroutine falls back to `php://stderr` when the file cannot be
+ * opened (avoids silent log loss). Results are memoised per path.
+ */
 function log_sink_for(string $path): ?\OpenSwoole\Coroutine\Channel
 {
     /** @var array<string, \OpenSwoole\Coroutine\Channel> $sinks */
@@ -379,6 +464,18 @@ function log_sink_for(string $path): ?\OpenSwoole\Coroutine\Channel
     // @codeCoverageIgnoreEnd
 }
 
+/**
+ * Write a log line to the appropriate sink for `$kind`.
+ *
+ * Pushes to the async `Channel` sink when one is available (non-blocking,
+ * coroutine-safe). Falls through to a synchronous `fopen`/`fwrite` when called
+ * outside a coroutine or when the channel push fails. Writes to `php://stderr`
+ * as a last resort when no log file can be resolved.
+ *
+ * Note: uses `php://stderr` directly (not `error_log()`) in fallback paths
+ * because `error_log()` is uopz-overridden to route into this very function —
+ * calling it would recurse infinitely.
+ */
 function log_write(string $message, string $kind = 'debug'): void
 {
     $path = log_file_for($kind);
@@ -429,7 +526,7 @@ function log_write(string $message, string $kind = 'debug'): void
  * The child is spawned with OpenSwoole's coroutine runtime enabled, so inside
  * `$taskLogic` you can `go()` + `Channel` + hooked I/O (`curl`, `file_get_contents`,
  * PDO over the network, `Co\System::exec`, ...) and they run concurrently. The
- * call BLOCKS until the child finishes (when `$wait` is true) and returns whatever
+ * call BLOCKS until the child finishes (when `$wait` is `true`) and returns whatever
  * the child echoed — so serialise structured results (`json_encode` in the child,
  * `json_decode` in the caller).
  *
@@ -463,9 +560,9 @@ function log_write(string $message, string $kind = 'debug'): void
  *
  * @param callable $taskLogic The logic to run in the coroutine-enabled child.
  *                            Receives the `OpenSwoole\Process` as its argument.
- * @param bool $wait Whether to block until the child completes. Default true.
+ * @param bool $wait Whether to block until the child completes. Default `true`.
  *
- * @return mixed The child's echoed output (string) when `$wait` is true.
+ * @return mixed The child's echoed output (string) when `$wait` is `true`.
  */
 function coprocess($taskLogic, $wait = true)
 {
@@ -512,7 +609,7 @@ function coprocess($taskLogic, $wait = true)
 }
 
 /**
- * Thin alias for {@see coprocess()} — same fork-a-coroutine-child semantics, so
+ * Thin alias for `coprocess()` — same fork-a-coroutine-child semantics, so
  * it shares `coprocess()`'s untestability (forks a child process; only valid in
  * the `superglobals(true)`+`enableCoroutine(false)` mode the coverage gate excludes).
  *
@@ -526,11 +623,12 @@ function coproc($taskLogic){
 
 
 /**
-* jTraceEx() - provide a Java style exception trace
-* @param \Throwable        $e
-* @param array<int,string>|null $seen array passed to recursive calls to accumulate trace lines already seen
-*                                     leave as NULL when calling this function
-* @return string of array strings, one entry per trace line
+ * Produce a Java-style exception trace string.
+ *
+ * @param \Throwable        $e
+ * @param array<int,string>|null $seen array passed to recursive calls to accumulate trace lines already seen;
+ *                                     leave as `null` when calling this function
+ * @return string of array strings, one entry per trace line
 */
 function jTraceEx($e, $seen=null): string
 {
@@ -575,6 +673,12 @@ function jTraceEx($e, $seen=null): string
     return $result;
 }
 
+/**
+ * Return the `basename` (without `.php` extension) of the calling API file.
+ *
+ * Used inside `api/` handlers to obtain the endpoint name for logging without
+ * hard-coding the filename. Reads one frame from `debug_backtrace()`.
+ */
 function zapi(): string {
     $bt = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 1);
     $caller = array_shift($bt);
@@ -582,11 +686,15 @@ function zapi(): string {
 }
 
 /**
- * Logs a message with an optional tag and limit.
+ * Log a debug message with caller location.
+ *
+ * Writes to the debug log (`debug.log`) when `debug_logging_enabled()` is
+ * `true`. Messages tagged `'wordpress'` are silently suppressed to avoid noise
+ * from WordPress's verbose internal logging.
  *
  * @param string $message The message to log.
- * @param string $tag The tag to associate with the log message. Default is "*".
- * @param int $limit The limit for the log message. Default is 1.
+ * @param string $tag     The tag to associate with the log message. Default `"*"`.
+ * @param int    $limit   Stack depth passed to `debug_backtrace()`. Default `1`.
  */
 function elog($message, $tag = "*", $limit = 1): void {
     if (!debug_logging_enabled()) {
@@ -604,12 +712,18 @@ function elog($message, $tag = "*", $limit = 1): void {
 }
 
 /**
- * Logs a message with an optional tag and filter.
+ * Log a structured message to `zlog.log` with request context.
  *
- * @param mixed  $log           The message or data to log.
- * @param string $tag           The tag to categorize the log entry. Default is "system".
- * @param mixed  $filter        Optional filter to apply to the log entry.
- * @param bool   $invert_filter Whether to invert the filter logic. Default is false.
+ * Writes caller file/line, request URL, request ID, and render timer alongside
+ * the message. Valid `$tag` values: `'system'`, `'fatal'`, `'error'`,
+ * `'warning'`, `'info'`, `'debug'`. Messages with unknown tags are silently
+ * dropped. No-op when `debug_logging_enabled()` is `false`.
+ *
+ * @param mixed  $log           The message or data to log (arrays/objects are JSON-encoded).
+ * @param string $tag           The tag to categorize the log entry. Default `"system"`.
+ * @param mixed  $filter        Optional URI substring filter; skips logging when the
+ *                              current `REQUEST_URI` does not contain this string.
+ * @param bool   $invert_filter Whether to invert the filter logic. Default `false`.
  */
 function zlog($log, $tag = "system", $filter = null, $invert_filter = false): void
 {
@@ -664,6 +778,11 @@ function zlog($log, $tag = "system", $filter = null, $invert_filter = false): vo
 
 
 /**
+ * Read a site configuration value by key.
+ *
+ * Decodes the global `$__site_config` JSON string and returns the value for
+ * `$key`, or `null` when the key is absent or the config is not valid JSON.
+ *
  * @param string $key
  * @return mixed
  */
@@ -699,7 +818,7 @@ function get_current_render_time()
 
 
 /**
- * Indend the given text with the given number of spaces
+ * Indent the given text with the given number of spaces.
  *
  * @param String $string
  * @param Integer $indend	Number of lines to indent
@@ -722,7 +841,8 @@ function indent($string, $indend = 4)
 }
 
 /**
- * Takes an iterator or object, and converts it into an Array.
+ * Convert an iterator or object into an array via JSON round-trip.
+ *
  * @param  mixed $obj
  * @return array<int|string, mixed>
  */
@@ -737,7 +857,7 @@ function purify_array($obj)
 /**
  * Generates a unique identifier of a specified length.
  *
- * @param int $length The length of the unique identifier to generate. Default is 13.
+ * @param int $length The length of the unique identifier to generate. Default is `13`.
  * @return string The generated unique identifier.
  */
 function uniqidReal($length = 13)
@@ -754,10 +874,16 @@ function uniqidReal($length = 13)
 }
 
 /**
- * Logs access details with the given status and length.
+ * Write an access log line for the current request.
  *
- * @param int $status The HTTP status code to log.
- * @param int $length The length of the response content.
+ * Delegates to `App::formatAccessLogLine()` so the entry honours
+ * `App::$access_log_format` (Apache `LogFormat` / `CustomLog` parity) and the
+ * trusted-proxy `X-Forwarded-For` walk in `App::clientIp()`. No-op when
+ * `access_logging_enabled()` is `false`.
+ *
+ * @param int        $status      The HTTP status code to log.
+ * @param int        $length      The response body length in bytes.
+ * @param float|null $durationSec Request duration in seconds, or `null` to omit.
  */
 function access_log(int $status = 200, int $length = 0, ?float $durationSec = null): void {
     if (!access_logging_enabled()) {
@@ -773,16 +899,14 @@ function access_log(int $status = 200, int $length = 0, ?float $durationSec = nu
 }
 
 /**
- * Adds a header to the response.
+ * Append a header to the current response.
  *
- * @param string $key The name of the header.
- * @param string $value The value of the header.
- * @param bool $ucwords Optional. Whether to capitalize the first letter of each word in the header name. Default is true.
- */
-/**
- * @param string $key
- * @param string $value
- * @param bool   $ucwords
+ * Delegates to `$g->zealphp_response->header()`. The `$ucwords` flag controls
+ * whether the header name is title-cased before queuing (default `true`).
+ *
+ * @param string $key     The header name.
+ * @param string $value   The header value.
+ * @param bool   $ucwords Whether to title-case the header name. Default `true`.
  */
 function response_add_header($key, $value, $ucwords = true): void
 {
@@ -814,27 +938,12 @@ function response_headers_list(): array
 }
 
 /**
- * Set a cookie.
+ * Set a response cookie (uopz override of PHP's built-in `setcookie()`).
  *
- * @param string $name The name of the cookie.
- * @param string $value The value of the cookie. Default is an empty string.
- * @param int $expire The time the cookie expires. This is a Unix timestamp so is in number of seconds since the epoch. Default is 0.
- * @param string $path The path on the server in which the cookie will be available on. Default is an empty string.
- * @param string $domain The (sub)domain that the cookie is available to. Default is an empty string.
- * @param bool $secure Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client. Default is false.
- * @param bool $httponly When true the cookie will be made accessible only through the HTTP protocol. Default is false.
- */
-/**
- * @param string $name
- * @param string $value
- * @param int    $expire
- * @param string $path
- * @param string $domain
- * @param bool   $secure
- * @param bool   $httponly
- * @param string $samesite
- */
-/**
+ * Validates the cookie name and value for control characters (matching PHP
+ * native behaviour since PHP 7). Supports the PHP 7.3+ options-array form for
+ * `$expire_or_options`. Delegates to `$g->zealphp_response->cookie()`.
+ *
  * @param string $name
  * @param string $value
  * @param int|array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool, samesite?: string} $expire_or_options
@@ -873,6 +982,12 @@ function setcookie($name, $value = "", int|array $expire_or_options = 0, $path =
 }
 
 /**
+ * Set a raw (URL-encoded) response cookie (uopz override of PHP's built-in `setrawcookie()`).
+ *
+ * Like `setcookie()` but the value is sent as-is without URL-encoding. Supports
+ * the PHP 7.3+ options-array form for `$expire_or_options`. Validates for
+ * control characters. Delegates to `$g->zealphp_response->rawCookie()`.
+ *
  * @param string $name
  * @param string $value
  * @param int|array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool} $expire_or_options
@@ -924,6 +1039,16 @@ function setrawcookie($name, $value = "", int|array $expire_or_options = 0, $pat
 }
 
 /**
+ * Set a response header (uopz override of PHP's built-in `header()`).
+ *
+ * Guards against CRLF/NUL injection (HTTP response splitting). Recognises
+ * the Apache mod_php status-line forms:
+ *   - `header("HTTP/1.1 404 Not Found")` — sets the response status code.
+ *   - `header("Status: 404 Not Found")` — CGI variant; sets the status code.
+ *
+ * When `$replace` is `true`, any previously queued header with the same name
+ * (case-insensitive) is removed before the new value is added.
+ *
  * @param string   $header
  * @param bool     $replace
  * @param int|null $http_response_code
@@ -973,11 +1098,12 @@ function header($header, $replace = true, $http_response_code = null) {
 }
 
 
-/*
-* @param int|null $code The HTTP status code to set. If null, the current status code is returned.
-* @return int The current HTTP response status code.
-*/
 /**
+ * Get or set the HTTP response status code (uopz override of PHP's built-in `http_response_code()`).
+ *
+ * When `$code` is `null`, returns the current status. Otherwise sets it and
+ * returns `null`.
+ *
  * @param int|null $code
  * @return int|null
  */
@@ -992,16 +1118,16 @@ function http_response_code($code = null) {
 
 /**
  * Per-coroutine `putenv()` — stores the assignment in the request-scoped
- * RequestContext (`$g->memo['_env']`), which is isolated per coroutine in
- * Mode 4, instead of the process-wide environment. Pairs with {@see getenv()}.
+ * `RequestContext` (`$g->memo['_env']`), which is isolated per coroutine in
+ * Mode 4, instead of the process-wide environment. Pairs with `getenv()`.
  * The process environment stays at its boot value, so concurrent requests no
  * longer race `putenv()` (a process-level landmine in any persistent server).
  *
- * Trade-off: subprocesses (proc_open) do NOT inherit a request-scoped putenv —
+ * Trade-off: subprocesses (`proc_open`) do NOT inherit a request-scoped `putenv` —
  * use it for request-scoped config (tenant id, locale), not for child-process
  * environment. Registered only in coroutine-isolated mode (Mode 4).
  *
- * @param string $assignment "NAME=value" to set, or "NAME" to unset.
+ * @param string $assignment `"NAME=value"` to set, or `"NAME"` to unset.
  */
 function zeal_putenv(string $assignment): bool {
     $g = RequestContext::instance();
@@ -1020,7 +1146,7 @@ function zeal_putenv(string $assignment): bool {
 
 /**
  * Per-coroutine `getenv()` — reads the request-scoped env first (set via
- * {@see putenv()}), then the process environment captured at boot
+ * `putenv()`), then the process environment captured at boot
  * (`App::$boot_env`). No-arg form returns the merged map. `$local_only`
  * returns only request-scoped variables (matches the native signature).
  *
@@ -1049,10 +1175,10 @@ function zeal_getenv($name = null, bool $local_only = false) {
 }
 
 /**
- * Coroutine-safe `shell_exec()` shim — routes through {@see App::exec()}.
+ * Coroutine-safe `shell_exec()` shim — routes through `App::exec()`.
  *
  * Registered as a uopz override of the `shell_exec` builtin when exec hooking
- * is enabled (see {@see App::$hook_exec}). Because the PHP backtick operator
+ * is enabled (see `App::$hook_exec`). Because the PHP backtick operator
  * compiles down to a `shell_exec()` call, overriding `shell_exec` also makes
  * `` `cmd` `` coroutine-safe transparently.
  *
@@ -1065,7 +1191,7 @@ function zeal_shell_exec(string $cmd): ?string {
 }
 
 /**
- * Coroutine-safe `system()` shim — routes through {@see App::exec()}.
+ * Coroutine-safe `system()` shim — routes through `App::exec()`.
  *
  * Echoes the full output (like the builtin) and returns the last line of
  * output, writing the exit code into `$code` by reference.
@@ -1083,7 +1209,7 @@ function zeal_system(string $cmd, &$code = null): string {
 }
 
 /**
- * Coroutine-safe `passthru()` shim — routes through {@see App::exec()}.
+ * Coroutine-safe `passthru()` shim — routes through `App::exec()`.
  *
  * Echoes the raw output and writes the exit code into `$code` by reference.
  *
@@ -1097,7 +1223,7 @@ function zeal_passthru(string $cmd, &$code = null): void {
 }
 
 /**
- * Coroutine-safe `exec()` shim — routes through {@see App::exec()}.
+ * Coroutine-safe `exec()` shim — routes through `App::exec()`.
  *
  * Appends each output line to `$output` (like the builtin) and writes the
  * exit code into `$code` by reference. Returns the last line of output.
@@ -1117,13 +1243,12 @@ function zeal_exec(string $cmd, array &$output = [], &$code = null): string {
 }
 
 /**
-* Retrieves all HTTP headers sent by the server.
-*
-* This function returns an array of all the HTTP headers that have been sent
-* by the server. It can be useful for debugging or logging purposes.
-*
-* @return array<int, string> An associative array of all the HTTP headers.
-*/
+ * Return all outbound response headers as formatted strings (uopz override of `headers_list()`).
+ *
+ * Each element is formatted as `"Name: value"`.
+ *
+ * @return array<int, string>
+ */
 function headers_list(): array {
    $headers = response_headers_list();
    $result = [];
@@ -1134,12 +1259,17 @@ function headers_list(): array {
 }
 
 /**
-* Checks if headers have already been sent and optionally returns the file and line number where the output started.
-*
-* @param string|null $file Optional. If provided, this will be set to the filename where output started.
-* @param int|null $line Optional. If provided, this will be set to the line number where output started.
-* @return bool Returns true if headers have already been sent, false otherwise.
-*/
+ * Check whether response headers have already been sent (uopz override of `headers_sent()`).
+ *
+ * Under OpenSwoole, headers are considered "sent" when the underlying
+ * `openswoole_response` is no longer writable. The `$file` and `$line`
+ * out-parameters are not populated (no PHP output-started tracking in this
+ * runtime).
+ *
+ * @param string|null $file Optional. If provided, this will be set to the filename where output started.
+ * @param int|null    $line Optional. If provided, this will be set to the line number where output started.
+ * @return bool Returns `true` if headers have already been sent, `false` otherwise.
+ */
 function headers_sent(&$file = null, &$line = null) {
    $g = RequestContext::instance();
    if (isset($g->openswoole_response)) {
@@ -1149,7 +1279,10 @@ function headers_sent(&$file = null, &$line = null) {
 }
 
 /**
- * Remove a previously set response header. With no argument, clears all.
+ * Remove a previously set response header (uopz override of `header_remove()`).
+ *
+ * With no argument (or `null`), clears all queued response headers. Otherwise
+ * removes all headers matching `$name` (case-insensitive).
  */
 function header_remove(?string $name = null): void
 {
@@ -1168,9 +1301,12 @@ function header_remove(?string $name = null): void
 }
 
 /**
- * Force the current output buffer to the client. In main-worker mode, this
- * switches the response into streaming mode (headers flushed, body chunks
- * written via OpenSwoole). Subsequent `echo`+`flush` calls stream incrementally.
+ * Force the current output buffer to the client (uopz override of `flush()`).
+ *
+ * In main-worker mode, this switches the response into streaming mode: headers
+ * are flushed once, then body chunks are written via `openswoole_response->write()`.
+ * Subsequent `echo` + `flush()` calls stream incrementally. No-op when the
+ * response is no longer writable or no response context is available.
  */
 function flush(): void
 {
@@ -1196,11 +1332,19 @@ function flush(): void
     }
 }
 
+/**
+ * Alias for `ZealPHP\flush()` — flushes the current output buffer to the client.
+ */
 function ob_flush(): void
 {
     \ZealPHP\flush();
 }
 
+/**
+ * Flush the current output buffer and close it (uopz override of `ob_end_flush()`).
+ *
+ * Delegates to `ZealPHP\flush()`, then ends the active output buffer level.
+ */
 function ob_end_flush(): void
 {
     \ZealPHP\flush();
@@ -1210,10 +1354,11 @@ function ob_end_flush(): void
 }
 
 /**
- * Apache mod_php toggles implicit flush on/off. ZealPHP buffers per request
- * by default; we accept the call as a no-op rather than crashing legacy code.
- */
-/**
+ * Apache mod_php `ob_implicit_flush()` compatibility shim.
+ *
+ * Toggles implicit flush on/off under mod_php. ZealPHP buffers per request
+ * by default; this call is accepted as a no-op rather than crashing legacy code.
+ *
  * @param bool|int $enable
  */
 function ob_implicit_flush($enable = true): void
@@ -1224,7 +1369,7 @@ function ob_implicit_flush($enable = true): void
 /**
  * mod_php-parity `phpinfo()`: render a self-contained HTML document instead of the
  * CLI SAPI's plain-text dump. Matches the native signature — echoes output and
- * returns true. Wired via uopz in `App::__construct()`; the renderer lives in
+ * returns `true`. Wired via uopz in `App::__construct()`; the renderer lives in
  * `\ZealPHP\Diagnostics\PhpInfo`.
  *
  * @param int $flags `INFO_*` bitmask.
@@ -1300,14 +1445,14 @@ function header_register_callback(callable $callback): bool
 
 /**
  * mod_php-parity `error_log()`: under the CLI SAPI native `error_log()` writes to
- * stderr / the `php.ini` `error_log` path. ZealPHP routes `message_type` 0 (system
- * logger) and 4 (SAPI logger) into the framework's async log (`debug.log`, or
+ * stderr / the `php.ini` `error_log` path. ZealPHP routes `message_type` `0` (system
+ * logger) and `4` (SAPI logger) into the framework's async log (`debug.log`, or
  * stderr if logging is disabled) so legacy `error_log()` calls land where the
  * rest of the app's diagnostics go — the "we have `elog` for `error_log`" contract.
  *
- *   - type 3 (append to file): honored verbatim — explicit destination intent.
- *   - type 1 (email): unsupported under the coroutine runtime; logged + `false`.
- *   - type 0 / 4: routed to `log_write()` (`debug.log` → stderr fallback).
+ *   - type `3` (append to file): honored verbatim — explicit destination intent.
+ *   - type `1` (email): unsupported under the coroutine runtime; logged + `false`.
+ *   - type `0` / `4`: routed to `log_write()` (`debug.log` → stderr fallback).
  *
  * Always lands somewhere (never silently dropped), unlike `elog()` which gates on
  * debug logging; that's why this routes through `log_write()` directly.
@@ -1357,6 +1502,8 @@ function apache_request_headers(): array
 }
 
 /**
+ * Alias for `apache_request_headers()` — return all inbound request headers.
+ *
  * @return array<string, string>
  */
 function getallheaders(): array
@@ -1365,7 +1512,7 @@ function getallheaders(): array
 }
 
 /**
- * Apache mod_php `apache_response_headers()` — currently set outbound headers.
+ * Apache mod_php `apache_response_headers()` — return currently queued outbound headers.
  *
  * @return array<string, string>
  */
@@ -1383,9 +1530,11 @@ function apache_response_headers(): array
 }
 
 /**
- * Apache mod_php per-request env table. Backed by `Legacy\ApacheContext` on
- * `G`; lifetime = one request. Lazy — only allocated if legacy code calls
- * `apache_setenv`/`getenv`/`note`.
+ * Apache mod_php per-request env table setter (`apache_setenv()`).
+ *
+ * Backed by `Legacy\ApacheContext` on `G`; lifetime = one request. Lazy —
+ * only allocated if legacy code calls `apache_setenv()`/`apache_getenv()`/`apache_note()`.
+ * The `$walk_to_top` flag is accepted for API compatibility but has no effect.
  */
 function apache_setenv(string $variable, string $value, bool $walk_to_top = false): bool
 {
@@ -1398,6 +1547,12 @@ function apache_setenv(string $variable, string $value, bool $walk_to_top = fals
 }
 
 /**
+ * Apache mod_php per-request env table getter (`apache_getenv()`).
+ *
+ * Returns `false` when no Apache context has been initialised or the variable
+ * is not set. The `$walk_to_top` flag is accepted for API compatibility but
+ * has no effect.
+ *
  * @return string|false
  */
 function apache_getenv(string $variable, bool $walk_to_top = false)
@@ -1408,6 +1563,9 @@ function apache_getenv(string $variable, bool $walk_to_top = false)
 
 /**
  * Apache mod_php `apache_note()` — per-request note table. Returns previous value.
+ *
+ * When `$note_value` is `null`, acts as a getter only. Setting a value
+ * lazily initialises the `ApacheContext` if needed.
  */
 function apache_note(string $note_name, ?string $note_value = null): string
 {
@@ -1423,9 +1581,10 @@ function apache_note(string $note_name, ?string $note_value = null): string
 }
 
 /**
- * Apache mod_php `virtual()` — performs an internal subrequest. Not supported
- * in ZealPHP's single-process model; we log once and return `false` rather than
- * crashing legacy code.
+ * Apache mod_php `virtual()` — performs an internal subrequest.
+ *
+ * Not supported in ZealPHP's single-process model; logs once via `elog()` and
+ * returns `false` rather than crashing legacy code.
  */
 function virtual(string $uri): bool
 {
@@ -1434,8 +1593,10 @@ function virtual(string $uri): bool
 }
 
 /**
- * `set_time_limit()` — OpenSwoole has its own coroutine/worker timeouts and
- * native PHP execution-time limit is irrelevant here. Treated as no-op success.
+ * `set_time_limit()` compatibility shim.
+ *
+ * OpenSwoole has its own coroutine/worker timeouts and the native PHP
+ * execution-time limit is irrelevant here. Treated as no-op success.
  */
 function set_time_limit(int $seconds): bool
 {
@@ -1443,11 +1604,13 @@ function set_time_limit(int $seconds): bool
 }
 
 /**
- * `ignore_user_abort()` — Apache mod_php controls whether the script keeps
- * running after the client disconnects. Tracked in `G`; with OpenSwoole the
- * coroutine continues regardless, but we honor the API contract.
- */
-/**
+ * `ignore_user_abort()` compatibility shim (uopz override).
+ *
+ * Apache mod_php controls whether the script keeps running after the client
+ * disconnects. The state is tracked in `G`; with OpenSwoole the coroutine
+ * continues regardless, but we honor the API contract. When called with no
+ * argument, returns the current setting without changing it.
+ *
  * @param bool|null $enable
  */
 function ignore_user_abort($enable = null): int
@@ -1460,6 +1623,12 @@ function ignore_user_abort($enable = null): int
     return $previous;
 }
 
+/**
+ * Return the connection status for the current request.
+ *
+ * Returns `1` (`CONNECTION_ABORTED`) when the underlying `openswoole_response`
+ * is no longer writable, `0` (`CONNECTION_NORMAL`) otherwise.
+ */
 function connection_status(): int
 {
     $g = RequestContext::instance();
@@ -1470,6 +1639,11 @@ function connection_status(): int
     return 0; // CONNECTION_NORMAL
 }
 
+/**
+ * Return `1` when the client connection has been aborted, `0` otherwise.
+ *
+ * Equivalent to `connection_status() === 1`.
+ */
 function connection_aborted(): int
 {
     $g = RequestContext::instance();
@@ -1481,21 +1655,26 @@ function connection_aborted(): int
 }
 
 /**
- * Apache's URL-rewrite output handler — not used in ZealPHP. No-op.
+ * Apache's URL-rewrite output handler — not used in ZealPHP. No-op returning `false`.
  */
 function output_add_rewrite_var(string $name, string $value): bool
 {
     return false;
 }
 
+/**
+ * Apache's URL-rewrite output handler reset — not used in ZealPHP. No-op returning `true`.
+ */
 function output_reset_rewrite_vars(): bool
 {
     return true;
 }
 
 /**
- * `is_uploaded_file()` — verifies that `$filename` is one of the temp paths
- * registered in this request's `$_FILES`. Rejects forged paths from user input.
+ * `is_uploaded_file()` compatibility shim (uopz override).
+ *
+ * Verifies that `$filename` is one of the temp paths registered in this
+ * request's `$_FILES` (via `$g->files`). Rejects forged paths from user input.
  */
 function is_uploaded_file(string $filename): bool
 {
@@ -1513,8 +1692,10 @@ function is_uploaded_file(string $filename): bool
 }
 
 /**
- * `move_uploaded_file()` — equivalent of Apache+mod_php behavior, gated by
- * `is_uploaded_file()` and falling back to `copy`+`unlink` across filesystems.
+ * `move_uploaded_file()` compatibility shim (uopz override).
+ *
+ * Equivalent to Apache+mod_php behaviour, gated by `is_uploaded_file()` and
+ * falling back to `copy()`+`unlink()` across filesystems when `rename()` fails.
  */
 function move_uploaded_file(string $from, string $to): bool
 {
@@ -1532,9 +1713,12 @@ function move_uploaded_file(string $from, string $to): bool
 }
 
 /**
- * Per-coroutine `set_error_handler` override. The native PHP handler is
- * installed at boot and delegates to `G`'s per-coroutine stack — this override
- * just records the user-space registration without touching the engine.
+ * Per-request `set_error_handler()` (uopz override).
+ *
+ * The native PHP error handler is installed at boot and delegates to `G`'s
+ * per-coroutine stack. This override records the user-space registration in
+ * `$g->error_handlers_stack` without touching the engine handler. Passing
+ * `null` pops the most recently registered handler (matches native behaviour).
  */
 function set_error_handler(?callable $callback, int $error_levels = E_ALL): ?callable
 {
@@ -1550,6 +1734,11 @@ function set_error_handler(?callable $callback, int $error_levels = E_ALL): ?cal
     return $prev;
 }
 
+/**
+ * Pop the most recently registered per-request error handler.
+ *
+ * Mirrors the native `restore_error_handler()` contract; always returns `true`.
+ */
 function restore_error_handler(): bool
 {
     $g = RequestContext::instance();
@@ -1559,6 +1748,13 @@ function restore_error_handler(): bool
     return true;
 }
 
+/**
+ * Per-request `set_exception_handler()` (uopz override).
+ *
+ * Stores the handler in `$g->exception_handlers_stack`. Passing `null` pops
+ * the most recently registered handler. Returns the previously active handler
+ * (or `null` when none was set).
+ */
 function set_exception_handler(?callable $callback): ?callable
 {
     $g = RequestContext::instance();
@@ -1573,6 +1769,11 @@ function set_exception_handler(?callable $callback): ?callable
     return $prev;
 }
 
+/**
+ * Pop the most recently registered per-request exception handler.
+ *
+ * Mirrors the native `restore_exception_handler()` contract; always returns `true`.
+ */
 function restore_exception_handler(): bool
 {
     $g = RequestContext::instance();
@@ -1583,9 +1784,12 @@ function restore_exception_handler(): bool
 }
 
 /**
- * Per-request shutdown function — fires after the route handler returns and
- * before the PSR response is emitted, so the function can still call
- * `echo`/`header`/`http_response_code` and have those land in the response.
+ * Per-request shutdown function (uopz override of `register_shutdown_function()`).
+ *
+ * Fires after the route handler returns and before the PSR response is emitted,
+ * so the callback can still call `echo`/`header()`/`http_response_code()` and
+ * have those land in the response. Multiple callbacks are supported and called
+ * in registration order.
  */
 function register_shutdown_function(callable $callback, mixed ...$args): void
 {
@@ -1596,7 +1800,12 @@ function register_shutdown_function(callable $callback, mixed ...$args): void
 }
 
 /**
- * Per-coroutine `error_reporting`. Falls back to the level captured at App boot.
+ * Per-coroutine `error_reporting()` (uopz override).
+ *
+ * When called without an argument, returns the current reporting level for this
+ * coroutine (falling back to the level captured at `App` boot via
+ * `App::$initial_error_reporting`). When called with a level, stores it in
+ * `$g->error_reporting_level` and returns the previous level.
  */
 function error_reporting(?int $error_level = null): int
 {


### PR DESCRIPTION
Codebase-wide PHPDoc quality pass — split out so it can be reviewed independently.

**Stacked on the docs-audit PR** (`base: docs/audit-2026-06-02`). Merge order: #174 → docs-audit → this.

Comment-only sweep across 45 `src/` files, applied by a 12-agent workflow (11 disjoint file-groups + `App.php` as a 3-agent bottom-to-top chain).

### What changed (docblocks/comments only)
- Code tokens wrapped in backticks: `$variables`, `method()`, `ClassName`, constants, `ZEALPHP_*` env vars, file paths, literals.
- Multi-line code samples converted to fenced ```php blocks.
- Missing docblocks added to classes, public/static **properties** (notably the many previously-undocumented `App.php` config properties), and public/protected methods — with `@param`/`@return`/`@var` only where they add information beyond the native signature (no redundant tags).
- House style matched to `src/Store.php`.

### Verification
- `php -l` clean on all 45 files.
- PHPStan L10 unchanged — back to exactly the 2 pre-existing local-only Session artifacts (one agent over-widened a `RedisBackend` `@return` to `mixed`, breaking the `StoreBackend` `scalar` contract under `TieredBackend`; narrowed back to `scalar` in this PR).
- Unit suite green except 4 pre-existing `uopz`-not-loaded env errors that also fail on a clean tree (they pass on CI where uopz loads).
- Behavior-change guard: comment-only confirmed (one byte-identical `App.php` method relocation, PHPStan-clean).
