### PR TITLE
fix(session): shard the TableSessionHandler write lock per session (scale blocker)

### DIFF
--- a/src/Session/Handler/TableSessionHandler.php
+++ b/src/Session/Handler/TableSessionHandler.php
@@ -16,7 +16,10 @@ use OpenSwoole\Table;
  *
  *   1. OpenSwoole\Table  — hot, in-memory, cross-worker, atomic ops
  *   2. File backing      — cold, persistent across restarts, overflow
- *   3. Per-id spinlock   — Atomic cmpset for write critical sections
+ *   3. Sharded spinlock  — Atomic cmpset, one of N shards per session id
+ *                          (`crc32($id) % WRITE_LOCK_SLOTS`), so writes to
+ *                          different sessions don't serialise against each
+ *                          other; only same-session writes (same shard) do.
  *
  * Writes use optimistic versioning (CAS): each session row has a
  * `version` column. On read, the handler snapshots both the data
@@ -51,9 +54,21 @@ final class TableSessionHandler implements \SessionHandlerInterface
     private const COL_VERSION = 'version';
     private const COL_EXPIRES = 'expires';
 
+    /**
+     * Number of sharded write-lock slots. Session ids hash to a slot
+     * (`crc32($id) % WRITE_LOCK_SLOTS`), so writes to DIFFERENT sessions almost
+     * always take DIFFERENT locks (proceed in parallel) while writes to the
+     * SAME session always take the same lock (serialised — required for the
+     * read-merge-CAS to be atomic). Bounded at boot (N small Atomics in shared
+     * memory), so there's no per-session unbounded allocation. Replaces the
+     * single global Atomic that serialised EVERY session write cluster-wide.
+     */
+    private const WRITE_LOCK_SLOTS = 1024;
+
     private static ?self $instance = null;
     private static ?Table $table = null;
-    private static ?Atomic $writeLock = null;
+    /** @var array<int, Atomic> Sharded write locks, indexed `crc32($id) % WRITE_LOCK_SLOTS`. */
+    private static array $writeLocks = [];
     private static string $savePath = '/var/lib/php/sessions';
     private static int $ttl = 7200;          // 2 hours
     private static int $maxRows = 65536;     // 64K rows
@@ -107,7 +122,14 @@ final class TableSessionHandler implements \SessionHandlerInterface
             $table->column(self::COL_EXPIRES, Table::TYPE_INT, 8);
             $table->create();
             self::$table = $table;
-            self::$writeLock = new Atomic(0);
+        }
+
+        // Sharded write locks — allocated once, BEFORE workers fork (Atomic is
+        // shared memory inherited on fork). Idempotent.
+        if (self::$writeLocks === []) {
+            for ($i = 0; $i < self::WRITE_LOCK_SLOTS; $i++) {
+                self::$writeLocks[$i] = new Atomic(0);
+            }
         }
 
         if (!is_dir(self::$savePath)) {
@@ -183,7 +205,7 @@ final class TableSessionHandler implements \SessionHandlerInterface
         $sessionId = (string) $sessionId;
         $data = (string) $data;
         $table = $this->table();
-        $writeLock = $this->writeLock();
+        $writeLock = $this->lockFor($sessionId);
 
         /** @var array{base: array<mixed,mixed>, version: int} $ctx */
         $ctx = $this->context[Coroutine::getCid()][$sessionId] ?? ['base' => [], 'version' => 0];
@@ -192,11 +214,15 @@ final class TableSessionHandler implements \SessionHandlerInterface
         $local = $this->decode($data);
 
         for ($attempt = 0; $attempt < 3; $attempt++) {
-            // Acquire write lock (per-server, not per-session — sessions are
-            // small, critical sections are short; per-id locks would need
-            // unbounded Atomic allocation).
+            // Acquire the per-session-shard write lock. With sharded locks the
+            // critical section only serialises writes to sessions that hash to
+            // the SAME slot (rare), not every session globally. Exponential
+            // backoff (0.1ms → cap 2ms) keeps a contended slot from busy-spinning
+            // at a fixed 0.5ms quantum.
+            $spin = 100; // microseconds
             while (!$writeLock->cmpset(0, 1)) {
-                Coroutine::usleep(500); // 0.5ms yield
+                Coroutine::usleep($spin);
+                $spin = min($spin * 2, 2000);
             }
             try {
                 $current = $table->get($sessionId);
@@ -434,11 +460,16 @@ final class TableSessionHandler implements \SessionHandlerInterface
         return self::$table;
     }
 
-    private function writeLock(): Atomic
+    /**
+     * The write lock for a session id — its hashed shard. Same id → same lock
+     * (serialised, required); different ids → almost always different locks
+     * (parallel).
+     */
+    private function lockFor(string $sessionId): Atomic
     {
-        if (self::$writeLock === null) {
+        if (self::$writeLocks === []) {
             throw new \RuntimeException('TableSessionHandler::register() must be called first');
         }
-        return self::$writeLock;
+        return self::$writeLocks[crc32($sessionId) % self::WRITE_LOCK_SLOTS];
     }
 }

--- a/tests/Unit/Session/TableSessionHandlerTest.php
+++ b/tests/Unit/Session/TableSessionHandlerTest.php
@@ -325,4 +325,48 @@ final class TableSessionHandlerTest extends TestCase
         $m->setAccessible(true);
         $this->assertSame('', $m->invoke(self::$handler, 'no-such-session-' . bin2hex(random_bytes(4))));
     }
+
+    // ── sharded write lock (scale fix) ────────────────────────────────────
+
+    public function testWriteLockShardingIsStablePerSessionAndDistributed(): void
+    {
+        // The single global write-lock Atomic (which serialised EVERY session
+        // write) was replaced with a bounded sharded set. Contract: same id →
+        // same lock (same-session writes MUST serialise for the read-merge-CAS);
+        // different ids spread across shards (so they don't all serialise).
+        $m = new \ReflectionMethod(self::$handler, 'lockFor');
+        $m->setAccessible(true);
+
+        $a1 = $m->invoke(self::$handler, 'session-A');
+        $a2 = $m->invoke(self::$handler, 'session-A');
+        $this->assertInstanceOf(\OpenSwoole\Atomic::class, $a1);
+        $this->assertSame($a1, $a2, 'same session id always maps to the same lock shard');
+
+        $shards = [];
+        for ($i = 0; $i < 300; $i++) {
+            $shards[spl_object_id($m->invoke(self::$handler, "sess-{$i}"))] = true;
+        }
+        $this->assertGreaterThan(1, count($shards), 'distinct sessions hash to multiple lock shards');
+    }
+
+    public function testConcurrentWritesToDistinctSessionsAllSucceed(): void
+    {
+        // The scale property: many concurrent writes to DIFFERENT sessions
+        // (which mostly hit different shards) all complete + round-trip
+        // correctly — they no longer serialise behind one global lock.
+        $results = [];
+        \OpenSwoole\Coroutine::run(function () use (&$results): void {
+            $done = new \OpenSwoole\Coroutine\Channel(24);
+            for ($i = 0; $i < 24; $i++) {
+                go(function () use ($done, $i): void {
+                    $sid = "conc-{$i}-" . bin2hex(random_bytes(3));
+                    self::$handler->write($sid, "v|i:{$i};");
+                    $done->push(self::$handler->read($sid) === "v|i:{$i};");
+                });
+            }
+            for ($i = 0; $i < 24; $i++) { $results[] = $done->pop(5.0); }
+        });
+        $this->assertCount(24, $results);
+        $this->assertNotContains(false, $results, 'every concurrent distinct-session write round-tripped');
+    }
 }


### PR DESCRIPTION
Architectural scale item (audit 2026-06-03, blocker). TableSessionHandler is the **default** coroutine-mode session handler, and its write critical section was guarded by **one global Atomic** — every session write across all coroutines/workers serialised behind it (fixed 0.5ms busy-spin). A hard throughput ceiling under concurrent session traffic.

Replaced the single global lock with a **bounded sharded set** (1024 Atomics, allocated before fork). `crc32($id) % 1024` → shard:
- different sessions → different shards → **parallel** (bottleneck gone);
- same session → same shard → still **serialised** (the read-merge-CAS needs it; 3-way merge unchanged).

Bounded at boot (no per-session unbounded allocation — the original design's stated reason for going global). Spin now uses exponential backoff (0.1ms→2ms cap).

Tests: sharding stability/distribution + 24 concurrent distinct-session writes all round-trip. 27 TableSessionHandler cases green. PHPStan L10 clean. (3rd of the 4 architectural scale items; cross-node fan-out is design-doc'd in #210, the riskier core-pub/sub rewrite.)