### PR TITLE
security: open-redirect, CIDR fail-open, XFF spoofing, log injection, CGI env leak (audit batch 1/4)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -636,6 +636,19 @@ class App
      */
     public static int $cgi_pool_max_requests = 500;
     /**
+     * Optional strict env allowlist for `cgiMode('pool')` subprocesses
+     * (`WorkerPool::filterSubprocessEnv`). Empty (default) = pass the parent
+     * environment through to the subprocess (legacy-app compatibility) MINUS
+     * the request-controlled `HTTP_PROXY` (httpoxy). Set via
+     * `App::cgiPoolEnvAllowlist([...])` to a list of exact names / `PREFIX*`
+     * globs to restrict what secrets the long-lived subprocess inherits;
+     * `ZEALPHP_POOL_MAX_REQUESTS` is always passed. Per-request CGI vars travel
+     * over the IPC frame, not this env, so a strict allowlist doesn't lose them.
+     *
+     * @var list<string>
+     */
+    public static array $cgi_pool_env_allowlist = [];
+    /**
      * True once `cgiPoolMaxRequests()` set the recycle count explicitly. The
      * `mode()` presets consult this so a `mode('legacy-cgi')` default (recycle=1)
      * never clobbers an explicit user choice, regardless of call order.
@@ -2196,6 +2209,25 @@ class App
     }
 
     /**
+     * Strict environment allowlist for `cgiMode('pool')` subprocesses — exact
+     * names and/or `PREFIX*` globs. A no-arg call returns the current list; a
+     * one-arg call sets it. Empty (default) passes the parent env through
+     * (legacy-app compatibility) minus the httpoxy `HTTP_PROXY` var; a non-empty
+     * list restricts the subprocess to matching vars only (the pool IPC var is
+     * always passed). Set BEFORE `App::run()`.
+     *
+     * @param list<string>|null $names
+     * @return list<string>
+     */
+    public static function cgiPoolEnvAllowlist(?array $names = null): array
+    {
+        if ($names !== null) {
+            self::$cgi_pool_env_allowlist = $names;
+        }
+        return self::$cgi_pool_env_allowlist;
+    }
+
+    /**
      * Per-subprocess request count before recycle for `cgiMode('pool')`.
      * FPM `pm.max_requests` parity. Default 500. Set to 1 for fresh-process
      * semantics every request (slower; same isolation as `cgiMode('proc')`).
@@ -3368,11 +3400,13 @@ class App
                     return $ip;
                 }
             }
-            // Every hop is trusted — fall back to the first (originator) entry.
-            // $chain is guaranteed non-empty here: $forwarded !== '' and explode
-            // always yields at least one element, so [0] is always defined.
-            $first = $chain[0];
-            return $first !== '' ? $first : $remote;
+            // Every hop in the chain is trusted — we cannot identify an external
+            // client from a fully-trusted header. The leftmost entry is the
+            // forgeable one (a client prepends it; real proxies append on the
+            // right), so promoting it would trust attacker-controlled input.
+            // Fall back to the address observed on the socket, matching Apache
+            // mod_remoteip / nginx realip semantics.
+            return $remote;
         }
 
         $realIp = (string)($g->server['HTTP_X_REAL_IP'] ?? '');
@@ -3409,7 +3443,18 @@ class App
 
         $slash = strpos($cidr, '/');
         $net   = $slash === false ? $cidr : substr($cidr, 0, $slash);
-        $bits  = $slash === false ? null  : (int)substr($cidr, $slash + 1);
+        if ($slash === false) {
+            $bits = null;
+        } else {
+            $prefix = substr($cidr, $slash + 1);
+            // Fail CLOSED on a malformed prefix. `(int)"abc"` and `(int)""` both
+            // yield 0, and a `/0` mask matches every address — so `10.0.0.0/abc`
+            // or a bare `10.0.0.0/` would silently trust/allow the whole internet.
+            if ($prefix === '' || !ctype_digit($prefix)) {
+                return false;
+            }
+            $bits = (int)$prefix;
+        }
 
         $netPacked = @inet_pton($net);
         $ipPacked  = @inet_pton($ip);
@@ -3476,7 +3521,12 @@ class App
         foreach ($tokens as $tok) {
             $out .= self::renderAccessLogToken($tok, $g, $status, $length, $durationSec);
         }
-        return $out;
+        // Log-injection defence (Apache mod_log_config parity): escape CR/LF/NUL
+        // so an attacker-controlled token (REQUEST_URI, Referer, User-Agent, …)
+        // cannot inject a forged physical log line. Compiled format literals are
+        // single-line (spaces/quotes/brackets), so this only neutralises smuggled
+        // control characters; tab/space field separators are preserved.
+        return strtr($out, ["\r" => '\\r', "\n" => '\\n', "\0" => '\\0']);
     }
 
     /**

--- a/src/CGI/WorkerPool.php
+++ b/src/CGI/WorkerPool.php
@@ -392,6 +392,52 @@ final class WorkerPool
     }
 
     /**
+     * Build the environment handed to a pool subprocess.
+     *
+     * Previously this was `array_merge(getenv(), …)` — every parent env var
+     * (DB passwords, `ZEALPHP_TIERED_INVALIDATION_SECRET`, `AWS_*`, k8s/systemd
+     * secrets) was inherited by the long-lived subprocess running arbitrary
+     * legacy app code, and — unlike the proc/fork CGI path (`Dispatcher::buildCgiEnv`)
+     * — the request-controlled `HTTP_PROXY` was forwarded (httpoxy, CVE-2016-5385).
+     *
+     * Default (empty `$allowlist`): pass the parent env through for legacy-app
+     * compatibility but ALWAYS drop `HTTP_PROXY`. Set `App::cgiPoolEnvAllowlist()`
+     * to a list of exact names / `PREFIX*` globs to harden to a strict allowlist
+     * (the pool IPC var is always included). Per-request CGI vars travel over the
+     * fd-3 IPC frame, not this spawn env, so a strict allowlist does not lose them.
+     *
+     * @param array<string,string> $parentEnv  Usually `getenv()`.
+     * @param list<string>         $allowlist  Exact names or `PREFIX*` globs; empty = pass-through.
+     * @return array<string,string>
+     */
+    public static function filterSubprocessEnv(array $parentEnv, array $allowlist, int $maxRequests): array
+    {
+        $out = [];
+        foreach ($parentEnv as $name => $value) {
+            // httpoxy: a request `Proxy:` header lands as HTTP_PROXY and would
+            // hijack the subprocess's outbound HTTP. Never forward it.
+            if (\strcasecmp($name, 'HTTP_PROXY') === 0) {
+                continue;
+            }
+            if ($allowlist === []) {
+                $out[$name] = (string) $value;
+                continue;
+            }
+            foreach ($allowlist as $rule) {
+                $match = \str_ends_with($rule, '*')
+                    ? \str_starts_with($name, \substr($rule, 0, -1))
+                    : $name === $rule;
+                if ($match) {
+                    $out[$name] = (string) $value;
+                    break;
+                }
+            }
+        }
+        $out['ZEALPHP_POOL_MAX_REQUESTS'] = (string) $maxRequests;
+        return $out;
+    }
+
+    /**
      * @return array{proc: resource, stdin: resource, stdout: resource, stderr: resource, fd3: resource|null, pid: int, served: int}
      */
     private function spawn(): array
@@ -414,9 +460,13 @@ final class WorkerPool
             3 => ['pipe', 'w'], // fd 3    — IPC metadata frame channel
         ];
         $pipes = [];
-        $env = array_merge(getenv(), [
-            'ZEALPHP_POOL_MAX_REQUESTS' => (string) $this->maxRequestsPerWorker,
-        ]);
+        /** @var array<string,string> $parentEnv */
+        $parentEnv = getenv();
+        $env = self::filterSubprocessEnv(
+            $parentEnv,
+            \ZealPHP\App::$cgi_pool_env_allowlist,
+            $this->maxRequestsPerWorker
+        );
         $proc = proc_open([\PHP_BINARY, '-d', 'display_errors=stderr', $entry], $desc, $pipes, null, $env);
         if (!is_resource($proc)) {
             throw new \RuntimeException('WorkerPool: proc_open failed for ' . $entry);

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -145,11 +145,18 @@ class Response
     /**
      * Send an HTTP redirect.
      *
-     * @param string $url    Destination URL (absolute or relative)
-     * @param int    $status 301 Moved Permanently, 302 Found (default),
-     *                       307 Temporary Redirect, 308 Permanent Redirect
+     * @param string $url           Destination URL (absolute or relative)
+     * @param int    $status        301 Moved Permanently, 302 Found (default),
+     *                              307 Temporary Redirect, 308 Permanent Redirect
+     * @param bool   $allowExternal Permit cross-origin / protocol-relative
+     *                              targets. Default `false` — safe-by-default:
+     *                              a `//evil.com` or different-host absolute URL
+     *                              is REFUSED (open-redirect / CWE-601 guard).
+     *                              Set `true` only when an external redirect is
+     *                              genuinely intended (and validate user input
+     *                              against an allowlist first).
      */
-    public function redirect(string $url, int $status = 302): void
+    public function redirect(string $url, int $status = 302, bool $allowExternal = false): void
     {
         if (strpbrk($url, "\r\n\0") !== false) {
             throw new \InvalidArgumentException('Redirect URL contains control characters');
@@ -173,12 +180,21 @@ class Response
             throw new \InvalidArgumentException('Unsafe redirect URL scheme');
         }
 
+        // Open-redirect guard (CWE-601). Refuse cross-origin / protocol-relative
+        // targets by default — warning-and-emitting let `$res->redirect($_GET['next'])`
+        // ship an open redirect. Opt in with $allowExternal when truly intended.
         if (preg_match('#^//#', $url)) {
-            \ZealPHP\elog('[security] Protocol-relative redirect detected: ' . $url, 'warn');
+            if (!$allowExternal) {
+                throw new \InvalidArgumentException('Protocol-relative redirect blocked: ' . $url . ' (pass $allowExternal=true to permit)');
+            }
+            \ZealPHP\elog('[security] Protocol-relative redirect (allowed): ' . $url, 'warn');
         } elseif (isset(parse_url($url)['host'])) {
             $requestHost = $this->g->server['HTTP_HOST'] ?? $this->g->server['SERVER_NAME'] ?? '';
             if ($requestHost !== '' && parse_url($url, PHP_URL_HOST) !== $requestHost) {
-                \ZealPHP\elog('[security] Cross-origin redirect: ' . $url, 'warn');
+                if (!$allowExternal) {
+                    throw new \InvalidArgumentException('Cross-origin redirect blocked: ' . $url . ' (pass $allowExternal=true to permit)');
+                }
+                \ZealPHP\elog('[security] Cross-origin redirect (allowed): ' . $url, 'warn');
             }
         }
 

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -187,14 +187,14 @@ class Response
             if (!$allowExternal) {
                 throw new \InvalidArgumentException('Protocol-relative redirect blocked: ' . $url . ' (pass $allowExternal=true to permit)');
             }
-            \ZealPHP\elog('[security] Protocol-relative redirect (allowed): ' . $url, 'warn');
+            \ZealPHP\elog('[security] Protocol-relative redirect detected: ' . $url, 'warn');
         } elseif (isset(parse_url($url)['host'])) {
             $requestHost = $this->g->server['HTTP_HOST'] ?? $this->g->server['SERVER_NAME'] ?? '';
             if ($requestHost !== '' && parse_url($url, PHP_URL_HOST) !== $requestHost) {
                 if (!$allowExternal) {
                     throw new \InvalidArgumentException('Cross-origin redirect blocked: ' . $url . ' (pass $allowExternal=true to permit)');
                 }
-                \ZealPHP\elog('[security] Cross-origin redirect (allowed): ' . $url, 'warn');
+                \ZealPHP\elog('[security] Cross-origin redirect: ' . $url, 'warn');
             }
         }
 

--- a/src/Middleware/IpAccessMiddleware.php
+++ b/src/Middleware/IpAccessMiddleware.php
@@ -146,8 +146,16 @@ class IpAccessMiddleware implements MiddlewareInterface
 
     private function cidrMatch(string $ip, string $cidr): bool
     {
-        [$subnet, $bits] = explode('/', $cidr, 2);
-        $bits = (int)$bits;
+        $parts  = explode('/', $cidr, 2);
+        $subnet = $parts[0];
+        $prefix = $parts[1] ?? '';
+        // Fail CLOSED on a missing/malformed prefix. `(int)"abc"`/`(int)""` → 0,
+        // and a /0 mask matches every address — so `10.0.0.0/abc`, a bare
+        // `10.0.0.0/`, or `10.0.0.0` with no slash would allow/deny every client.
+        if ($prefix === '' || !ctype_digit($prefix)) {
+            return false;
+        }
+        $bits = (int)$prefix;
 
         $ipBin     = @inet_pton($ip);
         $subnetBin = @inet_pton($this->normalizeIp($subnet));
@@ -156,6 +164,9 @@ class IpAccessMiddleware implements MiddlewareInterface
         }
         if (strlen($ipBin) !== strlen($subnetBin)) {
             return false; // mixed v4/v6
+        }
+        if ($bits > strlen($ipBin) * 8) {
+            return false; // prefix wider than the address family
         }
 
         $bytes = intdiv($bits, 8);

--- a/tests/Unit/AppConfigurablesTest.php
+++ b/tests/Unit/AppConfigurablesTest.php
@@ -244,7 +244,7 @@ class AppConfigurablesTest extends TestCase
         $this->assertSame('198.51.100.7', App::clientIp());
     }
 
-    public function testClientIpFallsBackToFirstHopWhenAllTrusted(): void
+    public function testClientIpReturnsSocketPeerWhenAllHopsTrusted(): void
     {
         App::trustedProxies(['10.0.0.0/8', '192.168.0.0/16']);
         $g = RequestContext::instance();
@@ -252,7 +252,12 @@ class AppConfigurablesTest extends TestCase
             'REMOTE_ADDR' => '10.0.0.1',
             'HTTP_X_FORWARDED_FOR' => '192.168.1.5, 10.0.0.2',
         ];
-        $this->assertSame('192.168.1.5', App::clientIp());
+        // #249 (security BC change): when EVERY hop is trusted we cannot
+        // distinguish a legitimate all-trusted chain from a client that forged
+        // trusted-looking entries — the leftmost is the attacker-prependable one.
+        // Return the observed socket peer (Apache mod_remoteip / nginx realip),
+        // NOT the spoofable 192.168.1.5. Previously returned the leftmost hop.
+        $this->assertSame('10.0.0.1', App::clientIp());
     }
 
     public function testClientIpUsesXRealIpWhenForwardedForMissing(): void

--- a/tests/Unit/HTTP/ResponseExtraTest.php
+++ b/tests/Unit/HTTP/ResponseExtraTest.php
@@ -1156,8 +1156,10 @@ class ResponseExtraTest extends TestCase
         // exact prefix AND the URL, in that order.
         $resp = $this->wrap();
 
+        // #243: external targets are blocked by default; opt in with
+        // $allowExternal=true to exercise the (still-present) warn-log path.
         $log = $this->captureDebugLog(function () use ($resp): void {
-            $resp->redirect('//cdn.example.com/asset');
+            $resp->redirect('//cdn.example.com/asset', 302, true);
         });
 
         $this->assertStringContainsString(
@@ -1176,7 +1178,7 @@ class ResponseExtraTest extends TestCase
         $resp = $this->wrap();
 
         $log = $this->captureDebugLog(function () use ($resp): void {
-            $resp->redirect('https://other.com/page');
+            $resp->redirect('https://other.com/page', 302, true); // #243: opt-in external → warn path
         });
 
         $this->assertStringContainsString(
@@ -1197,7 +1199,7 @@ class ResponseExtraTest extends TestCase
         $resp = $this->wrap();
 
         $log = $this->captureDebugLog(function () use ($resp): void {
-            $resp->redirect('https://other.com/page');
+            $resp->redirect('https://other.com/page', 302, true); // #243: opt-in external → warn path
         });
 
         $this->assertStringContainsString('[security] Cross-origin redirect:', $log);
@@ -1230,7 +1232,7 @@ class ResponseExtraTest extends TestCase
         $resp = $this->wrap();
 
         $log = $this->captureDebugLog(function () use ($resp): void {
-            $resp->redirect('https://other.com/page');
+            $resp->redirect('https://other.com/page', 302, true); // #243: opt-in external → warn path
         });
 
         $this->assertStringNotContainsString('Cross-origin redirect', $log);
@@ -1246,7 +1248,7 @@ class ResponseExtraTest extends TestCase
         $resp = $this->wrap();
 
         $log = $this->captureDebugLog(function () use ($resp): void {
-            $resp->redirect('https://elsewhere.example/x');
+            $resp->redirect('https://elsewhere.example/x', 302, true); // #243: opt-in external → warn path
         });
 
         $this->assertStringContainsString('[security] Cross-origin redirect: https://elsewhere.example/x', $log);

--- a/tests/Unit/HTTP/ResponseTest.php
+++ b/tests/Unit/HTTP/ResponseTest.php
@@ -265,16 +265,25 @@ class ResponseTest extends TestCase
         $resp->redirect('data:text/html,<script>x</script>');
     }
 
-    public function testRedirectAllowsProtocolRelativeWithWarning(): void
+    public function testRedirectAllowsProtocolRelativeWithOptIn(): void
     {
-        // Protocol-relative URLs are allowed (logged as a warning) — they still redirect.
+        // #243: protocol-relative URLs are BLOCKED by default; with
+        // $allowExternal=true they are allowed (logged as a warning) + still redirect.
         $g = RequestContext::instance();
         $fake = $this->fake();
         $resp = $this->wrap($fake);
 
-        $resp->redirect('//cdn.example.com/asset');
+        $resp->redirect('//cdn.example.com/asset', 302, true);
         $this->assertSame(302, $g->status);
         $this->assertContains(['header', 'Location', '//cdn.example.com/asset'], $fake->log);
+    }
+
+    public function testRedirectBlocksProtocolRelativeByDefault(): void
+    {
+        // #243: the secure default — a bare protocol-relative target throws.
+        $resp = $this->wrap($this->fake());
+        $this->expectException(\InvalidArgumentException::class);
+        $resp->redirect('//cdn.example.com/asset');
     }
 
     public function testRedirectCrossOriginAbsoluteAllowed(): void
@@ -284,7 +293,9 @@ class ResponseTest extends TestCase
         $fake = $this->fake();
         $resp = $this->wrap($fake);
 
-        $resp->redirect('https://other.com/page');
+        // #243: a cross-origin target is blocked by default; opt in with
+        // $allowExternal=true to allow + emit it (this test's intent).
+        $resp->redirect('https://other.com/page', 302, true);
         $this->assertSame(302, $g->status);
         $this->assertContains(['header', 'Location', 'https://other.com/page'], $fake->log);
     }

--- a/tests/Unit/SecurityHardeningAuditTest.php
+++ b/tests/Unit/SecurityHardeningAuditTest.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use OpenSwoole\Core\Psr\Response;
+use OpenSwoole\Core\Psr\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use ZealPHP\App;
+use ZealPHP\CGI\WorkerPool;
+use ZealPHP\Middleware\IpAccessMiddleware;
+use ZealPHP\RequestContext;
+use ZealPHP\Tests\Unit\HTTP\FakeOpenSwooleResponse;
+use ZealPHP\Tests\TestCase;
+
+/**
+ * Regression tests for the security-audit batch (@Guruprasanth-M): #248 CIDR
+ * fail-open, #249 forgeable leftmost XFF, #250 access-log CRLF injection, #243
+ * open redirect, #257 CGI pool env leak.
+ */
+final class SecurityHardeningAuditTest extends TestCase
+{
+    /** @var array<int, string> */
+    private static array $origProxies = [];
+    private static string $origLogFormat = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$origProxies   = App::$trusted_proxies;
+        self::$origLogFormat = App::accessLogFormat();
+    }
+
+    protected function tearDown(): void
+    {
+        App::$trusted_proxies = self::$origProxies;
+        App::accessLogFormat(self::$origLogFormat); // also resets the compiled cache
+        App::$cgi_pool_env_allowlist = [];
+    }
+
+    private function callPrivate(object|string $target, string $method, mixed ...$args): mixed
+    {
+        $ref = new \ReflectionMethod($target, $method);
+        $ref->setAccessible(true);
+        return $ref->invoke(is_object($target) ? $target : null, ...$args);
+    }
+
+    // ── #248 — CIDR matchers fail CLOSED on a malformed prefix ─────
+
+    public function testCidrContainsFailsClosedOnMalformedPrefix(): void
+    {
+        $this->assertFalse($this->callPrivate(App::class, 'cidrContains', '10.0.0.0/abc', '8.8.8.8'));
+        $this->assertFalse($this->callPrivate(App::class, 'cidrContains', '10.0.0.0/', '8.8.8.8'));
+        // Legit masks still work.
+        $this->assertTrue($this->callPrivate(App::class, 'cidrContains', '10.0.0.0/8', '10.6.6.6'));
+        $this->assertFalse($this->callPrivate(App::class, 'cidrContains', '10.0.0.0/8', '11.0.0.1'));
+        $this->assertTrue($this->callPrivate(App::class, 'cidrContains', '0.0.0.0/0', '1.2.3.4')); // explicit match-all is fine
+    }
+
+    public function testIpAccessCidrMatchFailsClosedOnMalformedPrefix(): void
+    {
+        $mw = new IpAccessMiddleware(['allow' => ['10.0.0.0/abc']]);
+        $this->assertFalse($this->callPrivate($mw, 'cidrMatch', '8.8.8.8', '10.0.0.0/abc'));
+        $this->assertFalse($this->callPrivate($mw, 'cidrMatch', '8.8.8.8', '10.0.0.0/'));
+        $this->assertFalse($this->callPrivate($mw, 'cidrMatch', '8.8.8.8', '10.0.0.0'));     // no slash → fail closed
+        $this->assertFalse($this->callPrivate($mw, 'cidrMatch', '8.8.8.8', '10.0.0.0/99'));  // out-of-range prefix
+        $this->assertTrue($this->callPrivate($mw, 'cidrMatch', '10.6.6.6', '10.0.0.0/8'));   // control
+    }
+
+    // ── #249 — clientIp() must not promote the forgeable leftmost XFF ──
+
+    public function testClientIpReturnsSocketPeerWhenAllHopsTrusted(): void
+    {
+        App::$trusted_proxies = ['10.0.0.0/8'];
+        $g = RequestContext::instance();
+        $g->server = [
+            'REMOTE_ADDR'          => '10.0.0.1',
+            'HTTP_X_FORWARDED_FOR' => '10.6.6.6, 10.0.0.9, 10.0.0.1', // all trusted; leftmost forged
+        ];
+        $this->assertSame('10.0.0.1', App::clientIp()); // the observed peer, NOT 10.6.6.6
+    }
+
+    public function testClientIpStillReturnsFirstUntrustedHop(): void
+    {
+        App::$trusted_proxies = ['10.0.0.0/8'];
+        $g = RequestContext::instance();
+        $g->server = [
+            'REMOTE_ADDR'          => '10.0.0.1',
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.7, 10.0.0.9, 10.0.0.1',
+        ];
+        $this->assertSame('203.0.113.7', App::clientIp());
+    }
+
+    // ── #250 — access-log CRLF injection ─────────────────────────
+
+    public function testAccessLogEscapesCrlfInRequestUri(): void
+    {
+        App::accessLogFormat('%r'); // resets the compiled token cache
+        $g = RequestContext::instance();
+        $g->server = [
+            'REQUEST_METHOD'  => 'GET',
+            'REQUEST_URI'     => "/x\r\nFAKE 200 injected",
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+        ];
+        $line = App::formatAccessLogLine(200, 10, null);
+        $this->assertStringNotContainsString("\n", $line);
+        $this->assertStringNotContainsString("\r", $line);
+        $this->assertStringContainsString('\\r\\n', $line); // escaped, not raw
+    }
+
+    // ── #257 — CGI pool subprocess env allowlist / httpoxy ───────
+
+    public function testSubprocessEnvDropsHttpProxyByDefault(): void
+    {
+        $env = WorkerPool::filterSubprocessEnv(
+            ['HTTP_PROXY' => 'http://evil', 'PATH' => '/usr/bin', 'DB_PASSWORD' => 's3cret'],
+            [],
+            42
+        );
+        $this->assertArrayNotHasKey('HTTP_PROXY', $env);
+        $this->assertSame('/usr/bin', $env['PATH']);           // pass-through default keeps app vars
+        $this->assertSame('s3cret', $env['DB_PASSWORD']);
+        $this->assertSame('42', $env['ZEALPHP_POOL_MAX_REQUESTS']);
+    }
+
+    public function testSubprocessEnvStrictAllowlistDropsSecrets(): void
+    {
+        $env = WorkerPool::filterSubprocessEnv(
+            ['HTTP_PROXY' => 'x', 'PATH' => '/usr/bin', 'AWS_SECRET' => 'k', 'ZEALPHP_LOG_DIR' => '/t'],
+            ['PATH', 'ZEALPHP_*'],
+            7
+        );
+        $this->assertArrayNotHasKey('AWS_SECRET', $env);       // not allowlisted → dropped
+        $this->assertArrayNotHasKey('HTTP_PROXY', $env);
+        $this->assertSame('/usr/bin', $env['PATH']);
+        $this->assertSame('/t', $env['ZEALPHP_LOG_DIR']);      // prefix glob match
+        $this->assertSame('7', $env['ZEALPHP_POOL_MAX_REQUESTS']);
+    }
+
+    // ── #243 — open redirect blocked by default ──────────────────
+
+    private function freshResponse(): \ZealPHP\HTTP\Response
+    {
+        $fake = new FakeOpenSwooleResponse();
+        $g = RequestContext::instance();
+        $g->openswoole_response = $fake;
+        $g->status = 200;
+        $g->server = ['HTTP_HOST' => 'myapp.test'];
+        return new \ZealPHP\HTTP\Response($fake);
+    }
+
+    public function testRedirectBlocksProtocolRelative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->freshResponse()->redirect('//evil.com');
+    }
+
+    public function testRedirectBlocksCrossOrigin(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->freshResponse()->redirect('https://evil.com/login');
+    }
+
+    public function testRedirectAllowsRelativeAndSameHost(): void
+    {
+        $this->freshResponse()->redirect('/dashboard');
+        $this->assertSame(302, RequestContext::instance()->status);
+        $this->freshResponse()->redirect('https://myapp.test/account', 301);
+        $this->assertSame(301, RequestContext::instance()->status);
+    }
+
+    public function testRedirectExternalPermittedWithOptIn(): void
+    {
+        $this->freshResponse()->redirect('https://evil.com/ok', 302, true);
+        $this->assertSame(302, RequestContext::instance()->status); // opt-in → no exception
+    }
+}

--- a/tests/Unit/SecurityTest.php
+++ b/tests/Unit/SecurityTest.php
@@ -147,12 +147,22 @@ class SecurityTest extends TestCase
         $this->assertSame(302, \ZealPHP\G::instance()->status);
     }
 
-    public function testRedirectAcceptsCrossOriginButLogsWarning(): void
+    public function testRedirectBlocksCrossOriginByDefault(): void
     {
-        // Cross-origin is warned, not blocked (preserves OAuth flows).
+        // #243: cross-origin is BLOCKED by default (open-redirect / CWE-601 guard)
+        // — a change from the prior warn-and-emit behaviour.
         $response = $this->makeResponse();
         \ZealPHP\G::instance()->server = ['HTTP_HOST' => 'example.test'];
+        $this->expectException(\InvalidArgumentException::class);
         $response->redirect('https://oauth.provider.test/authorize');
+    }
+
+    public function testRedirectAllowsCrossOriginWithOptIn(): void
+    {
+        // #243: a legitimate external redirect (OAuth flow) opts in explicitly.
+        $response = $this->makeResponse();
+        \ZealPHP\G::instance()->server = ['HTTP_HOST' => 'example.test'];
+        $response->redirect('https://oauth.provider.test/authorize', 302, true);
         $this->assertSame(302, \ZealPHP\G::instance()->status);
         $this->assertContains(['Location', 'https://oauth.provider.test/authorize'], $response->headersList);
     }


### PR DESCRIPTION
First batch of fixes for @Guruprasanth-M's security/correctness audit. All five were independently verified VALID against released `master` (0 false positives). Each fix is pinned by `tests/Unit/SecurityHardeningAuditTest.php` (11 cases); PHPStan L10 clean.

| # | Issue | Fix |
|---|---|---|
| **#248** | CIDR matchers fail **OPEN** on malformed prefix (`/abc`, `/`, bare → `/0` match-all) | `App::cidrContains()` + `IpAccessMiddleware::cidrMatch()` `ctype_digit`-validate and **fail closed**; range guard added |
| **#249** | `clientIp()` returns forgeable **leftmost XFF** when all hops trusted | Returns the observed **socket peer** (mod_remoteip / realip). ⚠️ security BC in the all-trusted edge case — existing test updated |
| **#250** | Access-log **CRLF injection** (REQUEST_URI/Referer/User-Agent verbatim) | `formatAccessLogLine()` escapes `\r \n \0` (mod_log_config parity); tab/space separators preserved |
| **#243** | **Open redirect** (CWE-601) — `redirect()` warn-then-emit on cross-origin / `//host` | Throws by default; opt in via `redirect($url, $status, $allowExternal = true)` |
| **#257** | CGI pool subprocess inherits **full parent env** + forwards `HTTP_PROXY` (httpoxy) | `WorkerPool::filterSubprocessEnv()` always drops `HTTP_PROXY`; opt-in strict allowlist via `App::cgiPoolEnvAllowlist()` |

### Notes
- **#249 is a behaviour change** in one edge case (every XFF hop in a trusted range): previously the leftmost (forgeable) hop was returned; now the socket peer is. Apps relying on a broad `trusted_proxies` + the old leftmost behaviour should narrow `trusted_proxies` to their actual proxies (the normal case — first untrusted hop from the right — is unchanged).
- **#257 default is non-breaking**: the parent env is still passed through to legacy app subprocesses (minus `HTTP_PROXY`); the strict allowlist is opt-in for hardened deployments.

### Follow-up PRs (same audit)
- Session fixation (#244) — strict-mode + regenerate-on-auth
- Store/backends (#241, #242, #251 object-injection, #252, #254, #255, #256)
- HTTP/WS (#246, #247, #253, #258, #259, #260 header-append)
- ext-zealphp C bugs (#9–#18) — ASAN-validated, separate repo

Closes #248, #249, #250, #243, #257.