### PR TITLE
fix(setup): complete OpenSwoole build deps (pkg-config) + macOS keg paths + pecl guard

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,6 +45,18 @@ install_openswoole_source() {
     src="$tmpdir/src"
     echo -e "${YELLOW}Building OpenSwoole from source (openswoole/ext-openswoole @ ${ref}).${RESET}"
 
+    # macOS/Homebrew: keg-only libs (openssl, c-ares, ...) aren't on the default
+    # search path, so point pkg-config at the brew kegs the build needs. Best-effort
+    # (not exercised in CI); guarded on Darwin so it's a no-op on Linux.
+    if [ "$(uname -s)" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+        local kl kp
+        for kl in openssl@3 c-ares nghttp2 brotli curl; do
+            kp="$(brew --prefix "$kl" 2>/dev/null)"
+            [ -n "$kp" ] && [ -d "$kp/lib/pkgconfig" ] && PKG_CONFIG_PATH="$kp/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+        done
+        export PKG_CONFIG_PATH
+    fi
+
     # Fetch the tagged source straight from GitHub — git clone first, then the
     # release tarball as a second transport. Both bypass PECL/PIE/Packagist.
     if ! git clone --depth 1 --branch "$ref" https://github.com/openswoole/ext-openswoole.git "$src" 2>/dev/null \
@@ -461,6 +473,9 @@ install_dependencies() {
         "libc-ares-dev"
         "libnghttp2-dev"
         "libbrotli-dev"
+        "zlib1g-dev"
+        "pkg-config"
+        "ca-certificates"
     )
 
     $SUDO apt install -y "${packages[@]}" || {
@@ -492,8 +507,9 @@ check_and_remove_openswoole() {
         }
     fi
 
-    # Check and remove installation via pecl
-    if pecl list | grep -q 'openswoole'; then
+    # Check and remove installation via pecl (pecl may be absent — we no longer
+    # install via it; guard so a missing pecl isn't a noisy "command not found").
+    if command -v pecl >/dev/null 2>&1 && pecl list 2>/dev/null | grep -q 'openswoole'; then
         echo -e "${GREEN}OpenSwoole is installed via pecl. Removing.${RESET}"
         pecl uninstall openswoole || {
             echo -e "${RED}Failed to remove OpenSwoole installed via pecl.${RESET}"


### PR DESCRIPTION
## Dependency audit (follow-up to the tagged-source-build change, #196)

Audited the OpenSwoole source build's real requirements against each install path's dep list.

### Real gap found & fixed
**`pkg-config` was missing from the system apt list.** It only worked before because it tends to be pre-installed — it is **not** a transitive dependency of anything in the list, so on a clean machine configure could fail to detect libraries. Added `pkg-config`, plus `zlib1g-dev` and `ca-certificates` for parity with the (known-good) Docker list and so HTTPS `git`/`curl` work on minimal hosts.

**Verified:** `ubuntu:24.04` with `apt-get install --no-install-recommends` of *exactly* the system list (strict — no recommended extras to mask a gap) builds **openswoole 26.2.0** with `--enable-cares`/`--with-postgres` and loads.

### macOS hardening
Point `pkg-config` at the Homebrew kegs (`openssl@3`, `c-ares`, …) since they're keg-only and off the default search path, so `--enable-openssl` etc. resolve. Darwin-guarded (no-op on Linux). Best-effort — not exercised in CI (no macOS runner).

### Minor
`check_and_remove_openswoole` now guards the legacy `pecl list`/`pecl uninstall` calls with `command -v pecl` — we no longer install via pecl and it may be absent, so this drops a spurious "pecl: command not found".

`bash -n` clean.
