### PR TITLE
fix: 6 HTTP/WS correctness issues from the audit (#246 #247 #253 #258 #259 #260)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,6 +43,17 @@ parameters:
         -
             message: '#^Negated boolean expression is always false\.$#'
             path: src/CLI.php
+        # openswoole/ide-helper stubs OpenSwoole\Http\Response::header()'s value
+        # param as `string`, but the real ext parses it as a zval (Z_PARAM_ZVAL)
+        # and, when given an ARRAY, emits one wire line per element — the
+        # documented mechanism for multiple same-name headers (the same path
+        # multiple Set-Cookie uses). Response::emitMultiHeader() relies on that
+        # array form to keep multiple Link / WWW-Authenticate / CSP appends on
+        # the wire (#260). Same ext-vs-stub category as the OpenSwoole entries
+        # above; scoped to the single call site.
+        -
+            message: '#^Parameter \#2 \$value of method OpenSwoole\\Http\\Response::header\(\) expects string, list<string> given\.$#'
+            path: src/HTTP/Response.php
         # ResponseMiddleware re-emits $g->status after handlers run; PHPStan
         # narrows from the constant ($beforeStatus = 200) and reports the
         # 3-way !== check as always-false. Runtime: status is mutated by

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -125,7 +125,20 @@ class Response
     }
 
     // You can override methods if necessary or add more custom methods
-    public function header(string $key, string $value): bool
+
+    /**
+     * Queue a response header.
+     *
+     * Mirrors PHP's native `header($value, $replace = true)` semantics (#260):
+     * `$replace = true` (the default) drops any previously-queued header of the
+     * same name before adding this one — last write wins, as every framework
+     * caller that sets a single header (Content-Type, Cache-Control, …) relies
+     * on. `$replace = false` is the APPEND form (`header($h, false)`) — it keeps
+     * prior same-name entries, so multiple `Link` / `WWW-Authenticate` / CSP
+     * headers all survive (flush() groups same-name appends into one
+     * array-valued OpenSwoole call so they all reach the wire).
+     */
+    public function header(string $key, string $value, bool $replace = true): bool
     {
         // CRLF / NUL injection guard. Also block `:` and whitespace in the
         // header name itself (RFC 7230 field-name = token, which excludes
@@ -134,6 +147,13 @@ class Response
         if (strpbrk($key, "\r\n\0: \t") !== false || strpbrk($value, "\r\n\0") !== false) {
             trigger_error('Header injection blocked: control characters in name or value', E_USER_WARNING);
             return false;
+        }
+        if ($replace) {
+            // Drop prior same-name entries (case-insensitive) so this value wins.
+            $this->headersList = array_values(array_filter(
+                $this->headersList,
+                static fn(array $pair): bool => strcasecmp($pair[0], $key) !== 0
+            ));
         }
         $this->headersList[] = [$key, $value];
         if (strtolower($key) === 'location' && $value && ($this->g->status === 200 || $this->g->status === null)) {
@@ -195,9 +215,10 @@ class Response
             $reason = self::REDIRECT_REASONS[$status] ?? '';
             $this->g->_streaming = true;
             $this->parent->status($status, $reason);
-            foreach ($this->headersList as [$k, $v]) {
-                $this->parent->header($k, $v);
-            }
+            // Group same-name headers so multiple appends (e.g. several Link
+            // preload hints emitted alongside a redirect) survive on the wire
+            // (#260) — same path flush() uses.
+            $this->emitQueuedHeaders();
             foreach ($this->cookiesList as $cookie) {
                 $this->parent->cookie(...$cookie);
             }
@@ -480,9 +501,11 @@ class Response
 
         // If-Range (RFC 9110 §13.1.5): only honour the Range if the validator
         // still matches. A leading `"` (or `W/"`) marks an entity-tag form,
-        // otherwise it is an HTTP-date compared against the file mtime (strong:
-        // exact second match required). On mismatch we ignore the Range and
-        // serve the full body — never a 412 here.
+        // otherwise it is an HTTP-date evaluated by the shared
+        // self::ifRangeDateMatches() strong-validation helper (Apache's 60 s
+        // clock-skew rule — identical to the buffered RangeMiddleware path, see
+        // #258). On mismatch we ignore the Range and serve the full body —
+        // never a 412 here.
         if ($rangeHeader !== '') {
             $ifRange = $reqHeaders['if-range'] ?? '';
             if (!is_string($ifRange)) {
@@ -552,10 +575,50 @@ class Response
             return $ifRange === $etag;
         }
 
-        // HTTP-date form: honour the Range only if the file has not been
-        // modified since the supplied date (exact-second strong match).
-        $when = strtotime($ifRange);
-        return $when !== false && $when === $mtime;
+        // HTTP-date form: defer to the single shared date-strong helper so the
+        // buffered (RangeMiddleware) and zero-copy (this) paths can never drift
+        // on what "strong date match" means (#258). reqTime = null → the helper
+        // uses wall-clock now (sendFile has no upstream Date header to consult).
+        return self::ifRangeDateMatches($ifRange, $mtime, null);
+    }
+
+    /**
+     * Shared If-Range HTTP-date evaluator — the SINGLE source of truth for
+     * date-form `If-Range` strong validation across both range-serving paths
+     * (this Response::sendFile() zero-copy path AND the buffered
+     * RangeMiddleware path), so they can never diverge on the same request
+     * (#258).
+     *
+     * Implements RFC 9110 §13.1.5's strong-validation requirement via Apache's
+     * one-minute clock-skew rule (ap_condition_if_range): a Last-Modified date
+     * is only a STRONG validator if it is at least 60 s older than the time the
+     * representation was served — a value younger than that window is treated
+     * as weak and a weak validator MUST NOT be used to short-circuit a Range
+     * request. The Range is honoured only when the supplied date matches the
+     * resource mtime exactly AND that 60 s skew window has elapsed.
+     *
+     * @param string   $ifRange Raw If-Range header value (already known to be
+     *                          the HTTP-date form, not an entity-tag).
+     * @param int      $mtime   Resource last-modified time (unix seconds).
+     * @param int|null $reqTime Time the response is/was served (unix seconds) —
+     *                          from the response Date header when available;
+     *                          null → use wall-clock now.
+     * @return bool true → the date is a strong match, honour the Range.
+     */
+    public static function ifRangeDateMatches(string $ifRange, int $mtime, ?int $reqTime): bool
+    {
+        $when = strtotime(trim($ifRange));
+        if ($when === false || $when !== $mtime) {
+            // Unparseable, or the validator no longer matches the resource —
+            // ignore the Range and serve the full representation.
+            return false;
+        }
+        $served = $reqTime ?? time();
+        if ($served < $mtime + 60) {
+            // Skew window not yet elapsed — weak match, not allowed with Range.
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -635,9 +698,7 @@ class Response
     public function flush(): bool
     {
         if ($this->parent->isWritable()) {
-            foreach ($this->headersList as $header) {
-                $this->parent->header(...$header);
-            }
+            $this->emitQueuedHeaders();
             foreach ($this->cookiesList as $cookie) {
                 $this->parent->cookie(...$cookie);
             }
@@ -651,5 +712,57 @@ class Response
             return true;
         }
         return false;
+    }
+
+    /**
+     * Emit every queued header to the underlying OpenSwoole response, grouping
+     * same-name entries so multiple appends survive on the wire (#260).
+     *
+     * `header($name, $value, false)` (PHP's append form) queues each value as a
+     * separate `$headersList` entry — correct. But OpenSwoole's scalar
+     * `$response->header($name, $scalar)` OVERWRITES any prior entry of the same
+     * name (it stores under the header name as the array key), so emitting one
+     * scalar call per entry collapses `Link` / `WWW-Authenticate` /
+     * `Content-Security-Policy` multi-value headers to the LAST value only.
+     *
+     * OpenSwoole DOES support multiple same-name headers — pass an ARRAY value
+     * and the ext emits one wire line per element (the same mechanism that makes
+     * multiple `Set-Cookie` work). So we group by name (first-seen order
+     * preserved), then emit a scalar for single-value names and an array for
+     * names with >1 value.
+     */
+    private function emitQueuedHeaders(): void
+    {
+        /** @var array<string, list<string>> $grouped */
+        $grouped = [];
+        foreach ($this->headersList as [$name, $value]) {
+            // Preserve first-seen order of distinct names; append repeats.
+            $grouped[$name][] = $value;
+        }
+        foreach ($grouped as $name => $values) {
+            if (count($values) === 1) {
+                $this->parent->header($name, $values[0]);
+            } else {
+                // Array value → OpenSwoole emits one `Name: value` line per
+                // element (proven against ext-openswoole 26.x: header() parses
+                // the value as a zval and the emit loop expands array values).
+                $this->emitMultiHeader($name, $values);
+            }
+        }
+    }
+
+    /**
+     * Emit a single header name with multiple values as one OpenSwoole
+     * `header()` call carrying an ARRAY value, so the ext writes one wire line
+     * per value (#260). Isolated in its own method because the
+     * openswoole/ide-helper stub types the value param as `string` while the
+     * real ext accepts any zval (incl. an array) — the array-value behaviour is
+     * a documented ext-vs-stub mismatch (see phpstan.neon ignoreErrors).
+     *
+     * @param list<string> $values
+     */
+    private function emitMultiHeader(string $name, array $values): void
+    {
+        $this->parent->header($name, $values);
     }
 }

--- a/src/Middleware/RangeMiddleware.php
+++ b/src/Middleware/RangeMiddleware.php
@@ -104,9 +104,12 @@ class RangeMiddleware implements MiddlewareInterface
                 }
                 // No ETag on response or tags match: fall through and honour range.
             } else {
-                // HTTP-date comparison against Last-Modified.
-                // Apache clock-skew rule: if request time < mtime + 60 s, treat as
-                // a weak (untrustworthy) match and ignore the range.
+                // HTTP-date comparison against Last-Modified — delegated to the
+                // single shared strong-validation helper so this buffered path
+                // and Response::sendFile()'s zero-copy path can never disagree
+                // on the same request (#258). The helper encodes Apache's 60 s
+                // clock-skew rule (a Last-Modified younger than 60 s is weak and
+                // must not short-circuit a Range).
                 $lastModifiedHeader = $response->getHeaderLine('Last-Modified');
                 if ($lastModifiedHeader === '') {
                     // No Last-Modified available — cannot validate; serve full body.
@@ -114,28 +117,21 @@ class RangeMiddleware implements MiddlewareInterface
                 }
 
                 $mtime = strtotime($lastModifiedHeader);
-                $rtime = strtotime($ifRange);
-
-                if ($mtime === false || $rtime === false || $mtime === -1 || $rtime === -1) {
-                    // Unparseable date — cannot validate; serve full body safely.
+                if ($mtime === false || $mtime === -1) {
+                    // Unparseable Last-Modified — cannot validate; serve full body.
                     return $response->withHeader('Accept-Ranges', 'bytes');
                 }
 
-                if ($rtime !== $mtime) {
-                    // Dates differ: resource has changed, ignore range.
-                    return $response->withHeader('Accept-Ranges', 'bytes');
-                }
-
-                // Dates match; apply Apache's one-minute clock-skew rule.
-                // Use the response Date header when present, otherwise wall clock.
+                // Resolve the served-time from the response Date header when
+                // present, otherwise wall clock — same source the inline code
+                // used; the helper applies the skew comparison.
                 $dateHeader = $response->getHeaderLine('Date');
-                $reqtime = ($dateHeader !== '') ? strtotime($dateHeader) : time();
-                if ($reqtime === false || $reqtime === -1) {
-                    $reqtime = time();
-                }
+                $reqtime = ($dateHeader !== '') ? strtotime($dateHeader) : false;
+                $servedTime = ($reqtime !== false && $reqtime !== -1) ? $reqtime : null;
 
-                if ($reqtime < $mtime + 60) {
-                    // Clock skew too small — weak match not allowed with Range.
+                if (!\ZealPHP\HTTP\Response::ifRangeDateMatches($ifRange, $mtime, $servedTime)) {
+                    // Date differs, unparseable, or skew window not elapsed —
+                    // ignore the range and serve the full body.
                     return $response->withHeader('Accept-Ranges', 'bytes');
                 }
                 // Strong match: honour range.

--- a/src/ResponseMiddleware.php
+++ b/src/ResponseMiddleware.php
@@ -29,6 +29,26 @@ use function ZealPHP\access_log;
 class ResponseMiddleware implements MiddlewareInterface
 {
     /**
+     * Map a status-only int return (the universal return contract's
+     * `return <int>;` shape) to a PSR-7 response. Coerces out-of-range codes
+     * to 500 (Apache parity) and — crucially — routes any 4xx/5xx through
+     * `renderError()` so a registered custom error page fires. Shared by the
+     * raw and non-raw dispatch paths so both honour the contract identically
+     * (#259: raw routes previously emitted a bare empty-body status, skipping
+     * the error page).
+     */
+    private function statusOnlyResponse(int $rawStatus): ResponseInterface
+    {
+        $status = App::coerceStatusCode($rawStatus);
+        if ($status >= 400 && $status < 600) {
+            $app = App::instance();
+            assert($app !== null);
+            return $app->renderError($status);
+        }
+        return new Response('', $status);
+    }
+
+    /**
      * @param array<string, mixed> $route
      * @param array<string, mixed> $params
      */
@@ -110,21 +130,21 @@ class ResponseMiddleware implements MiddlewareInterface
             }
 
             if (is_int($object)) {
-                // Universal return contract: int = HTTP status. Coerce out-of-range
-                // to 500 + log warning so bugs surface instead of silently emitting
-                // bogus status codes (Apache-parity behavior).
-                $status = App::coerceStatusCode((int)$object);
-                $body = '';
+                // Universal return contract: int = HTTP status. Status-only
+                // returns route through the shared helper so a 4xx/5xx fires any
+                // registered custom error page — identical to the non-raw path
+                // (#259). Out-of-range codes coerce to 500 (Apache parity).
+                return $this->statusOnlyResponse((int)$object);
+            }
+
+            $status = $g->status ?? 200;
+            if (is_array($object) or is_object($object)) {
+                response_add_header('Content-Type', 'application/json');
+                $body = (string)json_encode($object);
+            } else if (is_string($object)) {
+                $body = $object;
             } else {
-                $status = $g->status ?? 200;
-                if (is_array($object) or is_object($object)) {
-                    response_add_header('Content-Type', 'application/json');
-                    $body = (string)json_encode($object);
-                } else if (is_string($object)) {
-                    $body = $object;
-                } else {
-                    $body = '';
-                }
+                $body = '';
             }
 
             if ($method === 'HEAD') {
@@ -325,18 +345,12 @@ class ResponseMiddleware implements MiddlewareInterface
 
             if (is_int($object)) {
                 ob_end_clean();
-                // Universal return contract: int = HTTP status. Coerce out-of-range
-                // (< 100 or >= 600) to 500 + log warning — Apache-parity behavior.
-                $istatus = App::coerceStatusCode((int)$object);
-                // Status-only returns from a handler (e.g. `return 404;`) route
-                // through renderError so any registered custom error page fires —
-                // Apache's `ErrorDocument` behavior for unhandled status codes.
-                if ($istatus >= 400 && $istatus < 600) {
-                    $app = App::instance();
-                    assert($app !== null);
-                    return $app->renderError($istatus);
-                }
-                return (new Response('', $istatus));
+                // Universal return contract: int = HTTP status. Status-only
+                // returns (e.g. `return 404;`) route through the shared helper so
+                // a 4xx/5xx fires any registered custom error page (Apache's
+                // `ErrorDocument`); out-of-range coerces to 500. Shared with the
+                // raw path so both honour the contract identically (#259).
+                return $this->statusOnlyResponse((int)$object);
             }
 
             $status = $g->status ?? 200;

--- a/src/Session/Handler/TableSessionHandler.php
+++ b/src/Session/Handler/TableSessionHandler.php
@@ -323,6 +323,30 @@ final class TableSessionHandler implements \SessionHandlerInterface
                 continue;
             }
             if (is_array($val) && is_array($baseVal) && is_array($remoteVal)) {
+                // #253 — list-shaped (sequential-int-keyed) sub-arrays are the
+                // idiomatic `$_SESSION['flash'][] = ...` append. Two concurrent
+                // appends both land at the SAME next integer index, so the
+                // key-aligned leaf recursion below would pick one and silently
+                // drop the other. Treat three lists as an APPEND-merge instead:
+                // keep all of remote's elements plus the elements local added on
+                // top of base (union of remote + local-new), so BOTH appends
+                // survive. Caveat: "local-new" is diffed by VALUE
+                // (`!in_array($v, $base, true)`), so a local append whose value
+                // already EXISTS in base is indistinguishable from base's copy
+                // and is NOT re-added on top of remote (no data loss across
+                // distinct values; only a value-equal-to-an-existing-element is
+                // affected). String-keyed maps fall through to the leaf-level
+                // recursion and keep their existing local-wins behaviour.
+                if (array_is_list($baseVal) && array_is_list($val) && array_is_list($remoteVal)) {
+                    $added = array_values(array_filter(
+                        $val,
+                        static fn($v): bool => !in_array($v, $baseVal, true)
+                    ));
+                    // array_merge of two lists is already 0-indexed — no outer
+                    // array_values() needed (it would be a no-op).
+                    $result[$key] = array_merge($remoteVal, $added);
+                    continue;
+                }
                 // All three are arrays — recurse for leaf-level merge.
                 $result[$key] = $this->merge3($baseVal, $val, $remoteVal);
                 continue;

--- a/src/WS/Room.php
+++ b/src/WS/Room.php
@@ -21,12 +21,14 @@ use ZealPHP\WS\CapacityException;
  *   - One PSUBSCRIBE per worker covers EVERY room (no per-room subscriber
  *     proliferation).
  *
- * Construct via `WSRouter::room('chat:42')` — don't `new` directly
- * (instances need WSRouter::init() to have wired the PSUBSCRIBE).
+ * Construct via `WSRouter::room('chat.42')` — don't `new` directly
+ * (instances need WSRouter::init() to have wired the PSUBSCRIBE). Room names
+ * must match `/^[A-Za-z0-9_.-]+$/` (no `:` — it would collide ws_room_members
+ * keys and the `ws:room:*` channel; #247).
  *
  * Usage:
  *
- *     $room = WSRouter::room('chat:42');
+ *     $room = WSRouter::room('chat.42');
  *     $room->join('alice');                            // SADD-equivalent + presence broadcast
  *     $room->push(['from' => 'alice', 'msg' => 'hi']); // fans out across cluster
  *     $room->size();                                   // cluster-wide member count
@@ -288,9 +290,17 @@ final class Room
         return Store::publish(WSRouter::roomChannelPrefix() . $this->name, $signed);
     }
 
-    /** Composite key shape used in the ws_room_members Store table. */
+    /**
+     * Composite key shape used in the ws_room_members Store table.
+     *
+     * #247 — length-prefix the room half so the key is an unambiguous function
+     * of the (room, client) pair even if a client id contains a `:`. The room
+     * name is already charset-validated (no `:`) at the WSRouter::room()
+     * chokepoint; prefixing its byte length here removes any residual ambiguity
+     * at the room↔client boundary (`5:chat:42:alice` can only decompose one way).
+     */
     private static function compositeKey(string $room, string $clientId): string
     {
-        return $room . ':' . $clientId;
+        return strlen($room) . ':' . $room . ':' . $clientId;
     }
 }

--- a/src/WSRouter.php
+++ b/src/WSRouter.php
@@ -147,9 +147,16 @@ final class WSRouter
 
     /**
      * Per-worker cache of locally-owned clients by room.
-     * `room → [client_id => true]`
+     * `room → [client_id => conn_id]`
      *
-     * @var array<string, array<string, true>>
+     * #246 — the value is the per-connection nonce (conn_id) captured from
+     * `$localFds[$clientId]` at join time, NOT a bare `true`. The room push
+     * loop re-checks it against the live `$localFds[$clientId]['conn_id']`
+     * before pushing, so a reused fd (client reconnected under a fresh nonce
+     * while a stale membership entry lingers) can't receive a prior owner's
+     * room message — mirroring the C1 guard on the identity-delivery path.
+     *
+     * @var array<string, array<string, string>>
      */
     private static array $localRoomMembership = [];
 
@@ -700,6 +707,20 @@ final class WSRouter
         if (self::$serverId === '') {
             throw new StoreException('WSRouter::init() must be called before WSRouter::room()');
         }
+        // #247 — the room name is woven into Store keys (ws_room_members rows,
+        // the per-room SET key) and the `ws:room:{name}` pub/sub channel. A `:`
+        // (or other separator) in the name would alias one room's keys/channel
+        // onto another's (compositeKey('chat:42','alice') === compositeKey(
+        // 'chat','42:alice')). Restrict to a strict charset at the single
+        // construction chokepoint so neither the keys NOR the PSUBSCRIBE pattern
+        // can collide. (compositeKey() is additionally length-prefixed for
+        // defence in depth on the client-id half.)
+        if (!preg_match('/^[A-Za-z0-9_.-]+$/', $name)) {
+            throw new StoreException(
+                "WSRouter::room(): invalid room name '{$name}' — must match /^[A-Za-z0-9_.-]+$/ " .
+                "(no ':' or other separators, which would collide ws_room_members keys / the ws:room:* channel)"
+            );
+        }
         return new Room($name, self::$serverId);
     }
 
@@ -957,8 +978,10 @@ final class WSRouter
                 if ($type === 'join') {
                     // Only cache clients THIS worker owns (they're the push
                     // targets); a join for a remote client isn't ours to hold.
+                    // #246 — capture the connection's conn_id alongside the
+                    // client id so the push loop can detect an fd-reuse drift.
                     if (isset(self::$localFds[$cid])) {
-                        self::$localRoomMembership[$roomName][$cid] = true;
+                        self::$localRoomMembership[$roomName][$cid] = self::$localFds[$cid]['conn_id'];
                     }
                 } else {
                     // Always evict on leave — unsetting a non-member is a
@@ -995,9 +1018,17 @@ final class WSRouter
         $server = App::getServer();
         if (!($server instanceof \OpenSwoole\WebSocket\Server)) { return; }
         $data = (string) json_encode($msg);
-        foreach (array_keys($localMembers) as $cid) {
+        foreach ($localMembers as $cid => $cachedConnId) {
             $local = self::$localFds[$cid] ?? null;
             if ($local === null) { continue; }
+            // #246 — re-validate connection identity before pushing. If the fd
+            // was reused (the cached client id now maps to a DIFFERENT live
+            // connection, i.e. a fresh conn_id), skip — the room message was
+            // destined for the disconnected owner, not the new client on the
+            // reused fd. Same guarantee as the identity-path C1 guard.
+            if ($cachedConnId !== '' && $local['conn_id'] !== $cachedConnId) {
+                continue;
+            }
             $fd = $local['fd'];
             // Each push runs in its own coroutine so a slow consumer's
             // back-pressure (TCP buffer full → push waits) can't block the
@@ -1059,7 +1090,7 @@ final class WSRouter
 
     /**
      * @internal — current per-worker local-room cache snapshot (for tests).
-     * @return array<string, array<string, true>>
+     * @return array<string, array<string, string>>
      */
     public static function localRoomMembership(): array { return self::$localRoomMembership; }
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -899,16 +899,25 @@ function access_log(int $status = 200, int $length = 0, ?float $durationSec = nu
 }
 
 /**
- * Append a header to the current response.
+ * Add a header to the current response.
  *
- * Delegates to `$g->zealphp_response->header()`. The `$ucwords` flag controls
- * whether the header name is title-cased before queuing (default `true`).
+ * Delegates to `$g->zealphp_response->header()`. The 3rd argument is the
+ * `$replace` flag (PHP `header()` semantics): `true` (default) drops prior
+ * same-name entries so this value wins; `false` is the APPEND form, keeping
+ * earlier same-name headers so multiple Link / WWW-Authenticate / CSP headers
+ * all reach the wire (#260).
+ *
+ * Note: the parameter was historically named `$ucwords` and passed as a DEAD
+ * 3rd argument to a 2-param method (silently ignored). It is repurposed here as
+ * `$replace` — every existing 2-arg call keeps the replace-by-default behaviour
+ * it already had on the wire, so this is BC.
  *
  * @param string $key     The header name.
  * @param string $value   The header value.
- * @param bool   $ucwords Whether to title-case the header name. Default `true`.
+ * @param bool   $replace Whether to replace a prior same-name header (default
+ *                        true). Pass false to append.
  */
-function response_add_header($key, $value, $ucwords = true): void
+function response_add_header($key, $value, $replace = true): void
 {
     $g = RequestContext::instance();
     // elog("response_add_header: $key ".var_export($value, true));
@@ -917,8 +926,7 @@ function response_add_header($key, $value, $ucwords = true): void
         // header has nowhere to go, so no-op instead of a null method call (#195).
         return;
     }
-    // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any request handler runs
-    $g->zealphp_response->header($key, $value, $ucwords);
+    $g->zealphp_response->header($key, $value, $replace);
 }
 
 /**
@@ -1091,16 +1099,11 @@ function header($header, $replace = true, $http_response_code = null) {
     }
     $name = trim($parts[0]);
     $value = trim($parts[1]);
-    if ($replace) {
-        $response = RequestContext::instance()->zealphp_response;
-        if ($response !== null) {
-            $response->headersList = array_values(array_filter(
-                $response->headersList,
-                static fn($pair) => strcasecmp($pair[0], $name) !== 0
-            ));
-        }
-    }
-    response_add_header($name, $value);
+    // Thread $replace through to the response wrapper, which owns the same-name
+    // dedup (replace=true → last wins) vs append (replace=false → both kept, and
+    // flush() groups appends into one array-valued OpenSwoole call so multiple
+    // same-name headers all reach the wire — #260).
+    response_add_header($name, $value, (bool)$replace);
     if ($http_response_code !== null && (int)$http_response_code > 0) {
         response_set_status((int)$http_response_code);
     }

--- a/tests/Unit/AppPipelineExtraTest.php
+++ b/tests/Unit/AppPipelineExtraTest.php
@@ -64,6 +64,10 @@ class AppPipelineExtraTest extends TestCase
         $app->route('/xtra/raw/str', ['raw' => true], fn() => 'raw-str');
         $app->route('/xtra/raw/arr', ['raw' => true], fn() => ['r' => true]);
         $app->route('/xtra/raw/int', ['raw' => true], fn() => 404);
+        // #259 — a raw route and a non-raw route both returning the same 4xx
+        // int, used to prove the error-page (renderError) behaviour is identical.
+        $app->route('/xtra/raw/err404', ['raw' => true], fn() => 404);
+        $app->route('/xtra/nonraw/err404', fn() => 404);
         $app->route('/xtra/raw/psr', ['raw' => true], fn() => new Response('raw-psr', 233));
         $app->route('/xtra/raw/gen', ['raw' => true], fn() => (function () {
             yield 'r1';
@@ -311,6 +315,36 @@ class AppPipelineExtraTest extends TestCase
     public function testRawRouteIntStatus(): void
     {
         $this->assertSame(404, $this->dispatch('/xtra/raw/int')->getStatusCode());
+    }
+
+    public function testRawRouteIntRoutesThroughCustomErrorPage(): void
+    {
+        // #259 — a `raw: true` route returning a 4xx int must fire the registered
+        // custom error page, exactly like a normal route (previously it emitted a
+        // bare empty-body status, skipping renderError).
+        $app = App::instance();
+        \assert($app !== null);
+        $app->setErrorHandler(404, fn($status) => "custom-$status-page");
+
+        $res = $this->dispatch('/xtra/raw/err404');
+        $this->assertSame(404, $res->getStatusCode());
+        $this->assertStringContainsString('custom-404-page', (string) $res->getBody());
+    }
+
+    public function testRawAndNonRawIntErrorPagesAreIdentical(): void
+    {
+        // #259 — the universal-return-contract guarantee: the SAME custom error
+        // page body for `return 404;` from a raw route AND a non-raw route.
+        $app = App::instance();
+        \assert($app !== null);
+        $app->setErrorHandler(404, fn($status) => "custom-$status-page");
+
+        $raw    = $this->dispatch('/xtra/raw/err404');
+        $nonRaw = $this->dispatch('/xtra/nonraw/err404');
+
+        $this->assertSame($nonRaw->getStatusCode(), $raw->getStatusCode());
+        $this->assertSame((string) $nonRaw->getBody(), (string) $raw->getBody());
+        $this->assertStringContainsString('custom-404-page', (string) $raw->getBody());
     }
 
     public function testRawRoutePsrReturnedDirectly(): void

--- a/tests/Unit/HTTP/FakeOpenSwooleResponse.php
+++ b/tests/Unit/HTTP/FakeOpenSwooleResponse.php
@@ -32,7 +32,15 @@ class FakeOpenSwooleResponse extends \OpenSwoole\Http\Response
         return true;
     }
 
-    public function header(string $key, string $value, bool $format = true): bool
+    /**
+     * The real ext-openswoole header() parses its value as a zval (Z_PARAM_ZVAL)
+     * and emits one wire line per element when given an array — the multi
+     * same-name-header mechanism (#260). Mirror that here: accept array|string
+     * and log accordingly so tests can assert the array form was used.
+     *
+     * @param array<int, string>|string $value
+     */
+    public function header(string $key, array|string $value, bool $format = true): bool
     {
         $this->log[] = ['header', $key, $value];
         return true;

--- a/tests/Unit/HTTP/ResponseMultiHeaderTest.php
+++ b/tests/Unit/HTTP/ResponseMultiHeaderTest.php
@@ -1,0 +1,177 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\HTTP;
+
+use ZealPHP\App;
+use ZealPHP\HTTP\Response as ZResponse;
+use ZealPHP\RequestContext;
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #260 — multiple same-name headers must survive on the wire.
+ *
+ * PHP's `header($value, $replace = false)` appends; calling it twice with the
+ * same field name emits TWO headers (multiple Link preload hints, multiple
+ * WWW-Authenticate challenges, CSP + CSP-Report-Only). The wrapper queues each
+ * append as a separate headersList entry, but the OLD flush()/redirect emit
+ * loop called OpenSwoole's scalar `header($name, $scalar)` once per entry —
+ * which OVERWRITES by name, collapsing everything to the LAST value.
+ *
+ * The fix groups queued headers by name and hands OpenSwoole an ARRAY value for
+ * any name with >1 value (the ext emits one wire line per array element — the
+ * same mechanism multiple Set-Cookie uses). These tests drive flush() (and the
+ * redirect inline-emit path) against the recording FakeOpenSwooleResponse and
+ * assert BOTH values reach the parent, single-value headers stay scalar, and
+ * first-seen name order is preserved.
+ */
+class ResponseMultiHeaderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        App::$cwd = ZEALPHP_ROOT;
+        App::superglobals(true);
+
+        $g = RequestContext::instance();
+        $g->status = null;
+        $g->_streaming = false;
+        $g->server = [];
+    }
+
+    protected function tearDown(): void
+    {
+        // redirect()/flush() mutate shared RequestContext state (_streaming,
+        // status, zealphp_response). Reset it so this class can't leak into the
+        // next test class in the same process (e.g. a left-on _streaming makes
+        // RangeMiddleware early-return).
+        $g = RequestContext::instance();
+        $g->status = null;
+        $g->_streaming = false;
+        $g->zealphp_response = null;
+        parent::tearDown();
+    }
+
+    private function fake(bool $writable = true): FakeOpenSwooleResponse
+    {
+        $f = new FakeOpenSwooleResponse();
+        $f->writable = $writable;
+        return $f;
+    }
+
+    private function wrap(FakeOpenSwooleResponse $fake): ZResponse
+    {
+        return new ZResponse($fake);
+    }
+
+    /** Pull every ['header', name, value] entry for $name out of the call log. */
+    private function headerCalls(FakeOpenSwooleResponse $fake, string $name): array
+    {
+        $out = [];
+        foreach ($fake->log as $entry) {
+            if (($entry[0] ?? null) === 'header' && ($entry[1] ?? null) === $name) {
+                $out[] = $entry[2];
+            }
+        }
+        return $out;
+    }
+
+    public function testTwoSameNameAppendsBothReachTheWireViaFlush(): void
+    {
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        // PHP append form (`$replace = false`): two Link values, SAME name.
+        $resp->header('Link', '</style.css>; rel=preload', false);
+        $resp->header('Link', '</app.js>; rel=preload', false);
+
+        $this->assertTrue($resp->flush());
+
+        // Both values must survive. The fix emits them as one header() call with
+        // an ARRAY value, so the recorded value is the array of both.
+        $linkCalls = $this->headerCalls($fake, 'Link');
+        $this->assertCount(1, $linkCalls, 'multi-value name emitted as one array call');
+        $this->assertSame(
+            ['</style.css>; rel=preload', '</app.js>; rel=preload'],
+            $linkCalls[0]
+        );
+    }
+
+    public function testSingleValueHeaderStaysScalar(): void
+    {
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->header('Content-Type', 'text/html');
+        $this->assertTrue($resp->flush());
+
+        $calls = $this->headerCalls($fake, 'Content-Type');
+        $this->assertSame(['text/html'], $calls, 'single value emitted as a scalar string');
+    }
+
+    public function testReplaceByDefaultLastWinsAsScalar(): void
+    {
+        // The DEFAULT (replace=true) must NOT array-up — setting Content-Type
+        // twice keeps only the last value, emitted as a single scalar (what
+        // sendFile()/middleware rely on, e.g. file-mime then multipart override).
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->header('Content-Type', 'text/plain');
+        $resp->header('Content-Type', 'application/json'); // replace default
+        $this->assertTrue($resp->flush());
+
+        $calls = $this->headerCalls($fake, 'Content-Type');
+        $this->assertSame(['application/json'], $calls, 'replace=true → last value only, scalar');
+    }
+
+    public function testThreeWayMixIsGroupedAndOrderPreserved(): void
+    {
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        // Interleave a repeated (appended) name with single-value names.
+        $resp->header('X-Demo', 'alpha', false);
+        $resp->header('Content-Type', 'application/json');
+        $resp->header('X-Demo', 'beta', false);
+
+        $this->assertTrue($resp->flush());
+
+        // X-Demo appears once, as an array of both values, first-seen order kept.
+        $demo = $this->headerCalls($fake, 'X-Demo');
+        $this->assertCount(1, $demo);
+        $this->assertSame(['alpha', 'beta'], $demo[0]);
+
+        // Content-Type stays a scalar.
+        $this->assertSame(['application/json'], $this->headerCalls($fake, 'Content-Type'));
+
+        // First-seen NAME order is X-Demo then Content-Type.
+        $names = [];
+        foreach ($fake->log as $entry) {
+            if (($entry[0] ?? null) === 'header') {
+                $names[] = $entry[1];
+            }
+        }
+        $this->assertSame(['X-Demo', 'Content-Type'], $names);
+    }
+
+    public function testRedirectInlinePathPreservesMultiHeaders(): void
+    {
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        // Queue two same-name appends, THEN redirect — the redirect inline-emit
+        // path must group them too, not just flush().
+        $resp->header('Link', '</a.css>; rel=preload', false);
+        $resp->header('Link', '</b.js>; rel=preload', false);
+        $resp->redirect('/login', 302);
+
+        $link = $this->headerCalls($fake, 'Link');
+        $this->assertCount(1, $link, 'redirect path emits multi-value name as one array call');
+        $this->assertSame(['</a.css>; rel=preload', '</b.js>; rel=preload'], $link[0]);
+
+        // The Location header (single value) is still scalar on the redirect.
+        $this->assertSame(['/login'], $this->headerCalls($fake, 'Location'));
+        $this->assertContains(['status', 302, 'Found'], $fake->log);
+    }
+}

--- a/tests/Unit/HTTP/ResponseTest.php
+++ b/tests/Unit/HTTP/ResponseTest.php
@@ -636,7 +636,15 @@ class ResponseTest extends TestCase
     public function testSendFileIfRangeDateMatchHonoursRange(): void
     {
         $path = $this->makeTempFile(str_repeat('m', 100), 'bin');
-        $mtime = (int) filemtime($path);
+        // #258 — the shared strong-validation rule (Apache 60 s clock-skew) only
+        // HONOURS a date If-Range once the file is ≥ 60 s old (a younger
+        // Last-Modified is a weak validator). Backdate the file so the matching
+        // date is a STRONG match → range honoured (206). (Pre-#258 sendFile used
+        // exact-second and would 206 even on a brand-new file; that divergence
+        // from RangeMiddleware is exactly what this fix closes.)
+        $mtime = time() - 120;
+        touch($path, $mtime);
+        clearstatcache(true, $path);
         $this->setRequestHeaders([
             'range'    => 'bytes=0-9',
             'if-range' => gmdate('D, d M Y H:i:s', $mtime) . ' GMT',
@@ -646,7 +654,7 @@ class ResponseTest extends TestCase
 
         $resp->sendFile($path);
 
-        // Validator matches → range honoured (206 slice).
+        // Validator matches AND skew window elapsed → range honoured (206 slice).
         $this->assertContains(['status', 206, ''], $fake->log);
         $this->assertContains(['sendfile', $path, 0, 10], $fake->log);
     }

--- a/tests/Unit/IfRangeDateParityTest.php
+++ b/tests/Unit/IfRangeDateParityTest.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use OpenSwoole\Core\Psr\Response;
+use OpenSwoole\Core\Psr\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use ZealPHP\App;
+use ZealPHP\HTTP\Response as ZResponse;
+use ZealPHP\Middleware\RangeMiddleware;
+use ZealPHP\RequestContext;
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #258 — date-form If-Range must be evaluated identically by BOTH range paths.
+ *
+ * The buffered RangeMiddleware path and the zero-copy Response::sendFile()
+ * (ifRangeMatches) path previously disagreed: the middleware used Apache's 60 s
+ * clock-skew rule, sendFile used exact-second. Same request → 206 on one path,
+ * 200 on the other. The fix factors a single shared strong-validation helper
+ * (Response::ifRangeDateMatches, the 60 s skew rule per RFC 9110 §13.1.5) and
+ * calls it from both. These tests pin the shared helper across the matrix AND
+ * assert the two paths now agree on identical (ifRange, lastModified, mtime,
+ * reqTime) tuples.
+ */
+class IfRangeDateParityTest extends TestCase
+{
+    private const BODY = 'Hello, World! This is test content for range requests.';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        App::$cwd = ZEALPHP_ROOT;
+        App::superglobals(true);
+        // RangeMiddleware early-returns when $g->_streaming is truthy — make sure
+        // a prior test class didn't leave it set, else the matrix parity check
+        // sees a spurious 200.
+        $g = RequestContext::instance();
+        $g->_streaming = false;
+        $g->status = null;
+    }
+
+    protected function tearDown(): void
+    {
+        $g = RequestContext::instance();
+        $g->_streaming = false;
+        $g->status = null;
+        $g->zealphp_response = null;
+        parent::tearDown();
+    }
+
+    // ── Shared helper: the four canonical cases ───────────────────────────
+
+    public function testHelperMatchBeyond60sHonours(): void
+    {
+        $mtime = time() - 120;                 // file modified 2 min ago
+        $ifRange = gmdate('D, d M Y H:i:s', $mtime) . ' GMT';
+        // Served "now" → 120 s skew ≥ 60 → strong match → honour.
+        $this->assertTrue(ZResponse::ifRangeDateMatches($ifRange, $mtime, time()));
+    }
+
+    public function testHelperMatchWithin60sIgnores(): void
+    {
+        $mtime = time() - 10;                  // file modified 10 s ago
+        $ifRange = gmdate('D, d M Y H:i:s', $mtime) . ' GMT';
+        // Served "now" → only 10 s skew < 60 → weak → ignore (the divergence).
+        $this->assertFalse(ZResponse::ifRangeDateMatches($ifRange, $mtime, time()));
+    }
+
+    public function testHelperDatesDifferIgnores(): void
+    {
+        $mtime = time() - 120;
+        $ifRange = gmdate('D, d M Y H:i:s', $mtime - 5) . ' GMT'; // 5 s off mtime
+        $this->assertFalse(ZResponse::ifRangeDateMatches($ifRange, $mtime, time()));
+    }
+
+    public function testHelperUnparseableIgnores(): void
+    {
+        $mtime = time() - 120;
+        $this->assertFalse(ZResponse::ifRangeDateMatches('not-a-date', $mtime, time()));
+    }
+
+    public function testHelperNullReqTimeUsesWallClock(): void
+    {
+        // sendFile passes reqTime = null → helper falls back to now().
+        $mtime = time() - 120;
+        $ifRange = gmdate('D, d M Y H:i:s', $mtime) . ' GMT';
+        $this->assertTrue(ZResponse::ifRangeDateMatches($ifRange, $mtime, null));
+    }
+
+    // ── sendFile's private ifRangeMatches delegates to the shared helper ───
+
+    public function testSendFilePrivateMatcherDelegatesToSharedHelper(): void
+    {
+        // Drive the private ifRangeMatches() via reflection with a date-form
+        // If-Range and confirm it now follows the 60 s skew rule (a fresh file,
+        // < 60 s, is NOT honoured — proving it no longer uses exact-second).
+        $fake = new \ZealPHP\Tests\Unit\HTTP\FakeOpenSwooleResponse();
+        $resp = new ZResponse($fake);
+        $ref = new \ReflectionMethod(ZResponse::class, 'ifRangeMatches');
+
+        $freshMtime = time() - 10;
+        $ifRangeFresh = gmdate('D, d M Y H:i:s', $freshMtime) . ' GMT';
+        $etag = 'W/"deadbeef-10"';
+        $this->assertFalse(
+            (bool) $ref->invoke($resp, $ifRangeFresh, $etag, $freshMtime),
+            'fresh (<60s) date If-Range must be ignored — 60s skew rule, not exact-second'
+        );
+
+        $oldMtime = time() - 300;
+        $ifRangeOld = gmdate('D, d M Y H:i:s', $oldMtime) . ' GMT';
+        $this->assertTrue(
+            (bool) $ref->invoke($resp, $ifRangeOld, $etag, $oldMtime),
+            'old (>60s) matching date If-Range must be honoured'
+        );
+    }
+
+    // ── Cross-path parity: middleware result == shared-helper verdict ──────
+
+    /**
+     * Run RangeMiddleware with explicit Last-Modified + Date response headers
+     * and a date-form If-Range. Returns the resulting status (206 = honoured,
+     * 200 = ignored).
+     */
+    private function middlewareStatus(string $ifRange, int $mtime, int $reqTime): int
+    {
+        $lastModified = gmdate('D, d M Y H:i:s', $mtime) . ' GMT';
+        $dateHeader   = gmdate('D, d M Y H:i:s', $reqTime) . ' GMT';
+
+        $request = new ServerRequest('/', 'GET', '', [
+            'range'    => 'bytes=0-4',
+            'if-range' => $ifRange,
+        ]);
+        $handler = new class($lastModified, $dateHeader) implements RequestHandlerInterface {
+            public function __construct(private string $lastModified, private string $dateHeader) {}
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(IfRangeDateParityTest::body(), 200, '', [
+                    'Content-Type'  => 'text/plain',
+                    'Last-Modified' => $this->lastModified,
+                    'Date'          => $this->dateHeader,
+                ]);
+            }
+        };
+
+        $g = RequestContext::instance();
+        $prev = $g->zealphp_response;
+        $g->zealphp_response = new class {
+            public function header(string $name, string $value): void {}
+        };
+        try {
+            $response = (new RangeMiddleware())->process($request, $handler);
+        } finally {
+            $g->zealphp_response = $prev;
+        }
+        return $response->getStatusCode();
+    }
+
+    public static function body(): string
+    {
+        return self::BODY;
+    }
+
+    public function testMiddlewareAndHelperAgreeAcrossMatrix(): void
+    {
+        $now = time();
+        $cases = [
+            // [label, mtime, ifRangeOffsetFromMtime, reqTime]
+            'match beyond 60s' => [$now - 120, 0,  $now],
+            'match within 60s' => [$now - 10,  0,  $now],
+            'dates differ'     => [$now - 120, -5, $now],
+        ];
+
+        foreach ($cases as $label => [$mtime, $ifOffset, $reqTime]) {
+            $ifRange = gmdate('D, d M Y H:i:s', $mtime + $ifOffset) . ' GMT';
+
+            $helperHonours = ZResponse::ifRangeDateMatches($ifRange, $mtime, $reqTime);
+            $mwStatus      = $this->middlewareStatus($ifRange, $mtime, $reqTime);
+            $mwHonours     = ($mwStatus === 206);
+
+            $this->assertSame(
+                $helperHonours,
+                $mwHonours,
+                "Path divergence on '{$label}': shared helper "
+                . ($helperHonours ? 'HONOURS' : 'IGNORES')
+                . " but RangeMiddleware returned {$mwStatus}"
+            );
+        }
+    }
+}

--- a/tests/Unit/Session/TableSessionMergeTest.php
+++ b/tests/Unit/Session/TableSessionMergeTest.php
@@ -6,6 +6,7 @@ namespace ZealPHP\Tests\Unit\Session;
 
 use PHPUnit\Framework\TestCase;
 use ZealPHP\Session\Handler\RedisSessionHandler;
+use ZealPHP\Session\Handler\TableSessionHandler;
 
 /**
  * 3-way merge correctness — the property that closes the Deep_Ad1959
@@ -109,5 +110,102 @@ final class TableSessionMergeTest extends TestCase
     {
         $this->assertSame([], RedisSessionHandler::parseSession(''));
         $this->assertSame('', RedisSessionHandler::serializeSession([]));
+    }
+
+    // ── #253: TableSessionHandler::merge3() list-append union ──────────────
+    //
+    // merge3() diffs on array KEYS. The idiomatic `$_SESSION['flash'][] = 'x'`
+    // append writes the next integer index, so two concurrent appends both land
+    // at index 0 — the old key-aligned local-wins dropped one. The fix detects
+    // three list-shaped sub-arrays and merges them by VALUE union (remote +
+    // local-new) so both appends survive. These run against the real instance
+    // method (newInstanceWithoutConstructor — merge3 touches no state).
+
+    private function tableHandler(): TableSessionHandler
+    {
+        /** @var TableSessionHandler $h */
+        $h = (new \ReflectionClass(TableSessionHandler::class))->newInstanceWithoutConstructor();
+        return $h;
+    }
+
+    public function testConcurrentFlashAppendsBothSurvive(): void
+    {
+        $h = $this->tableHandler();
+        // base flash empty; A appended msgA, B appended msgB concurrently.
+        $merged = $h->merge3(
+            ['flash' => []],
+            ['flash' => ['msgA']],
+            ['flash' => ['msgB']]
+        );
+        // Both appends present — remote first (already committed), then local-new.
+        $this->assertSame(['flash' => ['msgB', 'msgA']], $merged);
+    }
+
+    public function testListAppendOntoExistingElementsUnions(): void
+    {
+        $h = $this->tableHandler();
+        // base already has one element; A and B each append a different one.
+        $merged = $h->merge3(
+            ['queue' => ['a']],
+            ['queue' => ['a', 'b']],   // local added b
+            ['queue' => ['a', 'c']]    // remote added c
+        );
+        $this->assertSame(['queue' => ['a', 'c', 'b']], $merged);
+    }
+
+    public function testListMergeReindexesSequentially(): void
+    {
+        $h = $this->tableHandler();
+        $merged = $h->merge3(
+            ['flash' => []],
+            ['flash' => ['only-local']],
+            ['flash' => ['remote-1', 'remote-2']]
+        );
+        $this->assertSame(['flash' => ['remote-1', 'remote-2', 'only-local']], $merged);
+        // Result is a clean 0-indexed list.
+        $this->assertSame([0, 1, 2], array_keys($merged['flash']));
+    }
+
+    public function testStringKeyedMapKeepsLeafLocalWins(): void
+    {
+        // The map case (string keys) must NOT use the list-union path — it keeps
+        // the documented leaf-level local-wins behaviour.
+        $h = $this->tableHandler();
+        $merged = $h->merge3(
+            ['cart' => ['item1' => 5]],
+            ['cart' => ['item1' => 5, 'item2' => 3]],   // local adds item2
+            ['cart' => ['item1' => 5, 'item3' => 7]]    // remote adds item3
+        );
+        $this->assertSame(['cart' => ['item1' => 5, 'item3' => 7, 'item2' => 3]], $merged);
+    }
+
+    public function testMapDeleteDetectionUnchanged(): void
+    {
+        // Deletion of a string key with remote unchanged still drops it.
+        $h = $this->tableHandler();
+        $merged = $h->merge3(
+            ['flag' => true, 'keep' => 1],
+            ['keep' => 1],                 // local deleted flag
+            ['flag' => true, 'keep' => 1]  // remote still has base value
+        );
+        $this->assertSame(['keep' => 1], $merged);
+    }
+
+    public function testValueDiffCaveatAppendEqualToBaseIsTreatedAsUnchanged(): void
+    {
+        // Documented caveat: the union diffs by VALUE (`!in_array($v, $base)`),
+        // so if local's appended value already EXISTS in base, the diff cannot
+        // tell it apart from base's copy and treats it as "not new" — the local
+        // append is not added on top of remote. (Two distinct values never
+        // collide; only a value-equal-to-an-existing-element does.)
+        $h = $this->tableHandler();
+        $merged = $h->merge3(
+            ['tags' => ['x']],
+            ['tags' => ['x', 'x']],   // local appended a SECOND 'x'
+            ['tags' => ['x', 'y']]    // remote appended 'y'
+        );
+        // The second 'x' is indistinguishable from base's 'x' → not re-added;
+        // remote's 'y' survives. No data is lost across distinct values.
+        $this->assertSame(['tags' => ['x', 'y']], $merged);
     }
 }

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -53,7 +53,20 @@ class UtilsTest extends TestCase
             public array $headersList = [];
             /** @var array<int, array<int, mixed>> */
             public array $cookies = [];
-            public function header(string $k, string $v, bool $ucwords = true): void { $this->headersList[] = [$k, $v]; }
+            // Mirrors the real ZealPHP\HTTP\Response::header() $replace contract
+            // (#260): replace=true drops prior same-name entries; replace=false
+            // appends. The uopz header() override now threads $replace here
+            // rather than filtering the list itself.
+            public function header(string $k, string $v, bool $replace = true): void
+            {
+                if ($replace) {
+                    $this->headersList = array_values(array_filter(
+                        $this->headersList,
+                        static fn(array $p): bool => strcasecmp($p[0], $k) !== 0
+                    ));
+                }
+                $this->headersList[] = [$k, $v];
+            }
             public function cookie(mixed ...$args): void { $this->cookies[] = $args; }
             public function rawCookie(mixed ...$args): void { $this->cookies[] = $args; }
         };
@@ -209,6 +222,18 @@ class UtilsTest extends TestCase
         $matches = array_filter(response_headers_list(), fn($p) => $p[0] === 'X-Dup');
         $this->assertCount(1, $matches);
         $this->assertSame('second', array_values($matches)[0][1]);
+    }
+
+    public function testHeaderAppendKeepsBoth(): void
+    {
+        // #260 — the append form (`header($h, false)`) must keep BOTH same-name
+        // entries in the queue, so flush() can emit them as multiple wire lines.
+        header('Link: </a.css>; rel=preload', false);
+        header('Link: </b.js>; rel=preload', false);
+        $matches = array_values(array_filter(response_headers_list(), fn($p) => $p[0] === 'Link'));
+        $this->assertCount(2, $matches);
+        $this->assertSame('</a.css>; rel=preload', $matches[0][1]);
+        $this->assertSame('</b.js>; rel=preload', $matches[1][1]);
     }
 
     public function testHttpResponseCodeGetAndSet(): void

--- a/tests/Unit/WS/RoomAccessorsTest.php
+++ b/tests/Unit/WS/RoomAccessorsTest.php
@@ -34,8 +34,10 @@ final class RoomAccessorsTest extends RedisTestCase
 
     public function testNameReturnsConstructedRoomName(): void
     {
-        $r = WSRouter::room('chat:42');
-        $this->assertSame('chat:42', $r->name());
+        // #247 — room names are charset-validated (no ':' which would collide
+        // ws_room_members keys / the ws:room:* channel). Use the dotted form.
+        $r = WSRouter::room('chat.42');
+        $this->assertSame('chat.42', $r->name());
     }
 
     public function testIsMemberFalseForUnjoinedClient(): void

--- a/tests/Unit/WS/RoomKeyAndConnIdTest.php
+++ b/tests/Unit/WS/RoomKeyAndConnIdTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\WS;
+
+use OpenSwoole\Coroutine;
+use PHPUnit\Framework\TestCase;
+use ZealPHP\Store;
+use ZealPHP\Store\StoreException;
+use ZealPHP\WSRouter;
+use ZealPHP\WS\Room;
+
+/**
+ * #246 (room fan-out conn_id fd-reuse guard) + #247 (room-name / compositeKey
+ * collision). Both need the Redis backend (rooms use cluster-wide membership +
+ * pub/sub); skipped if Valkey on :16379 isn't reachable.
+ */
+final class RoomKeyAndConnIdTest extends TestCase
+{
+    private string $url;
+
+    protected function setUp(): void
+    {
+        $url = (string) getenv('ZEALPHP_REDIS_URL');
+        $this->url = $url !== '' ? $url : 'redis://127.0.0.1:16379/0';
+        Store::defaultBackend(Store::BACKEND_REDIS, $this->url);
+        WSRouter::reset();
+        $this->skipIfNoRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        WSRouter::reset();
+        Store::defaultBackend(Store::BACKEND_TABLE);
+    }
+
+    private function skipIfNoRedis(): void
+    {
+        try {
+            $c = new \Predis\Client($this->url);
+            $c->ping();
+            $c->disconnect();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('Redis/Valkey not available: ' . $e->getMessage());
+        }
+    }
+
+    // ── #247: room-name validation rejects separator-bearing names ─────────
+
+    public function testRoomNameWithColonIsRejected(): void
+    {
+        Coroutine::run(function (): void {
+            WSRouter::init('test-server');
+            $threw = false;
+            try {
+                WSRouter::room('chat:42');
+            } catch (StoreException $e) {
+                $threw = true;
+                self::assertStringContainsString('invalid room name', $e->getMessage());
+            }
+            self::assertTrue($threw, "room('chat:42') must be rejected (':' collides keys/channel)");
+        });
+    }
+
+    public function testRoomNameWithOtherSeparatorsRejected(): void
+    {
+        Coroutine::run(function (): void {
+            WSRouter::init('test-server');
+            foreach (['a b', 'a/b', 'a:b', 'a*b', "a\nb", ''] as $bad) {
+                $threw = false;
+                try {
+                    WSRouter::room($bad);
+                } catch (StoreException) {
+                    $threw = true;
+                }
+                self::assertTrue($threw, "room('{$bad}') must be rejected");
+            }
+        });
+    }
+
+    public function testValidRoomNamesAccepted(): void
+    {
+        Coroutine::run(function (): void {
+            WSRouter::init('test-server');
+            foreach (['chat42', 'chat-42', 'chat_42', 'chat.42', 'Room-1.2_3'] as $ok) {
+                $room = WSRouter::room($ok);
+                self::assertSame($ok, $room->name());
+            }
+        });
+    }
+
+    public function testCompositeKeyDisambiguatesAmbiguousPairs(): void
+    {
+        // The original collision: compositeKey('chat:42','alice') ===
+        // compositeKey('chat','42:alice'). The length-prefix makes the key an
+        // unambiguous function of the pair. (Reflected because compositeKey is
+        // private — the room name itself is now charset-validated upstream, but
+        // the prefix defends the client-id half too.)
+        $ref = new \ReflectionMethod(Room::class, 'compositeKey');
+
+        $a = (string) $ref->invoke(null, 'chat:42', 'alice');
+        $b = (string) $ref->invoke(null, 'chat', '42:alice');
+        self::assertNotSame($a, $b, 'length-prefixed composite keys must differ');
+
+        // And the same pair is still stable.
+        $a2 = (string) $ref->invoke(null, 'chat:42', 'alice');
+        self::assertSame($a, $a2);
+    }
+
+    // ── #246: room push cache captures conn_id; fd-reuse drift is detectable ─
+
+    public function testJoinCachesConnIdNotBareTrue(): void
+    {
+        Coroutine::run(function (): void {
+            $roomName = 'r-' . bin2hex(random_bytes(3));
+            WSRouter::init('test-server');
+
+            // Own alice with an explicit nonce, then deliver her join event.
+            WSRouter::own('alice', 5, 'connAAA');
+            WSRouter::handleRoomMessage('ws:room:' . $roomName, (string) json_encode([
+                'type'      => 'join',
+                'client_id' => 'alice',
+                'ts'        => 1,
+            ]));
+
+            $cache = WSRouter::localRoomMembership();
+            self::assertArrayHasKey($roomName, $cache);
+            self::assertArrayHasKey('alice', $cache[$roomName]);
+            // The value is the captured conn_id (#246), not a bare `true`.
+            self::assertSame('connAAA', $cache[$roomName]['alice']);
+        });
+    }
+
+    public function testFdReuseProducesConnIdDriftTheGuardCatches(): void
+    {
+        Coroutine::run(function (): void {
+            $roomName = 'r-' . bin2hex(random_bytes(3));
+            WSRouter::init('test-server');
+
+            // alice joins on fd 5 / connAAA → cached as connAAA.
+            WSRouter::own('alice', 5, 'connAAA');
+            WSRouter::handleRoomMessage('ws:room:' . $roomName, (string) json_encode([
+                'type'      => 'join',
+                'client_id' => 'alice',
+                'ts'        => 1,
+            ]));
+            self::assertSame('connAAA', WSRouter::localRoomMembership()[$roomName]['alice']);
+
+            // alice's onClose was lost; the SAME fd 5 is reassigned to a fresh
+            // connection that reuses the client id but gets a NEW nonce. The
+            // membership cache still holds the STALE connAAA (no new join event
+            // fired for it yet) while localFds now maps to connBBB.
+            WSRouter::own('alice', 5, 'connBBB');
+
+            $cachedConnId = WSRouter::localRoomMembership()[$roomName]['alice'];
+            $liveConnId   = WSRouter::localFds()['alice']['conn_id'];
+
+            self::assertSame('connAAA', $cachedConnId, 'cache holds the stale nonce');
+            self::assertSame('connBBB', $liveConnId, 'live fd holds the fresh nonce');
+
+            // This is exactly the guard condition in the room push loop:
+            //   $cachedConnId !== '' && $local['conn_id'] !== $cachedConnId  → skip
+            // so the stale-destined room message is NOT pushed to the new client.
+            self::assertTrue(
+                $cachedConnId !== '' && $liveConnId !== $cachedConnId,
+                'conn_id drift must be detectable so the room push skips the reused fd'
+            );
+        });
+    }
+
+    public function testMatchingConnIdDoesNotDrift(): void
+    {
+        Coroutine::run(function (): void {
+            $roomName = 'r-' . bin2hex(random_bytes(3));
+            WSRouter::init('test-server');
+
+            WSRouter::own('bob', 9, 'connBOB');
+            WSRouter::handleRoomMessage('ws:room:' . $roomName, (string) json_encode([
+                'type'      => 'join',
+                'client_id' => 'bob',
+                'ts'        => 1,
+            ]));
+
+            $cachedConnId = WSRouter::localRoomMembership()[$roomName]['bob'];
+            $liveConnId   = WSRouter::localFds()['bob']['conn_id'];
+
+            // No reuse → cached === live → the guard does NOT skip (push proceeds).
+            self::assertSame($cachedConnId, $liveConnId);
+            self::assertFalse($cachedConnId !== '' && $liveConnId !== $cachedConnId);
+        });
+    }
+}


### PR DESCRIPTION
Six verified HTTP/WS correctness fixes from @Guruprasanth-M's audit. Each was reproduced against `master` before fixing, and confirmed VALID. Scope was confined to the response + WebSocket-room paths (no `App.php`, `Store/*`, or `CGI/*` changes).

## Fixes

| # | Sev | Issue | Root cause | Fix |
|---|-----|-------|-----------|-----|
| [#260](https://github.com/sibidharan/zealphp/issues/260) | MEDIUM | `header($h, false)` append collapses to the LAST same-name header on the wire | `flush()` + the redirect inline-emit call OpenSwoole's **scalar** `header($name, $scalar)` once per queued entry, which overwrites by name — only the last `Link`/`WWW-Authenticate`/CSP value survives | Group `headersList` by name (first-seen order kept) and pass OpenSwoole an **array** value for any name with >1 value (the ext emits one wire line per element — the multi-`Set-Cookie` mechanism). `Response::header()` now honours the PHP-native `$replace` flag so only genuine appends array-up; dropped the dead `$ucwords` arg on `response_add_header()` (repurposed as `$replace`, BC) |
| [#246](https://github.com/sibidharan/zealphp/issues/246) | LOW | WS room fan-out push skips the C1 `conn_id` fd-reuse guard | The room push loop looked up `$localFds[$cid]` but used only `['fd']`, never the `conn_id` the identity path checks | Cache the `conn_id` at join (`room → [client_id => conn_id]`, was `=> true`); drop a member whose live `conn_id` drifted from the cached one before pushing |
| [#247](https://github.com/sibidharan/zealphp/issues/247) | LOW-MED | `Room::compositeKey()` colon concat → cross-room key collision | `compositeKey('chat:42','alice') === compositeKey('chat','42:alice')` aliases `ws_room_members` rows + the `ws:room:*` channel | Validate room names at the single `WSRouter::room()` chokepoint (`/^[A-Za-z0-9_.-]+$/`, reject `:`) — also fixes the channel collision; length-prefix `compositeKey()` for defence in depth |
| [#253](https://github.com/sibidharan/zealphp/issues/253) | LOW | `TableSessionHandler::merge3()` drops concurrent list appends | Two coroutines doing `$_SESSION['flash'][] = …` both write index `0`; the key-aligned merge picks one | List-shaped sub-arrays (all three lists) now merge by **value union** (remote + local-new); string-keyed maps keep the existing leaf-level local-wins |
| [#258](https://github.com/sibidharan/zealphp/issues/258) | LOW | If-Range date semantics diverge between paths | `RangeMiddleware` used Apache's 60s clock-skew rule; `sendFile()` used exact-second → same request 206 vs 200 | One shared helper `Response::ifRangeDateMatches()` (the conservative 60s-skew rule, RFC 9110 §13.1.5) called from both paths |
| [#259](https://github.com/sibidharan/zealphp/issues/259) | LOW | `raw: true` routes skip the error page on `return <int 4xx/5xx>` | `dispatchRawRoute`'s int path emitted a bare empty-body status; the non-raw path called `renderError()` | Factor the int→response mapping into a shared `ResponseMiddleware::statusOnlyResponse()` both dispatch paths call (DRY) |

## Files changed (per issue)

- **#260** — `src/HTTP/Response.php` (`header()` `$replace` + `emitQueuedHeaders()`/`emitMultiHeader()`, `flush()`, `redirect()`), `src/utils.php` (`header()` override + `response_add_header()`)
- **#246** — `src/WSRouter.php` (`$localRoomMembership` value type, join capture, push-loop guard, accessor docblock)
- **#247** — `src/WSRouter.php` (`room()` validation), `src/WS/Room.php` (`compositeKey()` length-prefix + docblock)
- **#253** — `src/Session/Handler/TableSessionHandler.php` (`merge3()` list-union branch)
- **#258** — `src/HTTP/Response.php` (`ifRangeDateMatches()` + `ifRangeMatches()`), `src/Middleware/RangeMiddleware.php` (delegates to the shared helper)
- **#259** — `src/ResponseMiddleware.php` (`statusOnlyResponse()`, both int paths)

## PHPStan

The array-value `header()` call (#260) is a genuine **ext-vs-stub mismatch**: ext-openswoole 26.x parses the value via `Z_PARAM_ZVAL` and emits array values as multiple headers, but the `openswoole/ide-helper` stub types the param `string`. Added a scoped `phpstan.neon` `ignoreErrors` entry alongside the 5 existing OpenSwoole stub-mismatch entries (not an inline `@phpstan-ignore`). All 7 changed source files are **level-10 clean**; the 6 pre-existing `App.php`/`SessionManager` errors are unchanged (verified by stashing).

## Tests

New: `tests/Unit/HTTP/ResponseMultiHeaderTest.php` (#260 — both values reach the wire via flush() and the redirect path; replace-vs-append), `tests/Unit/IfRangeDateParityTest.php` (#258 — shared helper matrix + cross-path parity), `tests/Unit/WS/RoomKeyAndConnIdTest.php` (#246/#247 — name validation, key disambiguation, conn_id drift). Extended `TableSessionMergeTest` (#253 list-append union) and `AppPipelineExtraTest` (#259 raw/non-raw error-page parity). `FakeOpenSwooleResponse::header()` now accepts `array|string` to mirror the ext.

Existing HTTP / WS / Session / RangeMiddleware / ResponseMiddleware suites pass green when run per-directory (the natural CI grouping). Note: a **pre-existing** `RangeMiddlewareTest` test-isolation gap (no `_streaming` reset in its setUp) makes it fail only when `AppPipelineExtraTest` precedes it in the same ad-hoc process run — reproduces identically on `master`, untouched here.