### PR TITLE
fix(scale): bound RedisStreams XACK connections + plug CoroutineMemorySessionHandler close-leak

### DIFF
--- a/src/Session/Handler/CoroutineMemorySessionHandler.php
+++ b/src/Session/Handler/CoroutineMemorySessionHandler.php
@@ -61,6 +61,12 @@ class CoroutineMemorySessionHandler implements \SessionHandlerInterface
     // Close the session
     public function close(): bool
     {
+        // Drop this coroutine's session bucket so $sessions doesn't accumulate
+        // an entry per distinct (cid, sessionId) over the worker's lifetime.
+        // OpenSwoole reuses cids across requests but close() never pruned them,
+        // so the map only ever grew. Mirrors TableSessionHandler::close()'s
+        // per-cid context teardown.
+        unset($this->sessions[co::getCid()]);
         return true;
     }
 

--- a/src/Store/RedisStreams.php
+++ b/src/Store/RedisStreams.php
@@ -27,6 +27,17 @@ final class RedisStreams
     private string $consumerName;
 
     /**
+     * Small dedicated pool of clients for XACK. Each ACKed message used to
+     * spin up a BRAND-NEW connection (connect + close per message), so a
+     * busy stream opened a TCP connection per delivery — a connection storm
+     * under load. A size-2 pool reuses connections across messages while
+     * still giving each dispatch coroutine a private socket (XACK from two
+     * cors on one socket would interleave RESP frames). Built lazily in the
+     * runner coroutine; closed by stop().
+     */
+    private ?RedisConnectionPool $ackPool = null;
+
+    /**
      * @param array{prefer?: 'auto'|'phpredis'|'predis'} $opts Driver preference
      *        for the runner's connections. Forced to `['prefer' => 'predis']`
      *        by App::wirePubSubBoot() under the H7 phpredis+HOOK_ALL=0 deadlock
@@ -67,6 +78,21 @@ final class RedisStreams
     public function stop(): void
     {
         $this->running->set(0);
+        if ($this->ackPool !== null) {
+            $this->ackPool->close();
+            $this->ackPool = null;
+        }
+    }
+
+    /**
+     * Lazily-built ACK connection pool (size 2). Constructing it is cheap —
+     * the pool only connects on first `acquire()`, which happens inside the
+     * dispatch coroutine. Reused across messages so a busy stream doesn't
+     * connect-per-XACK.
+     */
+    private function ackPool(): RedisConnectionPool
+    {
+        return $this->ackPool ??= new RedisConnectionPool($this->url, 2, $this->opts);
     }
 
     /**
@@ -141,19 +167,18 @@ final class RedisStreams
         // user XADDs raw multi-field shapes, hand the whole map through.
         $payload = $msg['payload']['payload'] ?? '';
         $payloadFields = $msg['payload'];
-        $url = $this->url;
-        $opts = $this->opts;
+        $ackPool = $this->ackPool();
 
-        go(function () use ($url, $opts, $stream, $group, $id, $payload, $payloadFields, $handler): void {
-            // Each dispatch coroutine owns its own client — sharing the
-            // runner's read-client would race on the socket (two cors
-            // reading/writing one TCP stream interleaves RESP frames).
+        go(function () use ($ackPool, $stream, $group, $id, $payload, $payloadFields, $handler): void {
+            // The XACK runs on a pooled client (size-2 pool) rather than a
+            // fresh per-message connection — $pool->with() hands each dispatch
+            // coroutine a private socket from the channel (two cors XACKing on
+            // one socket would interleave RESP frames) and returns it after,
+            // so a busy stream reuses connections instead of connecting per ACK.
             try {
                 $ok = $handler($payload, $id, $stream, $payloadFields);
                 if ($ok === true) {
-                    $ackClient = new RedisClient($url, $opts);
-                    try { $ackClient->xack($stream, $group, $id); }
-                    finally { $ackClient->close(); }
+                    $ackPool->with(fn (RedisClient $c): int => $c->xack($stream, $group, $id));
                 }
             } catch (\Throwable $e) {
                 error_log("RedisStreams handler threw on {$stream}/{$id}: {$e->getMessage()}");

--- a/tests/Unit/CoroutineMemorySessionHandlerTest.php
+++ b/tests/Unit/CoroutineMemorySessionHandlerTest.php
@@ -89,6 +89,20 @@ class CoroutineMemorySessionHandlerTest extends TestCase
         $this->assertTrue($h->close());
     }
 
+    public function testCloseClearsCoroutineBucketSoMapCannotGrowUnbounded(): void
+    {
+        // The leak fix: close() drops this coroutine's session bucket. Before
+        // the fix close() was a no-op, so $sessions accumulated an entry per
+        // distinct (cid, sessionId) over the worker's whole lifetime (cids are
+        // reused, but the map only grew). After close(), the just-written data
+        // is gone — proving the bucket was pruned.
+        $h = new CoroutineMemorySessionHandler();
+        $h->write('rid', 'x|i:1;');
+        $this->assertSame('x|i:1;', $h->read('rid'));
+        $this->assertTrue($h->close());
+        $this->assertSame('', $h->read('rid'), 'close() must clear the coroutine bucket');
+    }
+
     public function testGcRemovesStaleSessions(): void
     {
         $h = new CoroutineMemorySessionHandler();


### PR DESCRIPTION
Batch 6 (contained scale fixes). Two HIGH-severity concerns from the 2026-06-03 scalability audit:

- **RedisStreams connect-per-XACK (HIGH, request-rate)** — every ACKed message did `new RedisClient()` + close, a TCP connect per delivery → connection storm under load. Now uses a lazily-built size-2 `RedisConnectionPool` reused across messages (`with()` still gives each dispatch coroutine a private socket), closed by `stop()`.
- **CoroutineMemorySessionHandler close-leak (HIGH, worker-lifetime)** — `close()` was a no-op, so the cid-keyed `$sessions` map grew an entry per distinct (cid, sessionId) forever (cids reused, never pruned). `close()` now drops the coroutine's bucket (mirrors `TableSessionHandler::close()`). Regression test added.

Remaining audit blockers (DB pool, per-node pub/sub aggregator, WS room targeting, per-session session lock) are architectural features needing a design decision — tracked separately. PHPStan L10 clean; validated against local Valkey 8.1.1.