### PR TITLE
fix(store/counter): 64-bit counters (HIGH), Redis pool poison-pill, Tiered L1 truncation

### DIFF
--- a/src/Counter.php
+++ b/src/Counter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ZealPHP;
 
-use OpenSwoole\Atomic;
+use OpenSwoole\Atomic\Long as Atomic;
 use ZealPHP\Counter\AtomicBackend;
 use ZealPHP\Counter\CounterBackend;
 use ZealPHP\Counter\CounterBackendKind;
@@ -167,15 +167,19 @@ class Counter
     }
 
     /**
-     * Return the raw `OpenSwoole\Atomic`. Only available on the atomic
-     * backend; throws on the redis backend (no Atomic equivalent there).
+     * Return the raw `OpenSwoole\Atomic\Long` (64-bit signed). Only available on
+     * the atomic backend; throws on the redis backend (no atomic equivalent there).
+     *
+     * NOTE: as of the 64-bit-counter fix this returns `OpenSwoole\Atomic\Long`, not
+     * the 32-bit `OpenSwoole\Atomic` it returned previously — so counters no longer
+     * silently wrap at 2^32.
      */
     public function raw(): Atomic
     {
         $b = self::defaultBackend();
         if (!($b instanceof AtomicBackend)) {
             throw new StoreException(
-                "Counter::raw() returns OpenSwoole\\Atomic — only available on the 'atomic' backend (current: " . self::$backendConfig['kind'] . ")"
+                "Counter::raw() returns OpenSwoole\\Atomic\\Long — only available on the 'atomic' backend (current: " . self::$backendConfig['kind'] . ")"
             );
         }
         return $b->atomicFor($this->name);

--- a/src/Counter/AtomicBackend.php
+++ b/src/Counter/AtomicBackend.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace ZealPHP\Counter;
 
-use OpenSwoole\Atomic;
+use OpenSwoole\Atomic\Long as Atomic;
 
 /**
- * Default CounterBackend — wraps OpenSwoole\Atomic.
+ * Default CounterBackend — wraps OpenSwoole\Atomic\Long (a 64-bit SIGNED atomic).
  *
- * Each named counter gets a process-shared Atomic; the map must be
- * populated BEFORE workers fork (the shared memory segment is inherited).
- * Lock-free reads, CAS-based compareAndSet.
+ * Each named counter gets a process-shared atomic; the map must be populated
+ * BEFORE workers fork (the shared memory segment is inherited). Lock-free reads,
+ * CAS-based compareAndSet. Uses the 64-bit `Long` variant rather than the 32-bit
+ * unsigned `OpenSwoole\Atomic` so a busy long-lived counter (a global request
+ * counter, etc.) can't silently wrap at 2^32 — its range is the full signed
+ * 64-bit space.
  */
 final class AtomicBackend implements CounterBackend
 {

--- a/src/Store/RedisConnectionPool.php
+++ b/src/Store/RedisConnectionPool.php
@@ -104,8 +104,42 @@ final class RedisConnectionPool
     public function with(callable $fn): mixed
     {
         $c = $this->acquire();
-        try { return $fn($c); }
-        finally { $this->release($c); }
+        try {
+            $result = $fn($c);
+        } catch (\Throwable $e) {
+            // The op threw — likely a connection/protocol error, so the client may
+            // have a dead socket or a half-consumed RESP frame. Returning it to the
+            // pool would poison every future borrower (the pre-existing bug: a dead
+            // connection was re-pooled and reused forever). Discard it and refill
+            // the pool with a fresh client so capacity is preserved, then re-throw.
+            $this->discard($c);
+            throw $e;
+        }
+        $this->release($c);
+        return $result;
+    }
+
+    /**
+     * Drop a (possibly broken) client instead of returning it to the pool, and
+     * refill the pool with a fresh connection so capacity is preserved. The
+     * sync-mode singleton is just nulled so acquire() lazily rebuilds it.
+     */
+    private function discard(RedisClient $client): void
+    {
+        try { $client->close(); } catch (\Throwable) { /* already dead */ }
+        if ($this->syncClient !== null && $client === $this->syncClient) {
+            $this->syncClient = null;
+            return;
+        }
+        if ($this->ch === null) { return; }
+        try {
+            $this->ch->push(new RedisClient($this->url, $this->opts));
+            $this->stats->inc('pool_clients_created_total');
+        } catch (\Throwable) {
+            // Couldn't reconnect right now; the pool runs one short until a future
+            // acquire times out and a fresh client is built — still better than
+            // pushing a known-dead client back.
+        }
     }
 
     /** Return the configured pool capacity. */

--- a/src/Store/TieredBackend.php
+++ b/src/Store/TieredBackend.php
@@ -230,7 +230,13 @@ final class TieredBackend implements StoreBackend
     {
         $ok = $this->l2->set($name, $key, $row);
         if ($ok) {
-            $this->l1->set($name, $key, $row + [self::CACHED_AT => time()]);
+            // If the L1 (Table) write fails — e.g. the row exceeds the L1 column
+            // size or the table is full — do NOT leave a partial/stale entry that
+            // get() would serve as authoritative within the TTL window. Evict it so
+            // reads fall through to L2 (the source of truth).
+            if (!$this->l1->set($name, $key, $row + [self::CACHED_AT => time()])) {
+                $this->l1->del($name, $key);
+            }
             $this->publishInvalidation($name, $key);
         }
         return $ok;
@@ -258,7 +264,12 @@ final class TieredBackend implements StoreBackend
         // L1 miss or stale — fetch from L2, repopulate L1.
         $l2Row = $this->l2->get($name, $key);
         if (is_array($l2Row)) {
-            $this->l1->set($name, $key, self::scalarRow($l2Row) + [self::CACHED_AT => $now]);
+            // Don't cache a truncated/partial copy in L1 (see set()): evict on a
+            // failed L1 write so the next read re-fetches L2 instead of serving a
+            // corrupt L1 entry.
+            if (!$this->l1->set($name, $key, self::scalarRow($l2Row) + [self::CACHED_AT => $now])) {
+                $this->l1->del($name, $key);
+            }
             return $field !== null ? ($l2Row[$field] ?? null) : $l2Row;
         }
         return $field !== null ? null : $l2Row;

--- a/tests/Unit/CounterFacadeParityTest.php
+++ b/tests/Unit/CounterFacadeParityTest.php
@@ -33,7 +33,9 @@ final class CounterFacadeParityTest extends TestCase
     {
         Counter::defaultBackend('atomic');
         $c = new Counter(7);
-        $this->assertInstanceOf(\OpenSwoole\Atomic::class, $c->raw());
+        // raw() returns the 64-bit OpenSwoole\Atomic\Long (was OpenSwoole\Atomic
+        // pre-overflow-fix) so counters can't silently wrap at 2^32.
+        $this->assertInstanceOf(\OpenSwoole\Atomic\Long::class, $c->raw());
         $this->assertSame(7, $c->raw()->get());
     }
 

--- a/tests/Unit/CounterTest.php
+++ b/tests/Unit/CounterTest.php
@@ -79,8 +79,23 @@ class CounterTest extends TestCase
 
     public function testRaw(): void
     {
+        // raw() now returns the 64-bit OpenSwoole\Atomic\Long (was the 32-bit
+        // OpenSwoole\Atomic) so counters can't silently wrap at 2^32.
         $c = new Counter(7);
-        $this->assertInstanceOf(\OpenSwoole\Atomic::class, $c->raw());
+        $this->assertInstanceOf(\OpenSwoole\Atomic\Long::class, $c->raw());
+    }
+
+    public function testCounterDoesNotWrapPast32Bit(): void
+    {
+        // Regression: the Atomic backend used the 32-bit unsigned OpenSwoole\Atomic,
+        // so a value/increment past 2^32 silently wrapped (corrupting e.g. a global
+        // request counter on a busy long-lived server). The 64-bit Atomic\Long
+        // backend holds the full value.
+        $c = new Counter(0, 'overflow_test_' . bin2hex(random_bytes(4)));
+        $big = 5_000_000_000; // > 2^32 (4_294_967_296)
+        $c->set($big);
+        $this->assertSame($big, $c->get(), 'value past 2^32 must not wrap');
+        $this->assertSame($big + 1, $c->increment(), 'increment past 2^32 must not wrap');
     }
 
     public function testChainedIncrements(): void


### PR DESCRIPTION
Batch 3. Three confirmed store/counter bugs:

- **Counter wrapped at 2³² (HIGH)** — AtomicBackend used the 32-bit unsigned `OpenSwoole\Atomic`; a value/increment past 4.29B silently wrapped (corrupting e.g. a global request counter). Switched to 64-bit `OpenSwoole\Atomic\Long`. ⚠️ `Counter::raw()` now returns `Atomic\Long` (low-level escape hatch; documented). Regression test with 5e9.
- **Redis pool poison-pill (MEDIUM)** — `with()` re-pooled a client even when the op threw, poisoning every future borrower with a dead socket / half-RESP frame. Now discards + refills with a fresh connection on throw.
- **Tiered L1 truncation (MEDIUM)** — set()/get() ignored the L1 write result, serving a truncated copy as authoritative within the TTL window. Now evicts L1 on a failed write so reads fall through to L2.

Remaining store LOWs (incrBounded contract, RedisBackend membership Lua-atomicity, CircuitBreaker single-Atomic) tracked for a follow-up. PHPStan L10 clean.