### PR TITLE
fix(pubsub/middleware): phpredis psubscribe leak, H7 auto-predis, exit ob-base, psr_request reset

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -4733,18 +4733,34 @@ class App
         } catch (\Throwable $e) {
             $warnings[] = 'Store(H6): Redis backend ping FAILED at boot: ' . $e->getMessage();
         }
-        // H7 — phpredis + HOOK_ALL=0 deadlock guard
+        // H7 — phpredis + HOOK_ALL=0 deadlock guard. wirePubSubBoot() auto-forces
+        // the predis driver for the subscriber runner in this exact condition, so
+        // this is now an advisory (the deadlock is prevented), not a live hazard.
         $hasSubscribers = self::$pubsubRegistry !== [] || self::$reliableRegistry !== [];
-        if ($hasSubscribers && self::hookAll() === 0) {
-            $preferEnv = strtolower((string) getenv('ZEALPHP_REDIS_PREFER'));
-            $willUsePhpredis = $preferEnv === 'phpredis'
-                || (($preferEnv === '' || $preferEnv === 'auto') && extension_loaded('redis'));
-            if ($willUsePhpredis) {
-                $warnings[] = 'Store(H7): phpredis SUBSCRIBE blocks the worker WITHOUT HOOK_ALL — pub/sub will deadlock. ' .
-                    'Either re-enable HOOK_ALL (default in coroutine mode) OR set ZEALPHP_REDIS_PREFER=predis for subscribers.';
-            }
+        if ($hasSubscribers && self::phpredisSubscribeWouldBlock()) {
+            $warnings[] = 'Store(H7): phpredis SUBSCRIBE blocks the worker WITHOUT HOOK_ALL — the pub/sub ' .
+                'runner has been auto-switched to the predis driver (pure-PHP socket, yields without HOOK_ALL). ' .
+                'To run subscribers on phpredis, re-enable HOOK_ALL (default in coroutine mode).';
         }
         return $warnings;
+    }
+
+    /**
+     * H7 detection: would a phpredis SUBSCRIBE/PSUBSCRIBE block the whole worker?
+     *
+     * phpredis's subscribe is a C-level blocking read that is only coroutinized
+     * under `OpenSwoole\Runtime::HOOK_ALL`. With HOOK_ALL off, a subscriber
+     * runner on phpredis would park the worker's single event loop forever.
+     * predis (pure-PHP socket) yields via the stream hooks regardless. Returns
+     * true when the resolved driver is phpredis AND HOOK_ALL is disabled — the
+     * signal for wirePubSubBoot() to force `['prefer' => 'predis']` on the runner.
+     */
+    private static function phpredisSubscribeWouldBlock(): bool
+    {
+        if (self::hookAll() !== 0) { return false; }
+        $preferEnv = strtolower((string) getenv('ZEALPHP_REDIS_PREFER'));
+        return $preferEnv === 'phpredis'
+            || (($preferEnv === '' || $preferEnv === 'auto') && extension_loaded('redis'));
     }
 
     /**
@@ -4767,9 +4783,14 @@ class App
             }
             $url    = $backend->url();
             $prefix = $backend->prefix();
+            // H7: if phpredis would block the worker under HOOK_ALL=0, force the
+            // subscriber runner onto the predis driver (pure-PHP socket yields
+            // regardless of HOOK_ALL) instead of letting it deadlock. The
+            // boot-time advisory in redisBootChecks() reports the auto-switch.
+            $subscriberOpts = self::phpredisSubscribeWouldBlock() ? ['prefer' => 'predis'] : [];
 
             if (self::$pubsubRegistry !== []) {
-                $pubsub = new \ZealPHP\Store\RedisPubSub($url, $prefix);
+                $pubsub = new \ZealPHP\Store\RedisPubSub($url, $prefix, 0, $subscriberOpts);
                 foreach (self::$pubsubRegistry as $channel => $handlers) {
                     foreach ($handlers as $h) { $pubsub->register((string) $channel, $h); }
                 }
@@ -4777,7 +4798,7 @@ class App
                 self::onWorkerStop(function () use ($pubsub) { $pubsub->stop(); });
             }
             if (self::$reliableRegistry !== []) {
-                $streams = new \ZealPHP\Store\RedisStreams($url);
+                $streams = new \ZealPHP\Store\RedisStreams($url, null, $subscriberOpts);
                 foreach (self::$reliableRegistry as $stream => $entries) {
                     foreach ($entries as $entry) {
                         $streams->register((string) $stream, $entry['group'], $entry['handler'], $entry['blockMs'], $entry['batchSize']);

--- a/src/ResponseMiddleware.php
+++ b/src/ResponseMiddleware.php
@@ -58,6 +58,11 @@ class ResponseMiddleware implements MiddlewareInterface
             }
         }
 
+        // Output-buffer baseline: this method opens no buffer of its own, so on
+        // an exit()/ExitException we must only reclaim buffers the HANDLER left
+        // open — draining all the way to level 0 would steal a parent dispatch's
+        // buffer (e.g. an exception-handler ob_start, or a nested render).
+        $obBase = ob_get_level();
         try {
             // Pin request-input superglobals to THIS coroutine's request before
             // the handler reads them (coroutine-legacy overlap defence). No-op
@@ -133,7 +138,7 @@ class ResponseMiddleware implements MiddlewareInterface
             ) {
                 $exitStatus = $e->getStatus();
                 $buffered = '';
-                while (ob_get_level() > 0) {
+                while (ob_get_level() > $obBase) {
                     $buffered = (string)ob_get_clean() . $buffered;
                 }
                 if ($exitStatus === 0 || $exitStatus === null) {

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -211,6 +211,12 @@ class SessionManager
         $g->_streaming               = null;
         $g->ignore_user_abort_state  = 0;
         $g->_session_started         = false;
+        // ResponseMiddleware stashes the canonical PSR-7 request here each
+        // request; on the process-wide singleton (superglobals mode) it would
+        // otherwise pin the previous request's object until the next dispatch
+        // overwrote it. Drop the reference at request end. (Coroutine mode's G
+        // is per-coroutine and freed automatically, so no equivalent is needed.)
+        $g->psr_request              = null;
 
         $sessionId = null;
         if ($manageSession) {

--- a/src/Store/PhpredisDriver.php
+++ b/src/Store/PhpredisDriver.php
@@ -517,15 +517,29 @@ final class PhpredisDriver implements RedisDriver
         // otherwise constant-fold the !== 0 check inside the inner closures.
         $running = new \OpenSwoole\Atomic(1);
 
+        // Each subscribe/psubscribe coroutine parks in a C-level blocking read
+        // that only wakes on a matching message. The stop sentinel is published
+        // to the runner's exact stop channel, so it reaches the SUBSCRIBE cor
+        // (which breaks the main loop) but NOT the PSUBSCRIBE cor — whose
+        // pattern the sentinel doesn't match. Without an explicit teardown that
+        // cor (plus its dedicated Redis connection) would leak on every stop().
+        // We register each cor's client here and force-close them in `finally`:
+        // closing the fd surfaces a RedisException in the parked read, which the
+        // cor catches and exits on. Deterministic — no reliance on a second
+        // message racing the running flag.
+        /** @var array<string, \Redis> $clients */
+        $clients = [];
+
         // Two parallel coroutines, each owning its OWN \Redis client. Sharing
         // $this->c between them would race on the underlying socket — phpredis
         // is not coroutine-safe on a single connection. Each cor connects via
         // self::buildClient() so subscribe + psubscribe own independent sockets.
 
         if ($exactChannels !== []) {
-            go(function () use ($url, $frames, $exactChannels, $running): void {
+            go(function () use ($url, $frames, $exactChannels, $running, &$clients): void {
                 try {
                     $client = self::buildClient($url);
+                    $clients['sub'] = $client;
                     $client->subscribe($exactChannels, function ($_redis, string $channel, string $payload) use ($frames, $running): void {
                         $frames->push(['channel' => $channel, 'payload' => $payload, 'pattern' => null]);
                         if ($running->get() === 0) { throw new PubSubStopException(); }
@@ -535,15 +549,17 @@ final class PhpredisDriver implements RedisDriver
                 } catch (\RedisException) {
                     /* phpredis re-throws the in-callback PubSubStopException as
                        a 'read error on connection' RedisException once the
-                       subscribe socket closes. Same intent as the sentinel —
-                       runner already saw the stop via $running; silently exit. */
+                       subscribe socket closes (also how the finally force-close
+                       below unblocks us). Runner already saw the stop via
+                       $running; silently exit. */
                 }
             });
         }
         if ($patternChannels !== []) {
-            go(function () use ($url, $frames, $patternChannels, $running): void {
+            go(function () use ($url, $frames, $patternChannels, $running, &$clients): void {
                 try {
                     $client = self::buildClient($url);
+                    $clients['psub'] = $client;
                     $client->psubscribe($patternChannels, function ($_redis, string $pattern, string $channel, string $payload) use ($frames, $running): void {
                         $frames->push(['channel' => $channel, 'payload' => $payload, 'pattern' => $pattern]);
                         if ($running->get() === 0) { throw new PubSubStopException(); }
@@ -570,6 +586,14 @@ final class PhpredisDriver implements RedisDriver
             }
         } finally {
             $running->set(0);
+            // Force the parked subscribe/psubscribe coroutines out of their
+            // blocking reads so they release their connections instead of
+            // lingering until the worker exits. Cooperative scheduling means
+            // those cors are parked (not mid-callback) when this runs, so
+            // closing their fds is safe.
+            foreach ($clients as $client) {
+                try { $client->close(); } catch (\Throwable) { /* already gone */ }
+            }
         }
     }
 

--- a/src/Store/RedisPubSub.php
+++ b/src/Store/RedisPubSub.php
@@ -52,11 +52,18 @@ final class RedisPubSub
      *                          when "keep trying forever" isn't acceptable —
      *                          e.g. a CI worker that should fail loudly if its
      *                          Redis disappears.
+     * @param array{prefer?: 'auto'|'phpredis'|'predis'} $opts Driver preference
+     *                          for the runner's connections. Forced to
+     *                          `['prefer' => 'predis']` by App::wirePubSubBoot()
+     *                          when phpredis would block the worker under
+     *                          HOOK_ALL=0 (H7) — predis SUBSCRIBE yields on its
+     *                          pure-PHP socket regardless of HOOK_ALL.
      */
     public function __construct(
         private string $url,
         private string $prefix = 'zealstore',
         private int $maxAttempts = 0,
+        private array $opts = [],
     ) {
         $this->running = new \OpenSwoole\Atomic(0);
         $this->stopChannel = $this->prefix . ':__pubsub_stop:' . bin2hex(random_bytes(4));
@@ -122,7 +129,7 @@ final class RedisPubSub
         if ($this->running->get() === 0) { return; }
         $this->running->set(0);
         try {
-            $signaller = new RedisClient($this->url);
+            $signaller = new RedisClient($this->url, $this->opts);
             $signaller->publish($this->stopChannel, '__stop__');
             $signaller->close();
         } catch (\Throwable) { /* tolerant; runner will see connection drop and exit */ }
@@ -143,7 +150,7 @@ final class RedisPubSub
         $attempt = 0;
         while ($this->running->get() === 1) {
             try {
-                $client = new RedisClient($this->url);
+                $client = new RedisClient($this->url, $this->opts);
                 $exacts = array_merge(array_keys($this->exactHandlers), [$this->stopChannel]);
                 $patterns = array_keys($this->patternHandlers);
                 $attempt = 0;

--- a/src/Store/RedisStreams.php
+++ b/src/Store/RedisStreams.php
@@ -26,7 +26,13 @@ final class RedisStreams
     private \OpenSwoole\Atomic $running;
     private string $consumerName;
 
-    public function __construct(private string $url, ?string $consumerName = null)
+    /**
+     * @param array{prefer?: 'auto'|'phpredis'|'predis'} $opts Driver preference
+     *        for the runner's connections. Forced to `['prefer' => 'predis']`
+     *        by App::wirePubSubBoot() under the H7 phpredis+HOOK_ALL=0 deadlock
+     *        condition (predis blocking reads yield without HOOK_ALL).
+     */
+    public function __construct(private string $url, ?string $consumerName = null, private array $opts = [])
     {
         $this->running = new \OpenSwoole\Atomic(0);
         $this->consumerName = $consumerName ?? (gethostname() . '-' . getmypid());
@@ -77,7 +83,7 @@ final class RedisStreams
             while (!self::atomicIsZero($this->running)) {
                 try {
                     if ($client === null) {
-                        $client = new RedisClient($this->url);
+                        $client = new RedisClient($this->url, $this->opts);
                         $this->ensureGroups($client);
                         $attempt = 0;
                     }
@@ -136,15 +142,16 @@ final class RedisStreams
         $payload = $msg['payload']['payload'] ?? '';
         $payloadFields = $msg['payload'];
         $url = $this->url;
+        $opts = $this->opts;
 
-        go(function () use ($url, $stream, $group, $id, $payload, $payloadFields, $handler): void {
+        go(function () use ($url, $opts, $stream, $group, $id, $payload, $payloadFields, $handler): void {
             // Each dispatch coroutine owns its own client — sharing the
             // runner's read-client would race on the socket (two cors
             // reading/writing one TCP stream interleaves RESP frames).
             try {
                 $ok = $handler($payload, $id, $stream, $payloadFields);
                 if ($ok === true) {
-                    $ackClient = new RedisClient($url);
+                    $ackClient = new RedisClient($url, $opts);
                     try { $ackClient->xack($stream, $group, $id); }
                     finally { $ackClient->close(); }
                 }

--- a/tests/Unit/AppRedisBootChecksTest.php
+++ b/tests/Unit/AppRedisBootChecksTest.php
@@ -72,6 +72,27 @@ final class AppRedisBootChecksTest extends TestCase
         App::hookAll(null);
     }
 
+    public function testH7WarningReportsAutoSwitchNotDeadlock(): void
+    {
+        // The H7 warning used to say pub/sub "will deadlock"; wirePubSubBoot()
+        // now auto-forces the predis driver, so the advisory must describe the
+        // auto-switch (the deadlock is prevented, not impending).
+        if (!extension_loaded('redis')) {
+            self::markTestSkipped('phpredis ext-redis not loaded — H7 condition cannot fire');
+        }
+        App::hookAll(false);
+        Store::defaultBackend(Store::BACKEND_REDIS, 'redis://127.0.0.1:16379/0');
+        App::onPubSub('unit-test:h7-msg', function (): void {});
+
+        $w  = App::redisBootChecks();
+        $h7 = array_values(array_filter($w, fn(string $m): bool => str_contains($m, 'H7')));
+        self::assertNotEmpty($h7);
+        self::assertStringContainsString('auto-switched to the predis driver', $h7[0]);
+        self::assertStringNotContainsString('will deadlock', $h7[0]);
+
+        App::hookAll(null);
+    }
+
     public function testForcedPredisSilencesH7Warning(): void
     {
         App::hookAll(false);


### PR DESCRIPTION
Batch 5 (pub/sub + middleware). Four confirmed bugs from the critical-infra edge audit:

- **phpredis PSUBSCRIBE cor + connection leak on stop() (MEDIUM)** — the driver runs SUBSCRIBE/PSUBSCRIBE in two parked coroutines; the stop sentinel (exact channel) never matches the PSUBSCRIBE patterns, so that cor + its connection leaked on every stop(). Now force-closes both cors' clients in `finally` (parked read errors out → cor exits). Deterministic, no message-delivery race.
- **H7 phpredis+HOOK_ALL=0 deadlock warned then wired anyway (MEDIUM)** — `wirePubSubBoot()` now force-switches the runner to predis (yields without HOOK_ALL) via `App::phpredisSubscribeWouldBlock()` instead of spawning a deadlocking phpredis subscriber. Threaded a driver-preference `$opts` through RedisPubSub + RedisStreams.
- **ExitException drained the entire ob stack (LOW)** — now captures the ob baseline and only reclaims the handler's own buffers (was stealing a parent dispatch's buffer).
- **`$g->psr_request` stash never cleared (LOW)** — pinned the previous request's PSR-7 object on the superglobals-mode singleton; added to SessionManager's per-request reset.

Test: `testH7WarningReportsAutoSwitchNotDeadlock`. PHPStan L10 clean (2 remaining session errors are a local ext 0.3.24 vs 0.3.25 mismatch, green on CI). Validated locally against Valkey 8.1.1.