### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-06-03
+
 WordPress (and any legacy `require_once`-bootstrap app) now runs end-to-end in the **CGI-subprocess modes** — `cgi-pool` and `cgi-proc` — including **wp-admin and the Gutenberg block editor**, with **unmodified WordPress source**. All four fixes live entirely in ZealPHP's CGI worker layer; the in-process (`coroutine`/`mixed`) paths and `App.php` are unchanged. Huge thanks to **@Guruprasanth-M** for the rigorous, source-cited bug reports (#167, #169) and the reference patches this lands.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project sibidharan/zealphp-project:^0.3.7 my-project
+composer create-project sibidharan/zealphp-project:^0.3.8 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -461,8 +461,8 @@ The fine-grained setters (`App::superglobals()`, `App::isolation()`, `App::enabl
 2. Run `composer validate` and confirm tests pass.
 3. Tag both `zealphp` and `zealphp-project` with the same version:
    ```bash
-   git tag -a v0.3.7 -m "Release v0.3.7"
-   git push origin master && git push origin v0.3.7
+   git tag -a v0.3.8 -m "Release v0.3.8"
+   git push origin master && git push origin v0.3.8
    ```
 4. Trigger Packagist webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.3.7 .
+docker build -t zealphp:0.3.8 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -231,7 +231,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.25 \
-    -t zealphp:0.3.7 .
+    -t zealphp:0.3.8 .
 ```
 
 ### Run (single container)
@@ -243,7 +243,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.3.7
+    zealphp:0.3.8
 ```
 
 ### Production compose
@@ -254,7 +254,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.3.7
+    image: registry.example.com/zealphp-app:0.3.8
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.3.7
+    image: zealphp:0.3.8
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -178,7 +178,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  sibidharan/zealphp-project:^0.3.7 \
+  sibidharan/zealphp-project:^0.3.8 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, coroutines, shared memory, task workers &mdash;
        first&#8209;class because the server never shuts down between requests.</p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.3.7 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.3.8 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -306,7 +306,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.3.7 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.3.7 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.3.8 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.3.8 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>


### PR DESCRIPTION
Release **v0.3.8**. Version bumps only (CHANGELOG, README, getting-started, home, deployment docs).

## Highlights since v0.3.7
- **`App::cgiMode('fork')`** — Apache MPM-prefork-style CGI runner: a long-lived fork-master forks a fresh child per request at ~1ms cost, runs the target at true global scope, hard-exits. Fresh-process correctness (no `Cannot redeclare`) without `proc_open` cold-start.
- **Per-route CGI backend** — the `backend:` route option + `App::cgiBackendAlias()`; a single route picks its own `pool`/`proc`/`fork`/`fcgi` dispatch.
- **Patched-opcache Docker build** (`--build-arg ZEALPHP_PATCH_OPCACHE=1`) so opcache stays fully on in coroutine-legacy for `require_once` apps — the upstream function-dups inconsistency ([php/php-src#22214](https://github.com/php/php-src/issues/22214)) fixed in the image. `App::opcacheLegacyBootCheck()` advisory leads with `dups_fix`.
- **WordPress** media uploads + wp-admin/Gutenberg work in the `cgi-pool`/`cgi-proc` subprocess modes (#167, #169).

Full detail in `CHANGELOG.md` `[0.3.8]`.