### PR TITLE
fix: 8 bugs from the 2026-06-03 issue triage (CORS bypass, session race, range, cache, …)

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -250,6 +250,10 @@ class Cache
                 self::$spillsFull?->increment();
             }
         } else {
+            // Oversize values live in the file tier only. Evict any stale
+            // memory-tier row for this key first — get() checks memory before
+            // file, so an old small value would otherwise mask this large one (#186).
+            Store::del(self::TABLE, $hash);
             self::$spillsFile?->increment();
         }
 

--- a/src/Cache/SimpleCacheAdapter.php
+++ b/src/Cache/SimpleCacheAdapter.php
@@ -15,14 +15,13 @@ class SimpleCacheAdapter implements CacheInterface
     public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $this->validateKey($key);
-        $ttlSeconds = $this->normalizeTtl($ttl);
 
-        if ($ttlSeconds < 0) {
+        if ($this->isExpiredTtl($ttl)) {
             Cache::del($key);
             return true;
         }
 
-        return Cache::set($key, $value, $ttlSeconds);
+        return Cache::set($key, $value, $this->normalizeTtl($ttl));
     }
 
     public function delete(string $key): bool
@@ -56,12 +55,13 @@ class SimpleCacheAdapter implements CacheInterface
     /** @param iterable<string, mixed> $values */
     public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
+        $expired    = $this->isExpiredTtl($ttl);
         $ttlSeconds = $this->normalizeTtl($ttl);
         $success = true;
 
         foreach ($values as $key => $value) {
             $this->validateKey($key);
-            if ($ttlSeconds < 0) {
+            if ($expired) {
                 Cache::del($key);
             } else {
                 if (!Cache::set($key, $value, $ttlSeconds)) {
@@ -96,6 +96,20 @@ class SimpleCacheAdapter implements CacheInterface
                 "Cache key \"{$key}\" contains reserved characters: {}()/\\@:"
             );
         }
+    }
+
+    /**
+     * PSR-16 distinguishes a null TTL ("use default / persist") from an explicit
+     * non-positive TTL ("expire immediately"). normalizeTtl() collapses null to 0,
+     * so we must consult the ORIGINAL $ttl to tell the two apart: null persists,
+     * an explicit 0 / negative / non-positive DateInterval expires now (#187).
+     */
+    private function isExpiredTtl(null|int|\DateInterval $ttl): bool
+    {
+        if ($ttl === null) {
+            return false;
+        }
+        return $this->normalizeTtl($ttl) <= 0;
     }
 
     private function normalizeTtl(null|int|\DateInterval $ttl): int

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -345,14 +345,19 @@ class Response
                 // clamp the start to 0 rather than treating it as unsatisfiable.
                 $suffixLen = (int) $sm[2];
                 if ($suffixLen <= 0) {
-                    return ['status' => 'unsatisfiable', 'ranges' => []];
+                    // Degenerate single spec — skip it; if it's the only spec the
+                    // post-loop empty check emits 416 (#185).
+                    continue;
                 }
                 $ranges[] = [max(0, $total - $suffixLen), $total - 1];
             } elseif ($sm[2] === '') {
                 // Open-end range: bytes=N-
                 $start = (int) $sm[1];
                 if ($start >= $total) {
-                    return ['status' => 'unsatisfiable', 'ranges' => []];
+                    // Out-of-bounds spec — skip it (RFC 7233 §4.4: an unsatisfiable
+                    // spec in a multi-range is ignored, not fatal); 416 only if ALL
+                    // specs are unsatisfiable (post-loop check) (#185).
+                    continue;
                 }
                 $ranges[] = [$start, $total - 1];
             } else {
@@ -360,12 +365,15 @@ class Response
                 $start = (int) $sm[1];
                 $end   = (int) $sm[2];
                 if ($start > $end || $start >= $total) {
-                    return ['status' => 'unsatisfiable', 'ranges' => []];
+                    // Unsatisfiable spec — skip (see the §4.4 note above) (#185).
+                    continue;
                 }
                 $ranges[] = [$start, min($end, $total - 1)];
             }
         }
 
+        // Every spec was unsatisfiable/degenerate → 416 (RFC 7233 §4.4). A
+        // multi-range header keeps its satisfiable specs (the bad ones skipped above).
         if ($ranges === []) {
             return ['status' => 'unsatisfiable', 'ranges' => []];
         }

--- a/src/Middleware/BlockPhpExtMiddleware.php
+++ b/src/Middleware/BlockPhpExtMiddleware.php
@@ -12,7 +12,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Block `.php` Extension Middleware
  *
- * Refuses any request whose path matches `\.php(\?|$)` with a `404`. Useful for
+ * Refuses any request whose path matches `\.php(/|$)` with a `404`. Useful for
  * apps that want extensionless URLs as the only public surface and don't want
  * `/index.php`, `/admin.php`, etc. to be reachable even when a public file
  * exists.
@@ -35,7 +35,9 @@ class BlockPhpExtMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $path = $request->getUri()->getPath();
-        if (preg_match('/\.php($|\?)/i', $path) === 1) {
+        // Match `.php` at the end of ANY path segment, not just the whole path —
+        // otherwise a PATH_INFO suffix (/admin.php/foo) bypasses the block (#184).
+        if (preg_match('#\.php(/|$)#i', $path) === 1) {
             return new Response('Not Found', 404, '', ['Content-Type' => 'text/plain']);
         }
         return $handler->handle($request);

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -110,7 +110,9 @@ class CorsMiddleware implements MiddlewareInterface
             $resp->header('Access-Control-Allow-Methods',     implode(', ', $this->methods));
             $resp->header('Access-Control-Allow-Headers',     implode(', ', $this->headers));
             $resp->header('Access-Control-Max-Age',           (string)$this->maxAge);
-            $resp->header('Access-Control-Allow-Credentials', $this->credentials ? 'true' : 'false');
+            if ($this->credentials && $allowedOrigin !== '*') {
+                $resp->header('Access-Control-Allow-Credentials', 'true');
+            }
             $resp->header('Vary',                             'Origin');
             return new Response('', 204);
         }
@@ -118,7 +120,9 @@ class CorsMiddleware implements MiddlewareInterface
         $response = $handler->handle($request);
 
         $resp->header('Access-Control-Allow-Origin',      $allowedOrigin);
-        $resp->header('Access-Control-Allow-Credentials', $this->credentials ? 'true' : 'false');
+        if ($this->credentials && $allowedOrigin !== '*') {
+            $resp->header('Access-Control-Allow-Credentials', 'true');
+        }
         $resp->header('Vary',                             'Origin');
 
         return $response;
@@ -127,8 +131,12 @@ class CorsMiddleware implements MiddlewareInterface
     private function resolveOrigin(string $requestOrigin): string
     {
         if (in_array('*', $this->origins, true)) {
-            // credentials=true requires explicit origin, not wildcard
-            return ($this->credentials && $requestOrigin !== '') ? $requestOrigin : '*';
+            // A wildcard config has no real allowlist to reflect against; echoing
+            // the request Origin back under credentials=true is the canonical
+            // credentialed-CORS bypass (issue #180). Always emit literal '*' —
+            // process() omits Access-Control-Allow-Credentials when the effective
+            // origin is '*', so browsers fail safe (they reject '*' + credentials).
+            return '*';
         }
         return in_array($requestOrigin, $this->origins, true) ? $requestOrigin : $this->origins[0];
     }

--- a/src/Middleware/RangeMiddleware.php
+++ b/src/Middleware/RangeMiddleware.php
@@ -176,10 +176,14 @@ class RangeMiddleware implements MiddlewareInterface
                     break;
                 }
                 $suffixLen = (int) $tail;
-                if ($suffixLen <= 0 || $suffixLen > $total) {
-                    return $this->unsatisfiable($total, $g);
+                if ($suffixLen <= 0) {
+                    // Degenerate (bytes=-0) — skip; 416 only if it's the sole spec
+                    // (the empty-$ranges check below) (#181/#185).
+                    continue;
                 }
-                $ranges[] = [$total - $suffixLen, $total - 1];
+                // A suffix longer than the file means "the whole representation"
+                // (RFC 7233 §2.1) — clamp the start to 0, don't 416 (#181).
+                $ranges[] = [max(0, $total - $suffixLen), $total - 1];
             } elseif (str_ends_with($spec, '-')) {
                 // Open-end range: bytes=N-
                 $startStr = substr($spec, 0, -1);
@@ -189,7 +193,9 @@ class RangeMiddleware implements MiddlewareInterface
                 }
                 $start = (int) $startStr;
                 if ($start >= $total) {
-                    return $this->unsatisfiable($total, $g);
+                    // Unsatisfiable spec — skip (RFC 7233 §4.4); 416 only if ALL
+                    // specs are unsatisfiable (the empty-$ranges check below) (#185).
+                    continue;
                 }
                 $ranges[] = [$start, $total - 1];
             } elseif (str_contains($spec, '-')) {
@@ -203,7 +209,8 @@ class RangeMiddleware implements MiddlewareInterface
                 $start = (int) $startStr;
                 $end   = (int) $endStr;
                 if ($start > $end || $start >= $total) {
-                    return $this->unsatisfiable($total, $g);
+                    // Unsatisfiable spec — skip (see the §4.4 note above) (#185).
+                    continue;
                 }
                 $end = min($end, $total - 1);
                 $ranges[] = [$start, $end];

--- a/src/Session/Handler/TableSessionHandler.php
+++ b/src/Session/Handler/TableSessionHandler.php
@@ -60,9 +60,11 @@ final class TableSessionHandler implements \SessionHandlerInterface
     private static int $dataSize = 16384;    // 16 KB per session
 
     /**
-     * Per-coroutine read snapshot.
+     * Read snapshot, keyed by coroutine id THEN session id. This is a per-worker
+     * singleton, so keying by coroutine id keeps concurrent requests for the SAME
+     * session id from clobbering each other's base/version snapshot (#182).
      *
-     * @var array<string, array{base: array<mixed,mixed>, version: int}>
+     * @var array<int, array<string, array{base: array<mixed,mixed>, version: int}>>
      */
     private array $context = [];
 
@@ -131,6 +133,10 @@ final class TableSessionHandler implements \SessionHandlerInterface
 
     public function close(): bool
     {
+        // Reclaim this coroutine's read-snapshot bucket at session_write_close
+        // (called per request by CoSessionManager) so it can't grow unbounded on
+        // a long-lived worker (#182).
+        unset($this->context[Coroutine::getCid()]);
         return true;
     }
 
@@ -149,7 +155,7 @@ final class TableSessionHandler implements \SessionHandlerInterface
                 $data = is_string($dRaw) ? $dRaw : '';
                 $vRaw = $row[self::COL_VERSION] ?? 0;
                 $version = is_numeric($vRaw) ? (int) $vRaw : 0;
-                $this->context[$sessionId] = [
+                $this->context[Coroutine::getCid()][$sessionId] = [
                     'base' => $this->decode($data),
                     'version' => $version,
                 ];
@@ -165,7 +171,7 @@ final class TableSessionHandler implements \SessionHandlerInterface
             self::COL_VERSION => 1,
             self::COL_EXPIRES => time() + self::$ttl,
         ]);
-        $this->context[$sessionId] = [
+        $this->context[Coroutine::getCid()][$sessionId] = [
             'base' => $this->decode($data),
             'version' => 1,
         ];
@@ -180,7 +186,7 @@ final class TableSessionHandler implements \SessionHandlerInterface
         $writeLock = $this->writeLock();
 
         /** @var array{base: array<mixed,mixed>, version: int} $ctx */
-        $ctx = $this->context[$sessionId] ?? ['base' => [], 'version' => 0];
+        $ctx = $this->context[Coroutine::getCid()][$sessionId] ?? ['base' => [], 'version' => 0];
         $base = $ctx['base'];
         $expectedVersion = $ctx['version'];
         $local = $this->decode($data);
@@ -219,7 +225,7 @@ final class TableSessionHandler implements \SessionHandlerInterface
                     self::COL_VERSION => $newVersion,
                     self::COL_EXPIRES => time() + self::$ttl,
                 ]);
-                $this->context[$sessionId] = ['base' => $local, 'version' => $newVersion];
+                $this->context[Coroutine::getCid()][$sessionId] = ['base' => $local, 'version' => $newVersion];
 
                 // Write-through to file backing.
                 $this->writeFile($sessionId, $data);
@@ -237,7 +243,7 @@ final class TableSessionHandler implements \SessionHandlerInterface
         $this->table()->del((string) $sessionId);
         $file = self::$savePath . '/sess_' . basename((string) $sessionId);
         if (is_file($file)) @unlink($file);
-        unset($this->context[(string) $sessionId]);
+        unset($this->context[Coroutine::getCid()][(string) $sessionId]);
         return true;
     }
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -912,6 +912,11 @@ function response_add_header($key, $value, $ucwords = true): void
 {
     $g = RequestContext::instance();
     // elog("response_add_header: $key ".var_export($value, true));
+    if ($g->zealphp_response === null) {
+        // No response object in worker-start / tick / CLI / task contexts — a
+        // header has nowhere to go, so no-op instead of a null method call (#195).
+        return;
+    }
     // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any request handler runs
     $g->zealphp_response->header($key, $value, $ucwords);
 }
@@ -976,7 +981,9 @@ function setcookie($name, $value = "", int|array $expire_or_options = 0, $path =
         return false;
     }
     $g = RequestContext::instance();
-    // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any request handler runs
+    if ($g->zealphp_response === null) {
+        return false; // no response object (worker-start/tick/CLI/task) — cookie not sent (#195)
+    }
     $g->zealphp_response->cookie($name, $value, $expire, $path, $domain, $secure, $httponly, $samesite);
     return true;
 }
@@ -1033,7 +1040,9 @@ function setrawcookie($name, $value = "", int|array $expire_or_options = 0, $pat
         $cookie .= "; httponly";
     }
     $g = RequestContext::instance();
-    // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any request handler runs
+    if ($g->zealphp_response === null) {
+        return false; // no response object (worker-start/tick/CLI/task) — cookie not sent (#195)
+    }
     $g->zealphp_response->rawCookie($name, $value, $expire, $path, $domain, $secure, $httponly);
     return true;
 }

--- a/tests/Unit/BlockPhpExtMiddlewareTest.php
+++ b/tests/Unit/BlockPhpExtMiddlewareTest.php
@@ -39,6 +39,22 @@ class BlockPhpExtMiddlewareTest extends TestCase
         $this->assertSame('OK', (string) $response->getBody());
     }
 
+    public function testBlocksPhpWithPathInfoSuffix(): void
+    {
+        // PATH_INFO bypass (#184): `.php` followed by more path segments must
+        // still be blocked, not just `.php` at the very end of the path.
+        $this->assertSame(404, $this->process('/admin.php/foo')->getStatusCode());
+        $this->assertSame(404, $this->process('/admin.php/')->getStatusCode());
+        $this->assertSame(404, $this->process('/a/b.php/c/d')->getStatusCode());
+    }
+
+    public function testPassesPathsWithNoPhpSegment(): void
+    {
+        // Paths that merely CONTAIN "php" (no `.php` segment) pass through.
+        $this->assertSame(200, $this->process('/phpinfo')->getStatusCode());
+        $this->assertSame(200, $this->process('/api/graphql')->getStatusCode());
+    }
+
     private function process(string $path): ResponseInterface
     {
         $middleware = new BlockPhpExtMiddleware();

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -95,6 +95,19 @@ class CacheTest extends TestCase
         $this->assertFileExists($filePath);
     }
 
+    public function testOverwriteSmallWithOversizeEvictsMemoryTier(): void
+    {
+        // #186: a small value lives in the memory tier; overwriting it with a
+        // >8KB value (file tier only) must evict the stale memory row, else get()
+        // (which checks memory before file) returns the OLD small value.
+        Cache::set('grow', 'small');
+        $this->assertSame('small', Cache::get('grow'));
+
+        $big = str_repeat('Z', 9000);
+        Cache::set('grow', $big);
+        $this->assertSame($big, Cache::get('grow'));
+    }
+
     public function testFlushClearsBothTiers(): void
     {
         Cache::set('a', 1);

--- a/tests/Unit/CorsMiddlewareTest.php
+++ b/tests/Unit/CorsMiddlewareTest.php
@@ -272,18 +272,19 @@ class CorsMiddlewareTest extends TestCase
         $this->assertTrue($this->getWarned());
     }
 
-    public function testWildcardWithCredentialsEchoesRequestOrigin(): void
+    public function testWildcardWithCredentialsDoesNotReflectOrigin(): void
     {
         $rec = $this->recorder();
         RequestContext::instance()->zealphp_response = $rec;
 
-        // origins '*' + credentials true -> must echo the request origin,
-        // never literal '*'. Kills LogicalAnd at resolveOrigin().
+        // origins '*' + credentials true must NOT reflect the request Origin
+        // (credentialed-CORS bypass, #180): emit literal '*' and omit the
+        // Access-Control-Allow-Credentials header so browsers fail safe.
         $mw = new CorsMiddleware(origins: ['*'], credentials: true);
         $this->invoke($mw, 'OPTIONS', ['origin' => 'https://caller.example']);
 
-        $this->assertSame('https://caller.example', $rec->sink['Access-Control-Allow-Origin']);
-        $this->assertSame('true', $rec->sink['Access-Control-Allow-Credentials']);
+        $this->assertSame('*', $rec->sink['Access-Control-Allow-Origin']);
+        $this->assertArrayNotHasKey('Access-Control-Allow-Credentials', $rec->sink);
     }
 
     public function testWildcardWithoutCredentialsReturnsStar(): void
@@ -291,13 +292,27 @@ class CorsMiddlewareTest extends TestCase
         $rec = $this->recorder();
         RequestContext::instance()->zealphp_response = $rec;
 
-        // credentials false -> literal '*' regardless of origin. With LogicalOr
-        // mutant ('||') this would echo the origin instead, so this fails it.
+        // credentials false -> literal '*'. No Access-Control-Allow-Credentials
+        // header is emitted when credentials are disabled.
         $mw = new CorsMiddleware(origins: ['*'], credentials: false);
         $this->invoke($mw, 'OPTIONS', ['origin' => 'https://caller.example']);
 
         $this->assertSame('*', $rec->sink['Access-Control-Allow-Origin']);
-        $this->assertSame('false', $rec->sink['Access-Control-Allow-Credentials']);
+        $this->assertArrayNotHasKey('Access-Control-Allow-Credentials', $rec->sink);
+    }
+
+    public function testExplicitAllowlistWithCredentialsReflectsMatchedOrigin(): void
+    {
+        $rec = $this->recorder();
+        RequestContext::instance()->zealphp_response = $rec;
+
+        // The legitimate credentialed-CORS path still works: an explicit allowlist
+        // reflects a MATCHED origin and emits Access-Control-Allow-Credentials:true.
+        $mw = new CorsMiddleware(origins: ['https://app.example'], credentials: true);
+        $this->invoke($mw, 'OPTIONS', ['origin' => 'https://app.example']);
+
+        $this->assertSame('https://app.example', $rec->sink['Access-Control-Allow-Origin']);
+        $this->assertSame('true', $rec->sink['Access-Control-Allow-Credentials']);
     }
 
     public function testNonPreflightAddsCorsHeadersAfterHandler(): void

--- a/tests/Unit/HTTP/ResponseTest.php
+++ b/tests/Unit/HTTP/ResponseTest.php
@@ -773,6 +773,25 @@ class ResponseTest extends TestCase
         $this->assertSame(['status' => 'unsatisfiable', 'ranges' => []], ZResponse::parseRange('bytes=100-', 100));
     }
 
+    public function testParseRangeMultiRangeSkipsUnsatisfiableSpec(): void
+    {
+        // #185: a multi-range header with one out-of-bounds spec keeps the
+        // satisfiable spec(s) instead of 416-ing the whole request (RFC 7233 §4.4).
+        $this->assertSame(
+            ['status' => 'ok', 'ranges' => [[0, 10]]],
+            ZResponse::parseRange('bytes=0-10,9999-10000', 100)
+        );
+    }
+
+    public function testParseRangeMultiRangeAllUnsatisfiable(): void
+    {
+        // Only when EVERY spec is unsatisfiable do we 416 (the post-loop check).
+        $this->assertSame(
+            ['status' => 'unsatisfiable', 'ranges' => []],
+            ZResponse::parseRange('bytes=500-600,9999-10000', 100)
+        );
+    }
+
     public function testParseRangeNonBytesUnitIgnored(): void
     {
         $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('items=0-9', 100));

--- a/tests/Unit/Middleware/CorsMiddlewareTest.php
+++ b/tests/Unit/Middleware/CorsMiddlewareTest.php
@@ -72,7 +72,8 @@ class CorsMiddlewareTest extends TestCase
 
         $this->assertSame(200, $res->getStatusCode());
         $this->assertSame('*', $this->resp->headers['Access-Control-Allow-Origin']);
-        $this->assertSame('false', $this->resp->headers['Access-Control-Allow-Credentials']);
+        // credentials default false -> no Access-Control-Allow-Credentials header.
+        $this->assertArrayNotHasKey('Access-Control-Allow-Credentials', $this->resp->headers);
         $this->assertSame('Origin', $this->resp->headers['Vary']);
     }
 
@@ -92,13 +93,15 @@ class CorsMiddlewareTest extends TestCase
         $this->assertSame('https://a.com', $this->resp->headers['Access-Control-Allow-Origin']);
     }
 
-    public function testWildcardWithCredentialsEchoesRequestOrigin(): void
+    public function testWildcardWithCredentialsDoesNotReflectOrigin(): void
     {
         $mw  = new CorsMiddleware(origins: ['*'], credentials: true);
         $req = (new ServerRequest('/', 'GET'))->withHeader('Origin', 'https://x.com');
         $mw->process($req, $this->okHandler());
-        // credentials=true can't use wildcard — must echo the concrete origin.
-        $this->assertSame('https://x.com', $this->resp->headers['Access-Control-Allow-Origin']);
+        // credentials=true + wildcard must NOT reflect the origin (#180): emit '*'
+        // and omit the credentials header so browsers fail safe.
+        $this->assertSame('*', $this->resp->headers['Access-Control-Allow-Origin']);
+        $this->assertArrayNotHasKey('Access-Control-Allow-Credentials', $this->resp->headers);
     }
 
     public function testEnvOriginsAreParsed(): void

--- a/tests/Unit/RangeMiddlewareTest.php
+++ b/tests/Unit/RangeMiddlewareTest.php
@@ -417,12 +417,25 @@ class RangeMiddlewareTest extends TestCase
         $this->assertSame('bytes */54', $response->getHeaderLine('Content-Range'));
     }
 
-    public function testSuffixLargerThanFileIsUnsatisfiable(): void
+    public function testSuffixLargerThanFileServesWholeBody(): void
     {
-        // bytes=-55 → suffixLen(55) > total(54) → 416. Kills GreaterThan and LogicalOr.
+        // bytes=-55 against a 54-byte body: a suffix longer than the file means
+        // "the whole representation" (RFC 7233 §2.1) — clamp to the full body and
+        // serve 206, not 416 (#181).
         $response = $this->dispatchRange('bytes=-55');
-        $this->assertSame(416, $response->getStatusCode());
-        $this->assertSame('bytes */54', $response->getHeaderLine('Content-Range'));
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertSame('bytes 0-53/54', $response->getHeaderLine('Content-Range'));
+        $this->assertSame(self::BODY, (string) $response->getBody());
+    }
+
+    public function testMultiRangeWithOneUnsatisfiableSpecServesSatisfiable(): void
+    {
+        // A multi-range header with one out-of-bounds spec must serve the
+        // satisfiable spec(s), not 416 the whole request (RFC 7233 §4.4) (#185).
+        $response = $this->dispatchRange('bytes=0-4,9999-10000');
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertSame('Hello', (string) $response->getBody());
+        $this->assertSame('bytes 0-4/54', $response->getHeaderLine('Content-Range'));
     }
 
     public function testEmptyRangeSpecIsUnsatisfiable(): void

--- a/tests/Unit/Session/TableSessionHandlerTest.php
+++ b/tests/Unit/Session/TableSessionHandlerTest.php
@@ -75,6 +75,26 @@ final class TableSessionHandlerTest extends TestCase
         $this->assertTrue(self::$handler->close());
     }
 
+    public function testReadSnapshotIsKeyedByCoroutineAndClearedOnClose(): void
+    {
+        // #182: the read snapshot is keyed by coroutine id THEN session id (so
+        // concurrent same-session requests don't clobber each other), and close()
+        // reclaims this coroutine's bucket so it can't grow unbounded.
+        $sid = $this->sid('snap');
+        self::$handler->write($sid, 'v|i:1;');
+        self::$handler->read($sid); // populates context[cid][sid]
+
+        $ref = new \ReflectionProperty(self::$handler, 'context');
+        $ref->setAccessible(true);
+        $cid = \OpenSwoole\Coroutine::getCid();
+        $ctx = $ref->getValue(self::$handler);
+        $this->assertArrayHasKey($cid, $ctx);
+        $this->assertArrayHasKey($sid, $ctx[$cid]);
+
+        $this->assertTrue(self::$handler->close());
+        $this->assertArrayNotHasKey($cid, $ref->getValue(self::$handler), 'close() clears the coroutine bucket');
+    }
+
     // ── read / write round-trip ───────────────────────────────────────────
 
     public function testWriteThenReadRoundTrip(): void

--- a/tests/Unit/SimpleCacheAdapterTest.php
+++ b/tests/Unit/SimpleCacheAdapterTest.php
@@ -138,6 +138,37 @@ class SimpleCacheAdapterTest extends TestCase
         $this->assertFalse($this->adapter->has('alive'));
     }
 
+    public function testZeroTtlExpiresImmediately(): void
+    {
+        // PSR-16: an explicit TTL of 0 expires the item immediately (#187).
+        $this->adapter->set('zero', 'gone', 0);
+        $this->assertFalse($this->adapter->has('zero'));
+        $this->assertNull($this->adapter->get('zero'));
+    }
+
+    public function testNullTtlPersists(): void
+    {
+        // PSR-16: a null TTL means "use default / persist", NOT expire (#187) —
+        // normalizeTtl(null) collapses to 0, so this must NOT be treated as 0-ttl.
+        $this->adapter->set('persist', 'kept', null);
+        $this->assertTrue($this->adapter->has('persist'));
+        $this->assertSame('kept', $this->adapter->get('persist'));
+    }
+
+    public function testSetMultipleZeroTtlExpiresAll(): void
+    {
+        $this->adapter->setMultiple(['mz_a' => 1, 'mz_b' => 2], 0);
+        $this->assertFalse($this->adapter->has('mz_a'));
+        $this->assertFalse($this->adapter->has('mz_b'));
+    }
+
+    public function testSetMultipleNullTtlPersists(): void
+    {
+        $this->adapter->setMultiple(['mn_c' => 3, 'mn_d' => 4], null);
+        $this->assertSame(3, $this->adapter->get('mn_c'));
+        $this->assertSame(4, $this->adapter->get('mn_d'));
+    }
+
     public function testInvalidKeyThrows(): void
     {
         $this->expectException(InvalidCacheKeyException::class);

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -145,6 +145,22 @@ class UtilsTest extends TestCase
         $this->assertContains(['X-Foo', 'bar'], $list);
     }
 
+    public function testResponseShimsNoOpWhenNoResponseObject(): void
+    {
+        // worker-start / tick / CLI / task contexts have no response object;
+        // the shims must no-op instead of a null method call (#195).
+        $g = RequestContext::instance();
+        $g->zealphp_response = null;
+        try {
+            response_add_header('X-Null', 'v'); // void — must not throw on null response
+            $this->assertFalse(setcookie('c', 'v'), 'setcookie returns false with no response');
+            $this->assertFalse(setrawcookie('rc', 'v'), 'setrawcookie returns false with no response');
+        } finally {
+            // Restore so the rest of the suite (shared singleton) keeps its recorder.
+            $g->zealphp_response = $this->resp;
+        }
+    }
+
     public function testResponseSetStatus(): void
     {
         response_set_status(418);


### PR DESCRIPTION
Fixes the 8 confirmed bugs from the 2026-06-03 issue triage. Each was verified against current master (several reports cited older versions / wrong line counts) and is pinned with a regression test. PHPStan level 10 clean on all touched files; full Unit suite green (the only remaining failures are the pre-existing `SessionStartMiddlewareTest` uopz-not-loaded errors, environmental).

| # | Sev | Fix |
|---|-----|-----|
| **#180** | high (security) | `CorsMiddleware` no longer reflects the request `Origin` under `origins:['*'] + credentials:true` (credentialed-CORS bypass). Wildcard branch returns `*`; `Access-Control-Allow-Credentials` only when the origin is a concrete allowlisted value. Explicit-allowlist credentialed CORS still works (new test). |
| **#182** | high | `TableSessionHandler` read-snapshot is keyed by **coroutine id then session id** so concurrent same-session requests don't clobber each other; `close()` reclaims the bucket. |
| **#186** | high | `Cache::set` evicts the stale memory-tier row when overwriting a key with a >8KB value (file tier only) — `get()` checks memory before file. |
| **#181 / #185** | med | `RangeMiddleware` + `Response::parseRange`: a multi-range header with one unsatisfiable spec serves the satisfiable spec(s) (RFC 7233 §4.4); an over-long suffix clamps to the whole body (§2.1) instead of 416. |
| **#184** | med | `BlockPhpExtMiddleware` blocks `.php` at the end of any path **segment** (`#\.php(/\|$)#i`) — closes the `/admin.php/foo` PATH_INFO bypass. |
| **#187** | med | `SimpleCacheAdapter` distinguishes a null TTL (persist) from an explicit `0` (expire now) via `isExpiredTtl()`. |
| **#195** | med | `response_add_header()` / `setcookie()` / `setrawcookie()` null-guard `$g->zealphp_response` (no-op in worker-start/tick/CLI/task instead of a null method call). |

Notes on the verifier's flags from triage: #180 needed **4** test updates (not the 2 the report claimed) — all done; #185's scope also covered `RangeMiddleware`'s own parser (fixed for consistency); #195 keeps the `header()` `@phpstan-ignore` (property is `mixed`) and drops the now-unmatched cookie ones.

**#194** is not reproducible (`REST::response()` does not throw `HaltException`) — closed separately. **zealphp-mongodb #3** is handled in that repo by its maintainer.

Closes #180, #181, #182, #184, #185, #186, #187, #195.
