### PR TITLE
fix(ws): release() leaves rooms, stale-GC reaps every row, leave evicts cache

### DIFF
--- a/src/WS/Room.php
+++ b/src/WS/Room.php
@@ -82,6 +82,10 @@ final class Room
             try { Store::sadd(WSRouter::roomMembersSetKey($this->name), $clientId); }
             catch (StoreException) { /* keep join — metadata is authoritative */ }
         }
+        // Track the join in this worker's reverse index so WSRouter::release()
+        // (ws onClose) can leave the room on an abnormal disconnect. No-op for
+        // clients this worker doesn't own.
+        WSRouter::noteLocalRoomJoin($clientId, $this->name);
         WSRouter::stats()->inc('room_joins_total');
         $this->publish([
             'type'      => 'join',
@@ -102,6 +106,7 @@ final class Room
             try { Store::srem(WSRouter::roomMembersSetKey($this->name), $clientId); }
             catch (StoreException) { /* metadata table already removed */ }
         }
+        WSRouter::noteLocalRoomLeave($clientId, $this->name);
         WSRouter::stats()->inc('room_leaves_total');
         $this->publish([
             'type'      => 'leave',

--- a/src/WSRouter.php
+++ b/src/WSRouter.php
@@ -154,6 +154,17 @@ final class WSRouter
     private static array $localRoomMembership = [];
 
     /**
+     * Per-worker reverse index: which rooms each LOCALLY-OWNED client has
+     * joined. Lets `release()` (ws onClose) leave every room a client was
+     * in, so an abnormal disconnect doesn't leak `ws_room_members` rows /
+     * per-room SET entries until the whole server is GC'd.
+     * `client_id → [room => true]`
+     *
+     * @var array<string, array<string, true>>
+     */
+    private static array $localClientRooms = [];
+
+    /**
      * User-registered message handlers per room. Each callable receives
      * `(array $msg, string $room)`.
      *
@@ -570,6 +581,31 @@ final class WSRouter
     /** Clean up when a client disconnects (call from ws onClose). */
     public static function release(string $clientId): void
     {
+        // Leave every room this client joined on this worker BEFORE we drop
+        // the local maps. Otherwise an abnormal disconnect (onClose without
+        // an explicit Room::leave) leaks the cluster-wide ws_room_members
+        // rows + per-room SET entries until the whole SERVER is GC'd, and
+        // leaves the per-worker $localRoomMembership cache pointing at a dead
+        // fd. $rooms is a value-copy, so Room::leave() mutating the static
+        // mid-loop is safe.
+        $rooms = self::$localClientRooms[$clientId] ?? [];
+        foreach (array_keys($rooms) as $room) {
+            try {
+                self::room($room)->leave($clientId);
+            } catch (\Throwable $e) {
+                error_log("WSRouter::release leave({$room}, {$clientId}): " . $e->getMessage());
+            }
+            // Evict the local-membership cache directly: the leave presence
+            // event we just published may not round-trip back to this worker
+            // before the localFds unset below, and the leave handler is the
+            // one that would otherwise clear it.
+            unset(self::$localRoomMembership[$room][$clientId]);
+            if (isset(self::$localRoomMembership[$room]) && self::$localRoomMembership[$room] === []) {
+                unset(self::$localRoomMembership[$room]);
+            }
+        }
+        unset(self::$localClientRooms[$clientId]);
+
         unset(self::$localFds[$clientId]);
         Store::del(self::TABLE, $clientId);
         self::stats()->inc('releases_total');
@@ -644,6 +680,7 @@ final class WSRouter
         self::$clientSink          = null;
         self::$initialized         = false;
         self::$localRoomMembership = [];
+        self::$localClientRooms    = [];
         self::$roomMessageHandlers = [];
         self::$roomPresenceHandlers= [];
     }
@@ -665,6 +702,36 @@ final class WSRouter
         }
         return new Room($name, self::$serverId);
     }
+
+    /**
+     * @internal — record that a locally-owned client joined a room, so
+     * `release()` can leave it on disconnect. No-op for clients this worker
+     * doesn't own (the owning worker tracks + cleans those up). Called by
+     * `Room::join()`.
+     */
+    public static function noteLocalRoomJoin(string $clientId, string $room): void
+    {
+        if (!isset(self::$localFds[$clientId])) { return; }
+        self::$localClientRooms[$clientId][$room] = true;
+    }
+
+    /**
+     * @internal — drop a room from a client's local reverse index. Called by
+     * `Room::leave()` (and indirectly by `release()` via the leave path).
+     */
+    public static function noteLocalRoomLeave(string $clientId, string $room): void
+    {
+        unset(self::$localClientRooms[$clientId][$room]);
+        if (isset(self::$localClientRooms[$clientId]) && self::$localClientRooms[$clientId] === []) {
+            unset(self::$localClientRooms[$clientId]);
+        }
+    }
+
+    /**
+     * @internal — current local client→rooms reverse index (for tests + debug).
+     * @return array<string, array<string, true>>
+     */
+    public static function localClientRooms(): array { return self::$localClientRooms; }
 
     /**
      * Total connected clients across the cluster.
@@ -785,10 +852,18 @@ final class WSRouter
 
         if ($type === 'join' || $type === 'leave') {
             $cid = is_string($msg['client_id'] ?? null) ? $msg['client_id'] : '';
-            if ($cid !== '' && isset(self::$localFds[$cid])) {
+            if ($cid !== '') {
                 if ($type === 'join') {
-                    self::$localRoomMembership[$roomName][$cid] = true;
+                    // Only cache clients THIS worker owns (they're the push
+                    // targets); a join for a remote client isn't ours to hold.
+                    if (isset(self::$localFds[$cid])) {
+                        self::$localRoomMembership[$roomName][$cid] = true;
+                    }
                 } else {
+                    // Always evict on leave — unsetting a non-member is a
+                    // harmless no-op, and gating this on $localFds would leak
+                    // the cache entry once release() has already cleared the
+                    // fd (the disconnect path that needs the eviction most).
                     unset(self::$localRoomMembership[$roomName][$cid]);
                     if (isset(self::$localRoomMembership[$roomName]) && self::$localRoomMembership[$roomName] === []) {
                         unset(self::$localRoomMembership[$roomName]);
@@ -926,19 +1001,25 @@ final class WSRouter
         }
         if ($dead === []) { return 0; }
         $reaped = 0;
-        // Drop dependent rows in ws_owner + ws_room_members.
+        // Collect-then-delete: deleting from an OpenSwoole\Table WHILE
+        // iterating it advances the internal cursor into a freed slot and
+        // silently skips ~28% of the remaining rows, so dead-server rows
+        // would survive the sweep. Materialize the hit list first, then
+        // delete after each iterator has fully drained.
+        $ownerDel = [];
         foreach (Store::iterate(self::TABLE) as $clientId => $row) {
             if (in_array((string) ($row['server_id'] ?? ''), $dead, true)) {
-                Store::del(self::TABLE, (string) $clientId);
-                $reaped++;
+                $ownerDel[] = (string) $clientId;
             }
         }
+        $roomDel = [];
         foreach (Store::iterate(self::ROOM_TABLE) as $key => $row) {
             if (in_array((string) ($row['server_id'] ?? ''), $dead, true)) {
-                Store::del(self::ROOM_TABLE, (string) $key);
-                $reaped++;
+                $roomDel[] = (string) $key;
             }
         }
+        foreach ($ownerDel as $clientId) { Store::del(self::TABLE, $clientId); $reaped++; }
+        foreach ($roomDel as $key)       { Store::del(self::ROOM_TABLE, $key);  $reaped++; }
         // Drop the server-registry rows themselves last.
         foreach ($dead as $serverId) {
             Store::del(self::SERVERS_TABLE, $serverId);
@@ -954,18 +1035,22 @@ final class WSRouter
     {
         if (self::$serverId === '') { return 0; }
         $reaped = 0;
+        // Collect-then-delete — see runStaleServerGC: deleting mid-iteration
+        // on the Table backend skips rows, leaving our own footprint behind.
+        $ownerDel = [];
         foreach (Store::iterate(self::TABLE) as $clientId => $row) {
             if (($row['server_id'] ?? '') === self::$serverId) {
-                Store::del(self::TABLE, (string) $clientId);
-                $reaped++;
+                $ownerDel[] = (string) $clientId;
             }
         }
+        $roomDel = [];
         foreach (Store::iterate(self::ROOM_TABLE) as $key => $row) {
             if (($row['server_id'] ?? '') === self::$serverId) {
-                Store::del(self::ROOM_TABLE, (string) $key);
-                $reaped++;
+                $roomDel[] = (string) $key;
             }
         }
+        foreach ($ownerDel as $clientId) { Store::del(self::TABLE, $clientId); $reaped++; }
+        foreach ($roomDel as $key)       { Store::del(self::ROOM_TABLE, $key);  $reaped++; }
         Store::del(self::SERVERS_TABLE, self::$serverId);
         return $reaped;
     }

--- a/tests/Unit/WS/RoomTest.php
+++ b/tests/Unit/WS/RoomTest.php
@@ -226,6 +226,60 @@ final class RoomTest extends TestCase
         });
     }
 
+    public function testReleaseLeavesEveryJoinedRoom(): void
+    {
+        // The membership-leak fix: an abnormal disconnect (ws onClose →
+        // WSRouter::release) must leave every room the client joined, so its
+        // ws_room_members rows + local caches don't linger until the whole
+        // server is GC'd.
+        Coroutine::run(function (): void {
+            $alpha = "alpha-" . bin2hex(random_bytes(3));
+            $beta  = "beta-"  . bin2hex(random_bytes(3));
+            WSRouter::init('test-server');
+            WSRouter::own('alice', 42);
+
+            $ra = WSRouter::room($alpha);
+            $rb = WSRouter::room($beta);
+            $ra->join('alice');
+            $rb->join('alice');
+
+            // Tracked in the per-worker reverse index (both rooms).
+            $tracked = WSRouter::localClientRooms();
+            self::assertArrayHasKey('alice', $tracked);
+            self::assertCount(2, $tracked['alice']);
+            self::assertTrue($ra->isMember('alice'));
+            self::assertTrue($rb->isMember('alice'));
+
+            WSRouter::release('alice');
+
+            // Cluster membership dropped in BOTH rooms.
+            self::assertFalse($ra->isMember('alice'), 'left alpha on release');
+            self::assertFalse($rb->isMember('alice'), 'left beta on release');
+            self::assertSame(0, $ra->size());
+            self::assertSame(0, $rb->size());
+            // Per-worker caches fully torn down — no dangling fd references.
+            self::assertArrayNotHasKey('alice', WSRouter::localClientRooms());
+            self::assertSame([], WSRouter::localRoomMembership());
+            self::assertArrayNotHasKey('alice', WSRouter::localFds());
+        });
+    }
+
+    public function testReleaseWithoutRoomsIsClean(): void
+    {
+        // A client that never joined a room still releases cleanly (no rooms
+        // tracked → the leave loop is a no-op, owner row + fd dropped).
+        Coroutine::run(function (): void {
+            WSRouter::init('test-server');
+            WSRouter::own('bob', 7);
+            self::assertArrayHasKey('bob', WSRouter::localFds());
+
+            WSRouter::release('bob');
+
+            self::assertArrayNotHasKey('bob', WSRouter::localFds());
+            self::assertSame([], WSRouter::localClientRooms());
+        });
+    }
+
     private function skipIfNoRedis(): void
     {
         try {

--- a/tests/Unit/WS/WsRouterGcTest.php
+++ b/tests/Unit/WS/WsRouterGcTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\WS;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\Store;
+use ZealPHP\WSRouter;
+
+/**
+ * WSRouter::runStaleServerGC() — dead-server reaping correctness.
+ *
+ * These run on the Table backend (no Redis needed): the GC functions
+ * operate directly on the ws_owner / ws_room_members / ws_servers Store
+ * tables, so the reaping logic is exercisable in-process.
+ *
+ * The bug under test: the GC used to `Store::del()` rows WHILE iterating
+ * the live OpenSwoole\Table. Deleting during iteration advances the
+ * internal cursor into a freed slot and silently skips a chunk of the
+ * remaining rows — so dead-server rows survived the sweep. The fix
+ * collects the hit list first, then deletes after the iterator drains.
+ */
+final class WsRouterGcTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Store::defaultBackend(Store::BACKEND_TABLE);
+        // Allocate the three tables WSRouter::init() would, with matching
+        // schemas, then clear any rows a prior test left behind.
+        Store::make(WSRouter::ownerTable(), 8192, [
+            'server_id' => [Store::TYPE_STRING, 192],
+            'conn_id'   => [Store::TYPE_STRING, 32],
+        ]);
+        Store::make(WSRouter::roomTable(), 8192, [
+            'room'      => [Store::TYPE_STRING, 64],
+            'client_id' => [Store::TYPE_STRING, 128],
+            'server_id' => [Store::TYPE_STRING, 192],
+            'joined_at' => [Store::TYPE_INT, 8],
+        ]);
+        Store::make(WSRouter::serverTable(), 256, [
+            'last_seen' => [Store::TYPE_INT, 8],
+            'host'      => [Store::TYPE_STRING, 128],
+            'pid'       => [Store::TYPE_INT, 8],
+        ]);
+        Store::clear(WSRouter::ownerTable());
+        Store::clear(WSRouter::roomTable());
+        Store::clear(WSRouter::serverTable());
+    }
+
+    protected function tearDown(): void
+    {
+        Store::clear(WSRouter::ownerTable());
+        Store::clear(WSRouter::roomTable());
+        Store::clear(WSRouter::serverTable());
+    }
+
+    public function testGcReapsEveryDeadServerRowDespiteIteration(): void
+    {
+        $now  = time();
+        $dead = 'dead-server';
+        $live = 'live-server';
+
+        // One stale registry row (older than the 90s threshold) + one fresh.
+        Store::set(WSRouter::serverTable(), $dead, ['last_seen' => $now - 1000, 'host' => 'h', 'pid' => 1]);
+        Store::set(WSRouter::serverTable(), $live, ['last_seen' => $now,        'host' => 'h', 'pid' => 2]);
+
+        // 60 owner rows from the dead server + 10 from the live one. 60 is far
+        // above the ~28% the delete-during-iterate bug would have skipped, so
+        // a regression leaves a clearly-nonzero remnant.
+        for ($i = 0; $i < 60; $i++) {
+            Store::set(WSRouter::ownerTable(), "dead-c$i", ['server_id' => $dead, 'conn_id' => "x$i"]);
+        }
+        for ($i = 0; $i < 10; $i++) {
+            Store::set(WSRouter::ownerTable(), "live-c$i", ['server_id' => $live, 'conn_id' => "y$i"]);
+        }
+        // 40 room rows from the dead server + 5 from the live one.
+        for ($i = 0; $i < 40; $i++) {
+            Store::set(WSRouter::roomTable(), "room:dead-c$i", [
+                'room' => 'room', 'client_id' => "dead-c$i", 'server_id' => $dead, 'joined_at' => $now,
+            ]);
+        }
+        for ($i = 0; $i < 5; $i++) {
+            Store::set(WSRouter::roomTable(), "room:live-c$i", [
+                'room' => 'room', 'client_id' => "live-c$i", 'server_id' => $live, 'joined_at' => $now,
+            ]);
+        }
+
+        $reaped = WSRouter::runStaleServerGC();
+
+        // 60 owner + 40 room = 100 dependent rows reaped, EVERY dead one gone.
+        self::assertSame(100, $reaped, 'all dead-server dependent rows reaped');
+        self::assertSame(10, Store::count(WSRouter::ownerTable()), 'only live owner rows remain');
+        self::assertSame(5, Store::count(WSRouter::roomTable()), 'only live room rows remain');
+        // The dead registry row itself is gone; the live one stays.
+        self::assertFalse(Store::exists(WSRouter::serverTable(), $dead));
+        self::assertTrue(Store::exists(WSRouter::serverTable(), $live));
+
+        // No dead-server rows linger in either dependent table.
+        foreach (Store::iterate(WSRouter::ownerTable()) as $row) {
+            self::assertNotSame($dead, $row['server_id'] ?? null);
+        }
+        foreach (Store::iterate(WSRouter::roomTable()) as $row) {
+            self::assertNotSame($dead, $row['server_id'] ?? null);
+        }
+    }
+
+    public function testGcNoOpWhenAllServersFresh(): void
+    {
+        $now = time();
+        Store::set(WSRouter::serverTable(), 'a', ['last_seen' => $now, 'host' => 'h', 'pid' => 1]);
+        Store::set(WSRouter::ownerTable(), 'c0', ['server_id' => 'a', 'conn_id' => 'z']);
+
+        self::assertSame(0, WSRouter::runStaleServerGC());
+        self::assertSame(1, Store::count(WSRouter::ownerTable()));
+    }
+}


### PR DESCRIPTION
Batch 4 (WebSocket). Three confirmed WSRouter bugs from the critical-infra edge audit:

- **Room membership leak on abnormal close (MEDIUM)** — `release()` (onClose) dropped the fd + `ws_owner` row but never left joined rooms, leaking `ws_room_members` rows + per-room SET entries until the whole server was stale-GC'd. Added a per-worker `$localClientRooms` reverse index (populated by `Room::join` for locally-owned clients); `release()` now leaves every tracked room + clears local caches.
- **`$localRoomMembership` cache leak racing release (MEDIUM)** — the leave branch was gated on `isset($localFds[$cid])`, so once `release()` cleared the fd the leave event couldn't evict the cache. `release()` now evicts directly + the leave handler always evicts.
- **Stale-GC skipped ~28% of rows (MEDIUM, TOCTOU)** — `runStaleServerGC()`/`sweepThisServer()` `Store::del()`'d mid-iteration of the live `OpenSwoole\Table`, advancing the cursor into freed slots. Both now collect-then-delete.

Tests: `WsRouterGcTest` (Table backend, no Redis — proves all 100 dead rows reaped, not ~72%); `RoomTest` +2 (Redis-gated, validated locally against Valkey 8.1.1). PHPStan L10 clean.