### PR TITLE
docs(scale): scaling-limits guide + surface the silent Table-full failure

### DIFF
--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -1,0 +1,78 @@
+# Scaling limits & sizing
+
+The hard limits and sizing formulas you need when running ZealPHP at scale, from
+the 2026-06-03 scalability audit. None of these are bugs — they're properties of
+the underlying primitives (`OpenSwoole\Table`, Redis connections) that you must
+size for.
+
+## Redis connection budget
+
+Every worker, on every node, opens its own connections:
+
+- A **data pool** (`RedisConnectionPool`, default `pool_size = 8`) per worker.
+- A **dedicated SUBSCRIBE connection** per worker for each pub/sub runner
+  (`App::subscribe` → `RedisPubSub`, `App::subscribeReliable` → `RedisStreams`).
+
+So steady-state Redis connections ≈
+
+```
+(pool_size + subscriber_runners) × workers × nodes
+```
+
+For `pool_size = 8`, one pub/sub + one streams runner (`+2`), 16 workers, 4
+nodes: `(8 + 2) × 16 × 4 = 640` connections against one Redis. Redis's default
+`maxclients` is 10000, but a proxy/cluster or a small instance can be far lower.
+
+**Sizing:** raise Redis `maxclients` to comfortably exceed the formula, OR front
+Redis with a multiplexing proxy (Twemproxy / Envoy / Redis Cluster), OR lower
+`pool_size` for large fleets. The per-node pub/sub aggregator
+(`docs/architecture/2026-06-03-cross-node-fanout.md`) collapses the *subscriber*
+term from `workers × nodes` to `nodes` once implemented.
+
+`App::stats()` / `Store::stats()` expose `pool_clients_created_total` so you can
+watch actual connection growth per worker.
+
+## `OpenSwoole\Table` `maxRows` is a hard cap with NO eviction
+
+`Store` / `Cache` on the **Table backend** allocate a fixed-size
+`OpenSwoole\Table` at `maxRows` **at master boot**. It does not grow and does
+**not evict** — once full, every new distinct key's `set()` **silently fails**
+(returns `false`, the value is dropped).
+
+- **Memory:** `RAM ≈ maxRows × (Σ column sizes + ~32 B/row)`. A 1M-row table with
+  a 32-byte string column ≈ 280 MB allocated up front. Setting `maxRows =
+  PHP_INT_MAX` will OOM-kill the master at boot.
+- **Advisory:** `TableBackend::set()` now emits a **one-time warning per table**
+  the first time a write fails, distinguishing "table FULL at maxRows" (no
+  eviction → keys silently dropped) from "row didn't fit" (a column value
+  exceeded its declared size). Grep your debug log for `is FULL at its hard
+  maxRows cap`.
+
+**Sizing:** size `maxRows` to the **full hot working set** up front (it can't
+grow). For unbounded / TTL'd data, use the **Redis** or **Tiered** backend
+(`Store::defaultBackend(Store::BACKEND_REDIS)`), or pair with `Cache::init(
+ttlSeconds: …)` so entries expire instead of accumulating to the cap.
+
+## `iteratePaged()` is O(N²) on the Table backend
+
+`TableBackend::iteratePaged()` treats the cursor as a skip-offset and
+**re-iterates from row 0 on every call**, so paginating all N rows costs
+`O(N² / page)`. Fine for a few thousand rows; above that it's quadratic.
+
+**Use instead:**
+
+- The **Redis / Tiered** backend, whose `iteratePaged()` is a true `SSCAN`
+  cursor (O(N) total).
+- `iterate()` (single O(N) pass) when you can hold one pass in memory and don't
+  need page boundaries.
+
+`count()`, `names()`, and `iterate()` on the Table backend are O(N) single
+passes and are fine.
+
+## See also
+
+- `docs/db-connection-pool.md` — bounding DB connections under coroutine
+  concurrency (the same connection-budget concern for SQL).
+- `docs/architecture/2026-06-03-cross-node-fanout.md` — the per-node pub/sub
+  aggregator + WS room targeting design that reduces the cross-node fan-out.
+- `docs/store.md` — backend selection (Table vs Redis vs Tiered).

--- a/src/Store/TableBackend.php
+++ b/src/Store/TableBackend.php
@@ -20,6 +20,10 @@ final class TableBackend implements StoreBackend
     private array $tables = [];
     /** @var array<string, array<string, array{0:int, 1?:int}>> */
     private array $schemas = [];
+    /** @var array<string, int> Declared `maxRows` per table — for the silent-full advisory. */
+    private array $maxRows = [];
+    /** @var array<string, true> Tables a capacity warning has already been emitted for (rate-limit to once per table per worker). */
+    private array $capacityWarned = [];
 
     /**
      * Create a named `OpenSwoole\Table` with the given schema. Each column in
@@ -43,19 +47,56 @@ final class TableBackend implements StoreBackend
         $t->create();
         $this->tables[$name]  = $t;
         $this->schemas[$name] = $columns;
+        $this->maxRows[$name] = $maxRows;
     }
 
     /**
      * Write a row to the named table. Returns `false` when the table doesn't
-     * exist or when `OpenSwoole\Table::set()` raises an exception (e.g. row
-     * too large for the allocated slot).
+     * exist or when `OpenSwoole\Table::set()` fails — most commonly because the
+     * table is **full** (`maxRows` is a HARD boot-time cap with NO eviction, so
+     * every new distinct key past the cap is silently dropped) or the row
+     * exceeded a declared column size. The FIRST such failure per table emits a
+     * one-time advisory (the failure would otherwise be silent — see the
+     * scaling-limits doc); the return value is unchanged.
      */
     public function set(string $name, string $key, array $row): bool
     {
         $t = $this->tables[$name] ?? null;
         if ($t === null) { return false; }
-        try { return $t->set($key, $row); }
-        catch (\OpenSwoole\Exception) { return false; }
+        try {
+            $ok = $t->set($key, $row);
+        } catch (\OpenSwoole\Exception) {
+            $ok = false;
+        }
+        if (!$ok) {
+            $this->warnCapacity($name, $t, $key);
+        }
+        return $ok;
+    }
+
+    /**
+     * Surface the otherwise-silent `set()` failure ONCE per table per worker.
+     * Distinguishes "table full" (count at the hard `maxRows` cap, no eviction)
+     * from "row didn't fit" (a column value exceeded its declared size).
+     */
+    private function warnCapacity(string $name, Table $t, string $key): void
+    {
+        if (isset($this->capacityWarned[$name])) { return; }
+        $this->capacityWarned[$name] = true;
+        $max   = $this->maxRows[$name] ?? 0;
+        $count = $t->count();
+        $full  = $max > 0 && $count >= $max;
+        $msg   = $full
+            ? "Store/Table '{$name}' is FULL at its hard maxRows cap ({$count}/{$max}) — "
+              . "OpenSwoole\\Table does NOT evict, so further new keys are SILENTLY DROPPED. "
+              . "Size maxRows to the full hot working set up front, or flip to the Redis/Tiered backend."
+            : "Store/Table '{$name}' set('{$key}') failed (count {$count}/{$max}) — likely a row/column "
+              . "value exceeded its declared size. Increase the column size at make() or use the Redis backend.";
+        if (function_exists('ZealPHP\\elog')) {
+            \ZealPHP\elog($msg, 'warn');
+        } else {
+            error_log($msg);
+        }
     }
 
     /**
@@ -131,6 +172,16 @@ final class TableBackend implements StoreBackend
         }
     }
 
+    /**
+     * Paginated iteration. **O(N²/page) on the Table backend** — the cursor is a
+     * skip-offset and each call re-iterates from row 0, discarding `$cursor`
+     * rows before collecting the next `$count`. Paginating all N rows therefore
+     * costs `O(N² / page)`. Fine for a few thousand rows; for large tables use
+     * the Redis/Tiered backend (true `SCAN` cursor) instead, or `iterate()` if
+     * you can hold one pass in memory. See the scaling-limits doc.
+     *
+     * @return array{cursor: string, rows: array<string, array<string, scalar>>}
+     */
     public function iteratePaged(string $name, string $cursor = '0', int $count = 100): array
     {
         $t = $this->tables[$name] ?? null;

--- a/tests/Unit/Store/TableBackendTest.php
+++ b/tests/Unit/Store/TableBackendTest.php
@@ -44,6 +44,28 @@ final class TableBackendTest extends TestCase
         $this->assertFalse($b->set('absent', 'k', ['v' => 'x']));
     }
 
+    public function testSetReturnsFalseAtTheHardMaxRowsCap(): void
+    {
+        // OpenSwoole\Table maxRows is a HARD cap with no eviction — past it,
+        // set() silently returns false (the value is dropped). The backend now
+        // emits a one-time advisory on the first such failure; here we assert
+        // the observable behaviour (writes eventually rejected, count bounded).
+        // OpenSwoole rounds maxRows up (power-of-2 + conflict headroom), so we
+        // loop until the cap is hit rather than assume an exact boundary.
+        $b = new TableBackend();
+        $b->make('capped', 64, ['v' => [Table::TYPE_STRING, 16]]);
+
+        $hitCap = false;
+        for ($i = 0; $i < 1000; $i++) {
+            if (!$b->set('capped', "k{$i}", ['v' => 'x'])) {
+                $hitCap = true;
+                break;
+            }
+        }
+        $this->assertTrue($hitCap, 'Table rejects writes at its hard cap (silent-full)');
+        $this->assertLessThan(1000, $b->count('capped'), 'the cap held — count did not run unbounded');
+    }
+
     public function testFieldRead(): void
     {
         $b = new TableBackend();


### PR DESCRIPTION
The 4th architectural scale item (audit 2026-06-03) — document the hard limits/sizing + one safe advisory so a silent failure stops being silent. No request-handling behavior change.

- **`docs/scaling-limits.md`** — Redis connection-budget formula (raise `maxclients` / proxy / lower `pool_size`), the `OpenSwoole\Table` `maxRows` **hard cap with no eviction** (size to the hot set or use Redis/Tiered + TTL; RAM formula), and `iteratePaged()` **O(N²)** on the Table backend (use the Redis SSCAN cursor).
- **`TableBackend::set()` silent-full advisory** — a write failing because the table is full at its hard `maxRows` cap **silently drops the value**; the backend now logs a one-time warning per table (FULL vs row-too-large). Return value unchanged.
- **`iteratePaged()` docblock** — documents the O(N²/page) cost.

Test: `testSetReturnsFalseAtTheHardMaxRowsCap`. PHPStan L10 clean. Completes the 4 architectural scale items (DB pool ✓, fan-out design ✓, session-lock ✓, docs/advisory ✓).