### PR TITLE
feat(routing): $req / $res aliases for $request / $response

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -336,11 +336,13 @@ Wire them ONCE during boot — either in the user's `app.php` for single-app dep
 
 | Parameter name | Injected value |
 |---------------|---------------|
-| `$request` | `ZealPHP\HTTP\Request` wrapper |
-| `$response` | `ZealPHP\HTTP\Response` wrapper |
+| `$request` (or `$req`) | `ZealPHP\HTTP\Request` wrapper |
+| `$response` (or `$res`) | `ZealPHP\HTTP\Response` wrapper |
 | `$app` | `ResponseMiddleware` instance |
 | `{param}` names | Matched URL segments |
 | Any other name with default | PHP default value |
+
+`$req` / `$res` are accepted as short aliases for `$request` / `$response` — they inject the exact same wrappers (route handlers + fallback/error handlers via `ResponseMiddleware`, api/ closures via `ZealAPI`, and template/streaming closures via `App::resolveClosureParams`). An explicit `{req}` / `{res}` URL segment still wins: a matched path parameter binds by name before the alias is considered. ws/task handlers are positional and unaffected.
 
 Reflection is cached per route at registration time — zero reflection overhead per request.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- **`$req` / `$res` handler-parameter aliases** — `$req` and `$res` are now accepted as short aliases for `$request` and `$response` in handler parameter injection, across route handlers, fallback + error handlers, `api/**.php` closures, and template/streaming closures. They inject the exact same wrapper instances as the long names. An explicit `{req}` / `{res}` URL segment still wins (a matched path parameter binds by name first); ws/task handlers are positional and unaffected.
+
 ## [0.3.9] - 2026-06-04
 
 A scale + hardening release: the coroutine-aware **`DbConnectionPool`** (the top scalability blocker), a sharded session write-lock, the **`Store::eval()`** atomic-Lua primitive + cross-node fan-out groundwork, Stage 8 global-scope include, and a sweep of edge-case fixes across session / cache / store / WebSocket / pub/sub from a full critical-infra + scalability audit.

--- a/api/test_aliases.php
+++ b/api/test_aliases.php
@@ -1,0 +1,16 @@
+<?php
+// Demo api endpoint proving $req / $res are accepted as short aliases for
+// $request / $response in api/ handlers — they receive the same wrappers the
+// long names would. Reached at GET /api/test_aliases.
+$test_aliases = function ($req, $res) {
+    $res->header('X-Alias-Inject', 'yes');
+    return [
+        'ok'             => true,
+        'api'            => 'test_aliases',
+        'method'         => $req->server['request_method'] ?? 'GET',
+        'request_class'  => get_class($req),
+        'response_class' => get_class($res),
+        'echo'           => $req->get['echo'] ?? null,
+        'note'           => '$req / $res are short aliases for $request / $response',
+    ];
+};

--- a/docs/api-layer.md
+++ b/docs/api-layer.md
@@ -62,10 +62,12 @@ ZealPHP inspects the closure signature and injects arguments by name. Supported 
 
 - **Framework objects**:
   - `$app` – current `ZealPHP\ZealAPI` instance
-  - `$request` – `ZealPHP\HTTP\Request` wrapper
-  - `$response` – `ZealPHP\HTTP\Response` wrapper
+  - `$request` – `ZealPHP\HTTP\Request` wrapper (`$req` is accepted as a short alias)
+  - `$response` – `ZealPHP\HTTP\Response` wrapper (`$res` is accepted as a short alias)
   - `$server` – underlying `OpenSwoole\HTTP\Server`
 - **Any other name** – receives `null`, or the parameter's declared default value if one exists.
+
+`$req` / `$res` are accepted as short aliases for `$request` / `$response` — they receive the exact same wrappers the long names would.
 
 > **ZealAPI does NOT inject route path parameters.** The URL segments `module` and `action` are consumed by `processApi()` during file resolution and are never passed as closure arguments. To read URL path values use `$request->get` (the query-string array) or `$this->_request` (the cleaned merged inputs). There is no `{id} → $id` injection in ZealAPI — that feature belongs to `$app->route()` handlers, not file-based API closures.
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -45,8 +45,8 @@ The handler is dispatched through the same `ResponseMiddleware::dispatchRoute()`
 |---|---|
 | `$status` | The error status code being rendered (`int`). |
 | `$exception` | The caught `\Throwable` (only present for 500 cases originating from a throw; `null` otherwise). |
-| `$request` | `ZealPHP\HTTP\Request` wrapper. |
-| `$response` | `ZealPHP\HTTP\Response` wrapper. |
+| `$request` | `ZealPHP\HTTP\Request` wrapper (`$req` is accepted as a short alias). |
+| `$response` | `ZealPHP\HTTP\Response` wrapper (`$res` is accepted as a short alias). |
 | `$app` | The middleware instance (rarely needed). |
 
 ### Handler return values

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -271,6 +271,8 @@ Handlers can declare special parameters to access framework objects:
 - `$response` – `ZealPHP\HTTP\Response` wrapper
 - `$app` – the current `ZealPHP\App` instance
 
+`$req` / `$res` are accepted as short aliases for `$request` / `$response` — they receive the exact same wrapper instances. An explicit `{req}` / `{res}` URL segment still wins: a matched path parameter binds by name before the alias is considered.
+
 To access the underlying `OpenSwoole\HTTP\Server`, call `App::getServer()` — it is not an injectable handler parameter.
 
 ```php

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -104,6 +104,8 @@ es.addEventListener('done', () => es.close());
    };
    ```
 
+   As with route handlers, `$req` / `$res` are accepted as short aliases for `$request` / `$response` when those are present in the `$args` array.
+
 2. **IIFE Generator** (explicit, when you want closure-style `use`):
 
    ```php

--- a/docs/templates-and-rendering.md
+++ b/docs/templates-and-rendering.md
@@ -124,7 +124,7 @@ return function($users) {
 };
 ```
 
-The framework injects `$users` from the args array by name, exactly like route parameter injection. Each `yield` flushes to the browser immediately.
+The framework injects `$users` from the args array by name, exactly like route parameter injection — and, exactly like route handlers, `$req` / `$res` are accepted as short aliases for `$request` / `$response` when those are present in the args array. Each `yield` flushes to the browser immediately.
 
 ## `App::include()` — run a `public/` file through the framework
 

--- a/route/demo.php
+++ b/route/demo.php
@@ -13,6 +13,8 @@
  *   /demo/inject/all/{id}           — $id + $request + $response
  *   /demo/inject/defaults/{id}      — with default $page = 1
  *   /demo/inject/defaults/{id}/{page}
+ *   /demo/inject/aliases/{id}       — $req / $res short aliases for $request / $response
+ *   /demo/inject/req-segment/{req}  — explicit {req} segment wins over the $request alias
  *
  * Route type demos:
  *   /demo/route/ns/items            — nsRoute
@@ -118,6 +120,31 @@ $app->route('/demo/inject/defaults/{id}', ['methods' => ['GET']], function($id, 
 
 $app->route('/demo/inject/defaults/{id}/{page}', ['methods' => ['GET']], function($id, $page = 1) {
     return ['id' => $id, 'page' => $page, 'note' => 'page from URL'];
+});
+
+// $req / $res are accepted as short aliases for $request / $response — they
+// receive the exact same wrapper instances as the long names.
+$app->route('/demo/inject/aliases/{id}', ['methods' => ['GET']], function($id, $req, $res) {
+    $res->header('X-Alias-Inject', 'yes');
+    return [
+        'id'             => $id,
+        'method'         => $req->server['request_method'] ?? 'GET',
+        'request_class'  => get_class($req),
+        'response_class' => get_class($res),
+        'echo'           => $req->get['echo'] ?? null,
+        'injected'       => ['id', 'req', 'res'],
+        'note'           => '$req / $res are short aliases for $request / $response',
+    ];
+});
+
+// Precedence: an explicit {req} URL segment binds the segment, NOT the Request
+// wrapper — the isset($params[$pname]) check wins over the alias.
+$app->route('/demo/inject/req-segment/{req}', ['methods' => ['GET']], function($req) {
+    return [
+        'req'      => $req,
+        'is_string' => is_string($req),
+        'note'     => 'explicit {req} URL segment wins over the $request alias',
+    ];
 });
 
 // ---------------------------------------------------------------------------

--- a/src/App.php
+++ b/src/App.php
@@ -5461,7 +5461,18 @@ class App
         }
         $out = [];
         foreach ($cache[$cacheKey] as $p) {
-            $out[] = $args[$p['name']] ?? $p['default'];
+            $name = $p['name'];
+            // Short aliases: $req → request, $res → response — only when the
+            // caller didn't pass an explicit 'req'/'res' arg but DID provide the
+            // long name. Keeps $req/$res working in any param-injected closure,
+            // mirroring the route/api handler injection.
+            if ($name === 'req' && !array_key_exists('req', $args) && array_key_exists('request', $args)) {
+                $out[] = $args['request'];
+            } elseif ($name === 'res' && !array_key_exists('res', $args) && array_key_exists('response', $args)) {
+                $out[] = $args['response'];
+            } else {
+                $out[] = $args[$name] ?? $p['default'];
+            }
         }
         return $out;
     }

--- a/src/ResponseMiddleware.php
+++ b/src/ResponseMiddleware.php
@@ -49,9 +49,9 @@ class ResponseMiddleware implements MiddlewareInterface
                 $invokeArgs[] = $params[$pname];
             } else if ($pname === 'app') {
                 $invokeArgs[] = $this;
-            } else if ($pname === 'request') {
+            } else if ($pname === 'request' || $pname === 'req') {
                 $invokeArgs[] = $g->zealphp_request;
-            } else if ($pname === 'response') {
+            } else if ($pname === 'response' || $pname === 'res') {
                 $invokeArgs[] = $g->zealphp_response;
             } else {
                 $invokeArgs[] = $param['has_default'] ? $param['default'] : null;
@@ -286,9 +286,9 @@ class ResponseMiddleware implements MiddlewareInterface
                 $invokeArgs[] = $params[$pname];
             } else if ($pname === 'app') {
                 $invokeArgs[] = $this;
-            } else if ($pname === 'request') {
+            } else if ($pname === 'request' || $pname === 'req') {
                 $invokeArgs[] = $g->zealphp_request;
-            } else if ($pname === 'response') {
+            } else if ($pname === 'response' || $pname === 'res') {
                 $invokeArgs[] = $g->zealphp_response;
             } else {
                 $invokeArgs[] = $param['has_default'] ? $param['default'] : null;

--- a/src/ZealAPI.php
+++ b/src/ZealAPI.php
@@ -279,9 +279,9 @@ class ZealAPI extends REST
                     $pname = $param->getName();
                     if ($pname == 'app'){
                         $invokeArgs[] = $this;
-                    } else if ($pname == 'request'){
+                    } else if ($pname == 'request' || $pname == 'req'){
                         $invokeArgs[] = $this->request;
-                    } else if ($pname == 'response'){
+                    } else if ($pname == 'response' || $pname == 'res'){
                         $invokeArgs[] = $this->_response;
                     } else if ($pname == 'server'){
                         $invokeArgs[] = App::$server;

--- a/template/pages/api.php
+++ b/template/pages/api.php
@@ -91,7 +91,7 @@ $list = function() {
 PHP]); ?>
 
 <h2>Parameter injection</h2>
-<p>API handlers get the same parameter injection as route handlers:</p>
+<p>API handlers get the same parameter injection as route handlers. <code>$req</code> / <code>$res</code> are accepted as short aliases for <code>$request</code> / <code>$response</code> — they receive the exact same wrappers:</p>
 
 <?php App::render('/components/_code', [
     'label' => 'Magic parameters: $request, $response, $app, $server (auto-injected by name)',
@@ -101,8 +101,8 @@ use ZealPHP\RequestContext;
 
 $get = function($request, $response) {
     // ZealAPI's dispatcher injects these by parameter name (reflection-cached):
-    //   $request  → ZealPHP\HTTP\Request  (wrapped OpenSwoole request)
-    //   $response → ZealPHP\HTTP\Response (wrapped OpenSwoole response)
+    //   $request  → ZealPHP\HTTP\Request  (wrapped OpenSwoole request; alias: $req)
+    //   $response → ZealPHP\HTTP\Response (wrapped OpenSwoole response; alias: $res)
     //   $app      → ZealAPI instance      (same as $this)
     //   $server   → \OpenSwoole\Http\Server (raw OpenSwoole server handle)
     //   $this     → ZealAPI instance      (handler runs inside Closure::bind)

--- a/template/pages/learn/injection.php
+++ b/template/pages/learn/injection.php
@@ -39,16 +39,21 @@
     </p>
 
     <h2>The four magic names</h2>
-    <p>ZealPHP recognizes four parameter-name patterns:</p>
+    <p>ZealPHP recognizes four parameter-name patterns (<code>$request</code> and <code>$response</code> each have a short alias — <code>$req</code> and <code>$res</code>):</p>
     <table class="cmp-table">
       <thead><tr><th>If your parameter is named…</th><th>You get…</th></tr></thead>
       <tbody>
-        <tr><td><code>$request</code></td><td>The <code>ZealPHP\HTTP\Request</code> wrapper — headers, query, body, cookies, files</td></tr>
-        <tr><td><code>$response</code></td><td>The <code>ZealPHP\HTTP\Response</code> wrapper — <code>json()</code>, <code>redirect()</code>, <code>stream()</code>, <code>sse()</code>, <code>cookie()</code></td></tr>
+        <tr><td><code>$request</code> (or <code>$req</code>)</td><td>The <code>ZealPHP\HTTP\Request</code> wrapper — headers, query, body, cookies, files</td></tr>
+        <tr><td><code>$response</code> (or <code>$res</code>)</td><td>The <code>ZealPHP\HTTP\Response</code> wrapper — <code>json()</code>, <code>redirect()</code>, <code>stream()</code>, <code>sse()</code>, <code>cookie()</code></td></tr>
         <tr><td><code>$app</code></td><td>The <code>ResponseMiddleware</code> instance handling this request — almost never useful in modern handlers; reach for the static <code>\ZealPHP\App::*</code> facade (<code>render()</code>, <code>include()</code>, <code>after()</code>, <code>getServer()</code>) instead</td></tr>
         <tr><td>Anything matching a <code>{name}</code> in the route</td><td>The captured URL segment as a string</td></tr>
       </tbody>
     </table>
+    <p>
+      <code>$req</code> / <code>$res</code> are accepted as short aliases for <code>$request</code> / <code>$response</code> —
+      they receive the exact same wrappers. An explicit <code>{req}</code> / <code>{res}</code> URL segment still wins:
+      a matched path parameter binds by name before the alias is considered.
+    </p>
     <p>
       Any other parameter with a default value gets its default. A parameter without a default that
       ZealPHP can’t resolve is passed <code>null</code> — if the parameter is typed non-nullable,

--- a/template/pages/learn/routes.php
+++ b/template/pages/learn/routes.php
@@ -115,7 +115,7 @@ $delete = function ($request) { return User::delete($request->get['id'] ?? null)
 // GET /api/users/item?id=42 → $get; DELETE → $delete; POST → 405 + Allow</code></pre>
     <p>
       Why a separate convention from <code>public/</code>? Because <code>api/</code> files get
-      parameter injection (<code>$app</code>, <code>$request</code>, <code>$response</code>, <code>$server</code>),
+      parameter injection (<code>$app</code>, <code>$request</code> / <code>$req</code>, <code>$response</code> / <code>$res</code>, <code>$server</code>),
       a <code>ZealAPI</code> base class with helpers like
       <code>$this-&gt;paramsExists()</code>, and automatic JSON encoding for array/object returns.
       <code>public/</code> files are plain PHP scripts that echo their own output. Pick

--- a/template/pages/routing.php
+++ b/template/pages/routing.php
@@ -3,7 +3,7 @@
 <section class="section">
 <div class="container">
 <h1 class="section-title">Routing &amp; Parameter Injection</h1>
-<p class="section-desc">ZealPHP uses reflection to inject route parameters, <code>$request</code>, <code>$response</code>, and <code>$app</code> into handlers by name — no annotations, no containers.</p>
+<p class="section-desc">ZealPHP uses reflection to inject route parameters, <code>$request</code>, <code>$response</code>, and <code>$app</code> into handlers by name — no annotations, no containers. <code>$req</code> / <code>$res</code> are accepted as short aliases for <code>$request</code> / <code>$response</code>.</p>
 
 <!-- File-based routing -->
 <h2 class="route-h2">File-based routing — just like LAMP</h2>
@@ -240,7 +240,7 @@ PHP
 
 <!-- Injection cases -->
 <h2 class="route-h2">Parameter injection — every case</h2>
-<p class="route-mb-1-5">All panels below auto-run against the live server. The handler signature determines what gets injected.</p>
+<p class="route-mb-1-5">All panels below auto-run against the live server. The handler signature determines what gets injected. <code>$req</code> / <code>$res</code> are accepted as short aliases for <code>$request</code> / <code>$response</code> — an explicit <code>{req}</code> / <code>{res}</code> URL segment still wins.</p>
 
 <?php
 $cases = [

--- a/tests/Integration/RoutingTest.php
+++ b/tests/Integration/RoutingTest.php
@@ -58,6 +58,50 @@ class RoutingTest extends TestCase
         $this->assertArrayHasKey('response_class', $j);
     }
 
+    // --- $req / $res short aliases for $request / $response ---
+
+    public function testReqResAliasesInjectSameWrappers(): void
+    {
+        // A handler `function ($id, $req, $res)` must receive the exact same
+        // Request/Response wrappers as `$request`/`$response` — read a query
+        // param via $req, set a header via $res.
+        $r = $this->get('/demo/inject/aliases/55?echo=ping');
+        $this->assertStatus(200, $r);
+        $j = $this->assertJsonResponse($r);
+        $this->assertSame('55', $j['id']);
+        $this->assertSame('GET', $j['method']);
+        $this->assertSame('ping', $j['echo']);            // $req->get['echo']
+        $this->assertHeader('x-alias-inject', 'yes', $r); // $res->header(...)
+        // Same wrapper classes the long names resolve to.
+        $this->assertSame('ZealPHP\\HTTP\\Request', $j['request_class']);
+        $this->assertSame('ZealPHP\\HTTP\\Response', $j['response_class']);
+    }
+
+    public function testExplicitReqSegmentWinsOverAlias(): void
+    {
+        // A {req} URL segment binds the matched string, not the Request wrapper
+        // — the isset($params[$pname]) check runs before the alias.
+        $r = $this->get('/demo/inject/req-segment/hello');
+        $this->assertStatus(200, $r);
+        $j = $this->assertJsonResponse($r);
+        $this->assertSame('hello', $j['req']);
+        $this->assertTrue($j['is_string']);
+    }
+
+    public function testReqResAliasesInjectInApiLayer(): void
+    {
+        // The api/ layer (ZealAPI) accepts the same $req/$res aliases — the
+        // fixture api/test_aliases.php declares `function ($req, $res)`.
+        $r = $this->get('/api/test_aliases?echo=pong');
+        $this->assertStatus(200, $r);
+        $j = $this->assertJsonResponse($r);
+        $this->assertTrue($j['ok']);
+        $this->assertSame('pong', $j['echo']);            // $req->get['echo']
+        $this->assertHeader('x-alias-inject', 'yes', $r); // $res->header(...)
+        $this->assertSame('ZealPHP\\HTTP\\Request', $j['request_class']);
+        $this->assertSame('ZealPHP\\HTTP\\Response', $j['response_class']);
+    }
+
     public function testDefaultParamUsed(): void
     {
         $r = $this->get('/demo/inject/defaults/abc');

--- a/tests/Unit/RenderStreamTest.php
+++ b/tests/Unit/RenderStreamTest.php
@@ -99,6 +99,43 @@ class RenderStreamTest extends TestCase
         $this->assertEmpty($chunks);
     }
 
+    public function testReqResAliasesInClosureTemplate(): void
+    {
+        // resolveClosureParams aliases $req → request, $res → response when the
+        // caller supplied the long-name args but no explicit 'req'/'res'.
+        $this->writeTemplate('aliases', '<?php
+            return function($req, $res) {
+                yield "$req|$res";
+            };
+        ');
+
+        $chunks = iterator_to_array(App::renderStream('aliases', [
+            'request'  => 'REQ',
+            'response' => 'RES',
+        ]));
+        $this->assertCount(1, $chunks);
+        $this->assertEquals('REQ|RES', $chunks[0]);
+    }
+
+    public function testExplicitReqArgWinsOverAlias(): void
+    {
+        // An explicit 'req'/'res' arg binds directly — the alias only fills in
+        // when the caller did NOT pass the short name.
+        $this->writeTemplate('alias-explicit', '<?php
+            return function($req, $res) {
+                yield "$req|$res";
+            };
+        ');
+
+        $chunks = iterator_to_array(App::renderStream('alias-explicit', [
+            'req'      => 'EXPLICIT_REQ',
+            'res'      => 'EXPLICIT_RES',
+            'request'  => 'LONG_REQ',
+            'response' => 'LONG_RES',
+        ]));
+        $this->assertEquals('EXPLICIT_REQ|EXPLICIT_RES', $chunks[0]);
+    }
+
     public function testRenderToStringCaptures(): void
     {
         $this->writeTemplate('string-test', '<h1><?= $title ?></h1>');


### PR DESCRIPTION
## Summary

Adds `$req` / `$res` as short aliases for `$request` / `$response` in handler parameter injection (by reflection param name), across every injection site, plus tests and a docs sweep.

The aliases inject the **exact same wrapper instances** as the long names. An explicit `{req}` / `{res}` URL segment still wins (a matched path parameter binds by name first, before the alias is considered). `ws`/`task` handlers are positional and unaffected.

## Code (already committed on this branch — `ea44154`)

- `src/ResponseMiddleware.php` — route handlers + fallback + error handlers (both `param_map` loops): `$pname === 'request' || $pname === 'req'` and `... 'response' || 'res'`.
- `src/ZealAPI.php` — `api/**.php` handlers: `$pname == 'request' || $pname == 'req'` / `... 'response' || 'res'`.
- `src/App.php` `resolveClosureParams()` — template/streaming closures: aliases `req`→`request`, `res`→`response` when present in `$args` (and only when the caller didn't pass an explicit short name).

## Tests (this PR)

- **Integration** (`tests/Integration/RoutingTest.php`):
  - `testReqResAliasesInjectSameWrappers` — a `function ($id, $req, $res)` route reads a query param via `$req` and sets a header via `$res`; asserts the wrapper classes match the long-name resolution (`ZealPHP\HTTP\Request` / `Response`).
  - `testExplicitReqSegmentWinsOverAlias` — a `{req}` URL segment binds the matched string, not the Request wrapper.
  - `testReqResAliasesInjectInApiLayer` — the `api/` layer accepts the same aliases (fixture `api/test_aliases.php`).
- **Backing fixtures/routes**: `route/demo.php` adds `/demo/inject/aliases/{id}` and `/demo/inject/req-segment/{req}`; `api/test_aliases.php` is a new api fixture.
- **Unit** (`tests/Unit/RenderStreamTest.php`): `testReqResAliasesInClosureTemplate` + `testExplicitReqArgWinsOverAlias` exercise `resolveClosureParams` aliasing (alias fills in only when the explicit short name is absent).

### Test results
- Integration `RoutingTest` (run against a fresh server booted on this branch's code): **17/17 pass**, incl. the 3 new cases.
- Unit `RenderStreamTest` + `BuildParamMapTest`: green.
- Full unit suite: 3551 tests; the only errors are the 4 pre-existing `SessionStartMiddlewareTest` cases that need `uopz` (not loaded in this env) — unchanged by this PR.

## Docs (this PR)

`$req` / `$res` are noted wherever `$request` / `$response` injection is documented, with one consistent phrasing:
- `.claude/CLAUDE.md` (Parameter Injection table)
- `docs/routing.md`, `docs/api-layer.md`, `docs/templates-and-rendering.md`, `docs/streaming.md`, `docs/error-handling.md`
- Website pages: `template/pages/routing.php`, `template/pages/api.php`, `template/pages/learn/injection.php`, `template/pages/learn/routes.php`
- `CHANGELOG.md` `[Unreleased]` → `### Added`

No inline styles/scripts introduced (separation-of-concerns preserved).

## Quality gates
- PHPStan (Level 10): no new errors introduced by this PR. The 2 errors in `src/Session/*Manager.php` (`zealphp_process_state_clean(...)` arity) are pre-existing on this branch and master — caused by the local env lacking the ext-zealphp stubs — and are untouched here.
- No version bump; no files touched outside scope.
