### PR TITLE
feat(cli): print a console banner on foreground start (plain `php app.php`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- **Foreground start banner.** A plain `php app.php` (no `-d`) used to start **silently** — the "server running" line only went to the debug log, so the terminal sat empty with no confirmation. It now prints a console banner from the master's `on('start')` callback once the server is actually listening: `ZealPHP running at http://localhost:8080  (N routes, W workers)  —  press Ctrl+C to stop`. Bound host `0.0.0.0`/`::` is shown as `localhost` for a clickable URL. The daemonized path (`-d`) is unchanged — its "Started (pid …, port …)" confirmation is still printed by the forked CLI parent, and a detached master prints nothing to the terminal.
+
 ## [0.3.9] - 2026-06-04
 
 A scale + hardening release: the coroutine-aware **`DbConnectionPool`** (the top scalability blocker), a sharded session write-lock, the **`Store::eval()`** atomic-Lua primitive + cross-node fan-out groundwork, Stage 8 global-scope include, and a sweep of edge-case fixes across session / cache / store / WebSocket / pub/sub from a full critical-infra + scalability audit.

--- a/src/App.php
+++ b/src/App.php
@@ -7224,12 +7224,38 @@ class App
         self::$server = $server;
         self::wireProcessHandlers();
 
-        // Master-side signal handlers wire from inside the on-start callback —
-        // the event loop is alive at that point so Process::signal() doesn't
-        // pre-initialize it.
-        if (self::$signalHandlers !== []) {
-            $server->on('start', function () {
-                self::applySignalHandlersFor('master');
+        // Master-side on-start callback. Fires in the master once the server is
+        // bound + listening. Two jobs:
+        //   1. Foreground (no -d): print a console banner so a plain
+        //      `php app.php` confirms it started + where to reach it. The
+        //      daemon path (-d) stays silent here — its "Started (pid …)"
+        //      confirmation is printed by the forked CLI parent (src/CLI.php),
+        //      and a daemonized master's stdout is detached from the terminal.
+        //   2. Wire master signal handlers — the event loop is alive at this
+        //      point, so Process::signal() doesn't pre-initialize it.
+        $foreground   = empty($effective_settings['daemonize']) && PHP_SAPI === 'cli';
+        $haveSignals  = self::$signalHandlers !== [];
+        if ($foreground || $haveSignals) {
+            $displayHost   = in_array($this->host, ['0.0.0.0', '', '::'], true) ? 'localhost' : $this->host;
+            $bannerPort    = $this->port;
+            $bannerRoutes  = count($this->routes);
+            $bannerWorkersRaw = $effective_settings['worker_num'] ?? 0;
+            $bannerWorkers    = is_numeric($bannerWorkersRaw) ? (int) $bannerWorkersRaw : 0;
+            $server->on('start', function () use (
+                $foreground, $haveSignals, $displayHost, $bannerPort, $bannerRoutes, $bannerWorkers
+            ) {
+                if ($foreground) {
+                    fwrite(STDOUT, sprintf(
+                        "ZealPHP running at http://%s:%d  (%d routes%s)  —  press Ctrl+C to stop\n",
+                        $displayHost,
+                        $bannerPort,
+                        $bannerRoutes,
+                        $bannerWorkers > 0 ? ", {$bannerWorkers} workers" : ''
+                    ));
+                }
+                if ($haveSignals) {
+                    self::applySignalHandlersFor('master');
+                }
             });
         }
 


### PR DESCRIPTION
**Problem:** a plain `php app.php` (no `-d`) starts **silently** — the 'server running' line only goes to the debug log, so the terminal sits empty and looks hung. (The `-d` path prints 'Started (pid …)' from the forked CLI parent.)

**Fix:** the master's `on('start')` callback now prints a banner once the server is actually listening, gated to foreground:

```
ZealPHP running at http://localhost:8080  (197 routes, 2 workers)  —  press Ctrl+C to stop
```

- Bound host `0.0.0.0`/`::` shown as `localhost` (clickable).
- `-d` unchanged — stays silent here (its confirmation comes from the CLI parent; a detached master's stdout isn't on the terminal).
- Merged into the existing `on('start')` signal-handler registration (one handler, both jobs).

Verified by a live foreground boot (banner prints with the real route/worker counts); PHPStan L10 clean.