### PR TITLE
docs(api): show $this->get_request_method() in the Mode 1 example

### DIFF
--- a/docs/api-layer.md
+++ b/docs/api-layer.md
@@ -18,11 +18,19 @@ Assign a closure to a variable whose name matches the file base name. It receive
 // File: api/device/list.php
 
 $list = function () {
-    return $this->json(['devices' => []]);
+    // Mode 1 sends EVERY HTTP method to this one closure. Use the helper to
+    // tell which verb came in (there is no separate $get/$post here):
+    $method = $this->get_request_method();   // 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+
+    if ($method === 'POST') {
+        return $this->json(['created' => true, 'method' => $method]);
+    }
+
+    return $this->json(['devices' => [], 'method' => $method]);
 };
 ```
 
-`ZealAPI::processApi()` includes the file, binds `$list` to the API object (`$this`), and executes it.
+`ZealAPI::processApi()` includes the file, binds `$list` to the API object (`$this`), and executes it. Since a Mode 1 closure answers **every** verb, `$this->get_request_method()` (returns `GET`/`POST`/`PUT`/`DELETE`/`PATCH`, defaulting to `GET`) is how you branch on the HTTP method inside it — the per-method helpers table below lists the related request accessors. If you'd rather split each verb into its own closure, use Mode 2 (per-method dispatch) instead.
 
 ### Mode 2 — Per-method dispatch
 

--- a/template/pages/api.php
+++ b/template/pages/api.php
@@ -11,20 +11,34 @@
     'code'  => <<<'PHP'
 <?php
 // File: api/device/list.php
-// Endpoint: /api/device/list (any HTTP method)
+// Endpoint: /api/device/list — Mode 1: EVERY HTTP method hits this ONE handler.
 // The variable name MUST match basename($file, '.php') → 'list'
 
 use ZealPHP\G;
 
 $list = function() {
-    $g = G::instance();
+    // $this is the ZealAPI instance. Because Mode 1 doesn't split GET/POST
+    // into separate closures, use the helper to tell which verb came in:
+    $method = $this->get_request_method();   // 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+
+    if ($method === 'POST') {
+        $g = G::instance();
+        return ['created' => true, 'method' => $method, 'body' => $g->post];
+    }
+
+    // default (GET, HEAD, …)
     return [
         'devices' => [['id' => 1, 'name' => 'Sensor A'], ['id' => 2, 'name' => 'Sensor B']],
-        'method'  => $g->server['REQUEST_METHOD'],
-        'query'   => $g->get,
+        'method'  => $method,
     ];
 };
 PHP]); ?>
+
+<p>In <strong>Mode 1</strong> a single closure answers every HTTP method, so use
+<code>$this->get_request_method()</code> to branch on the verb (it returns
+<code>GET</code>, <code>POST</code>, <code>PUT</code>, <code>DELETE</code>, or
+<code>PATCH</code>). If you'd rather split each method into its own closure, use
+<a href="#per-method-dispatch">per-method dispatch</a> (Mode 2) instead.</p>
 
 <h2>File naming convention</h2>
 <table class="ztable">


### PR DESCRIPTION
The filename-match (**Mode 1**) example returned the verb via the raw `$g->server['REQUEST_METHOD']` and never showed *branching* on it — but Mode 1 routes **every** HTTP method to one closure, so the common need is "which method came in?". ZealAPI already exposes **`$this->get_request_method()`** (`src/REST.php`) for exactly that; it was only listed in the helper table, not the example.

Updates the Mode 1 example in **both** the website API page (`template/pages/api.php`) and `docs/api-layer.md` to call `$this->get_request_method()` and branch GET vs POST, with a note pointing at per-method dispatch (Mode 2) as the split-per-verb alternative. Docs only; template lints clean.