### PR TITLE
fix: session.use_strict_mode parity to close session fixation (#244)

### DIFF
--- a/docs/middleware-and-authentication.md
+++ b/docs/middleware-and-authentication.md
@@ -525,6 +525,24 @@ $post = function () {
 
 All three hooks default to `null` (fail-closed): without `App::authChecker()`, `isAuthenticated()` returns `false` and `requirePostAuth()` rejects every request. See `template/pages/api.php` on the live site for the full auth-hooks reference.
 
+## Session Fixation Defence (#244)
+
+Session fixation has two halves, and ZealPHP closes both:
+
+1. **Planting an id — handled by the framework.** `App::$session_strict_mode` (default **on**, security-first) gives `session.use_strict_mode=1` parity: a client-supplied `PHPSESSID` (cookie or query param) whose backing store loads an **empty** session is treated as unrecognised — both session managers mint a fresh server-generated id and switch the client to it. So an attacker can't pre-plant a known id and have it promoted to the victim's authenticated session. A well-formed id that resolves to a **non-empty** stored session is preserved unchanged. Opt out (e.g. multi-node without shared/sticky session storage — see the caveat below) with `App::sessionStrictMode(false)`.
+
+2. **Reusing a pre-auth id — your responsibility, one call.** The framework can't know when *your* app changes a privilege level, so on **login / logout / role change** call `session_regenerate_id(true)` (the framework's coroutine-safe override — deletes the old session and emits a fresh `Set-Cookie`):
+
+   ```php
+   // After verifying credentials, BEFORE writing the authenticated identity:
+   session_regenerate_id(true);
+   $_SESSION['user_id'] = $user->id;   // or G::instance()->session['user_id'] in coroutine mode
+   ```
+
+   Strict mode blocks *planting* an id; regenerate-on-auth blocks *reusing* a pre-auth id. Use both.
+
+> **Multi-node caveat.** The empty-session signal is only meaningful when the id's store is visible to the node serving the request — single-node (`TableSessionHandler`, the coroutine-mode default) or shared `Redis`/`Tiered`-backed sessions. A multi-node deployment using the per-server `TableSessionHandler` **without** sticky load-balancing or shared storage is already broken (sessions don't persist cross-node); with strict mode on it will also rotate the id on every cross-node hop. Such setups should use Redis-backed sessions or `App::sessionStrictMode(false)`.
+
 ## Future Directions
 
 `standards-and-roadmap.md` tracks planned improvements such as:

--- a/src/App.php
+++ b/src/App.php
@@ -894,6 +894,12 @@ class App
      * fail-closed values (`false`, `false`, `null`). See the issue #13
      * discussion and `/learn/api` for usage.
      *
+     * SECURITY (#244): on any privilege change (login / logout / role change)
+     * call `session_regenerate_id(true)` to defeat session fixation. Strict mode
+     * (`App::$session_strict_mode`, default on) blocks an attacker from
+     * *planting* an id; regenerate-on-auth blocks *reusing* a pre-auth id. The
+     * framework can't force this — it doesn't know when your app authenticates.
+     *
      * @var callable|null
      */
     public static $auth_checker = null;
@@ -917,6 +923,29 @@ class App
      * form. Inverse of `$directory_slash`. Default false (keeps current behaviour).
      */
     public static bool $strip_trailing_slash = false;
+    /**
+     * PHP `session.use_strict_mode` parity (#244). When true (the default —
+     * security-first) a CLIENT-SUPPLIED session id (from a `PHPSESSID` cookie or
+     * query param) whose backing store loads an EMPTY session is treated as
+     * untrusted: the session managers mint a fresh server-generated id and switch
+     * the client to it. This defeats session FIXATION — an attacker who plants a
+     * known id into the victim's browser can no longer have it promoted to an
+     * authenticated session, because the framework rotates any unrecognised id
+     * before the victim ever authenticates under it. A well-formed id that DOES
+     * resolve to a non-empty stored session is preserved unchanged.
+     *
+     * CAVEAT — storage topology: the empty-session signal is only meaningful when
+     * the id's store is visible to the node handling the request. That holds for
+     * single-node (`TableSessionHandler`, the coroutine-mode default) and for
+     * shared storage (`Redis`/`Tiered`-backed sessions). A MULTI-NODE deployment
+     * using the per-server `TableSessionHandler` WITHOUT sticky load-balancing or
+     * shared session storage is already broken (sessions don't persist across
+     * nodes); with strict mode on it will ALSO rotate the id on every cross-node
+     * hop. Such setups should switch to Redis-backed sessions (so every node sees
+     * the same store) or opt out via `App::sessionStrictMode(false)`. Set via the
+     * fluent setter `App::sessionStrictMode()`.
+     */
+    public static bool $session_strict_mode = true;
     /**
      * Apache `ServerAdmin webmaster@example.com`. When set, the framework's default
      * `500`/error page mentions this contact. `null` disables the contact line.
@@ -3247,6 +3276,20 @@ class App
     {
         if ($on !== null) self::$strip_trailing_slash = $on;
         return self::$strip_trailing_slash;
+    }
+
+    /**
+     * PHP `session.use_strict_mode` parity (#244). When on (the default), a
+     * client-supplied session id that loads an empty session is rotated to a
+     * fresh server-generated id, defeating session fixation. Pass `false` to
+     * accept client-supplied ids verbatim (only safe for multi-node setups
+     * without shared/sticky session storage — see `App::$session_strict_mode`).
+     * No-arg call returns the current value.
+     */
+    public static function sessionStrictMode(?bool $on = null): bool
+    {
+        if ($on !== null) self::$session_strict_mode = $on;
+        return self::$session_strict_mode;
     }
 
     /**

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -217,6 +217,24 @@ class CoSessionManager
                 zeal_session_start();
                 $g->_session_started = true;
 
+                // #244 session.use_strict_mode: this branch is reached ONLY for a
+                // client-supplied id, so if it loaded an EMPTY session (stale /
+                // foreign / never-issued) it must not be honoured — mint a fresh
+                // server-generated id so a fixated id can't become an authed
+                // session. The store was just read by zeal_session_start() into
+                // $g->session, so [] here means "id not recognised".
+                if (zeal_session_strict_should_regenerate(
+                    \ZealPHP\App::$session_strict_mode,
+                    true,
+                    $g->session
+                )) {
+                    $freshId = session_create_id();
+                    if (is_string($freshId)) {
+                        $sessionId = $freshId;
+                        zeal_session_id($sessionId);
+                    }
+                }
+
                 if ($this->useCookies) {
                     $cookie = zeal_session_get_cookie_params();
                     $response->cookie(

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -223,10 +223,17 @@ class SessionManager
             $sessionName = session_name() ?: 'PHPSESSID';
             $reqCookie = is_array($request->cookie) ? $request->cookie : [];
             $reqGet = is_array($request->get) ? $request->get : [];
+            // #244: track whether the id is CLIENT-SUPPLIED (cookie/query param)
+            // vs server-minted by the idGenerator. Only a client id can be a
+            // planted/fixated value, so only it is subject to the strict-mode
+            // rotation below.
+            $clientSupplied = false;
             if ($this->useCookies && isset($reqCookie[$sessionName])) {
                 $rawSid = $reqCookie[$sessionName];
+                $clientSupplied = true;
             } else if (!$this->useOnlyCookies && isset($reqGet[$sessionName])) {
                 $rawSid = $reqGet[$sessionName];
+                $clientSupplied = true;
             } else {
                 $gen = $this->idGenerator;
                 $rawSid = is_callable($gen) ? $gen() : null;
@@ -261,6 +268,25 @@ class SessionManager
             // belt-and-suspenders for direct $g->session reads before the
             // first session_*() call.
             unset($g->session);
+
+            // #244 session.use_strict_mode: a CLIENT-SUPPLIED id that opened an
+            // EMPTY session (stale / foreign / never-issued) must not be honoured
+            // — regenerate to a fresh server-generated id and delete the old one
+            // so a fixated id can't become an authed session. $_SESSION is the
+            // canonical store here (the typed $g->session slot was just unset);
+            // read it defensively in case an upstream cleared it. session_*() are
+            // the framework's uopz overrides; session_regenerate_id(true) routes
+            // through zeal_session_regenerate_id (deletes old + emits Set-Cookie)
+            // and session_id() returns the new id for the cookie emit below.
+            if (zeal_session_strict_should_regenerate(
+                \ZealPHP\App::$session_strict_mode,
+                $clientSupplied,
+                isset($_SESSION) ? $_SESSION : []
+            )) {
+                session_regenerate_id(true);
+                $newId = session_id();
+                $sessionId = is_string($newId) ? $newId : $sessionId;
+            }
 
             if ($this->useCookies) {
                 $cookie = session_get_cookie_params();

--- a/src/Session/utils.php
+++ b/src/Session/utils.php
@@ -315,13 +315,48 @@ function zeal_valid_session_id(string $id): bool
 }
 
 /**
+ * `session.use_strict_mode` provenance decision (#244).
+ *
+ * `zeal_valid_session_id()` checks only the FORMAT of a client-supplied id; a
+ * well-formed but server-never-issued id (a planted/fixated `PHPSESSID`) still
+ * passes it. PHP's `session.use_strict_mode=1` rejects any id the server has no
+ * record of by minting a fresh one. The session managers reproduce that here:
+ * after `zeal_session_start()` has loaded the store for a CLIENT-SUPPLIED id,
+ * an EMPTY result means the id is unrecognised (stale / foreign / never issued)
+ * — so it must not be honoured, and a fresh server-generated id is issued in
+ * its place. This is the single trust check both `CoSessionManager` and
+ * `SessionManager` consult, kept here so it is unit-testable without driving a
+ * full request through OpenSwoole.
+ *
+ * @param bool   $strictMode      `App::$session_strict_mode`.
+ * @param bool   $clientSupplied  Whether the active id came from the client
+ *                                (cookie/query param) rather than being
+ *                                server-minted.
+ * @param array<array-key, mixed> $loadedSession  The session data the store
+ *                                resolved for that id; only its emptiness is
+ *                                inspected.
+ * @return bool  `true` when the id must be rotated to a fresh server id.
+ */
+function zeal_session_strict_should_regenerate(
+    bool $strictMode,
+    bool $clientSupplied,
+    array $loadedSession
+): bool {
+    return $strictMode && $clientSupplied && $loadedSession === [];
+}
+
+/**
  * Get or set the session ID.
  *
  * With no argument: reads the `PHPSESSID` (or custom session name) cookie
  * from `$g->cookie`. When no cookie is present a fresh ID is generated via
  * `session_create_id()` and stashed in `$g->cookie`. A malformed inbound ID
- * (path traversal, NUL, oversized) is silently replaced with a fresh one
- * (`session.use_strict_mode` parity).
+ * (path traversal, NUL, oversized) is silently replaced with a fresh one.
+ *
+ * NOTE: this function only validates id FORMAT. The `session.use_strict_mode`
+ * PROVENANCE check (rotating a well-formed but never-issued id that loads an
+ * empty session — #244) lives in the session managers, which call
+ * `zeal_session_strict_should_regenerate()` after the store has been read.
  *
  * @param string|null $id  Pass a string to set the session ID explicitly.
  * @return string|false  The current (or newly-set) session ID.

--- a/tests/Unit/Session/SessionStrictModeTest.php
+++ b/tests/Unit/Session/SessionStrictModeTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\Session;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+use function ZealPHP\Session\zeal_session_strict_should_regenerate;
+use function ZealPHP\Session\zeal_valid_session_id;
+
+/**
+ * Covers the #244 session-fixation fix: `App::$session_strict_mode` + the shared
+ * `zeal_session_strict_should_regenerate()` decision that both CoSessionManager
+ * (coroutine) and SessionManager (superglobals) consult.
+ *
+ * The bug: `zeal_valid_session_id()` validates only the FORMAT of a
+ * client-supplied PHPSESSID, so a well-formed but server-never-issued id (a
+ * planted/fixated id) is accepted verbatim. PHP's `session.use_strict_mode=1`
+ * rotates any id that loads an empty (unrecognised) session. This suite pins
+ * the rotation decision at the seam the managers reach (the pure helper), plus
+ * the fluent setter — driving a full OpenSwoole request through the managers is
+ * integration territory and needs the uopz session_* overrides (not loaded in
+ * the unit bootstrap).
+ */
+final class SessionStrictModeTest extends TestCase
+{
+    private bool $origStrict;
+
+    protected function setUp(): void
+    {
+        $this->origStrict = App::$session_strict_mode;
+    }
+
+    protected function tearDown(): void
+    {
+        App::$session_strict_mode = $this->origStrict;
+    }
+
+    // --- the helper: provenance decision ------------------------------------
+
+    /**
+     * The fixation case: a client-supplied id that loaded an EMPTY session is
+     * unrecognised → must be rotated to a fresh server id.
+     */
+    public function testClientIdWithEmptySessionRegenerates(): void
+    {
+        $this->assertTrue(
+            zeal_session_strict_should_regenerate(true, true, []),
+            'strict + client-supplied + empty store must rotate the id (fixation defence)'
+        );
+    }
+
+    /**
+     * A client-supplied id that resolved to a NON-EMPTY stored session is a
+     * legitimate returning visitor → preserve it, no rotation.
+     */
+    public function testClientIdWithExistingSessionPreserved(): void
+    {
+        $this->assertFalse(
+            zeal_session_strict_should_regenerate(true, true, ['user_id' => 7]),
+            'a recognised (non-empty) session must keep its id'
+        );
+    }
+
+    /**
+     * A server-MINTED id (not client-supplied) is never a planted value, so even
+     * an empty session must not be rotated — that is just a brand-new session.
+     */
+    public function testServerMintedIdNeverRegenerates(): void
+    {
+        $this->assertFalse(
+            zeal_session_strict_should_regenerate(true, false, []),
+            'a server-generated id is not attacker-controlled — no rotation'
+        );
+    }
+
+    /**
+     * `App::sessionStrictMode(false)` disables the rotation entirely: even a
+     * client id with an empty session is accepted verbatim (legacy behaviour /
+     * multi-node opt-out).
+     */
+    public function testStrictModeOffDisablesRotation(): void
+    {
+        $this->assertFalse(
+            zeal_session_strict_should_regenerate(false, true, []),
+            'strict mode off → client id accepted verbatim'
+        );
+    }
+
+    /**
+     * The empty check is exact: a session holding only a falsy-keyed value is
+     * still non-empty and must be preserved.
+     */
+    public function testNonEmptySessionWithFalsyValuePreserved(): void
+    {
+        $this->assertFalse(
+            zeal_session_strict_should_regenerate(true, true, ['flag' => false]),
+            'any populated key means the id is recognised'
+        );
+    }
+
+    // --- the rotated id is a usable, valid session id -----------------------
+
+    /**
+     * When the helper says "rotate", the managers mint via session_create_id().
+     * Assert that a freshly minted id differs from a planted one AND passes the
+     * format validator — so the cookie the client receives is a clean server id.
+     */
+    public function testFreshIdDiffersFromPlantedAndIsValid(): void
+    {
+        $planted = 'attacker_fixed_session_0123456789abcdef';
+        // The planted id is well-formed (this is the whole bug — format alone
+        // accepts it), so the manager only rejects it via the empty-session
+        // provenance check, then mints a replacement.
+        $this->assertTrue(zeal_valid_session_id($planted));
+        $this->assertTrue(
+            zeal_session_strict_should_regenerate(true, true, []),
+            'planted id with empty store triggers rotation'
+        );
+
+        $fresh = session_create_id();
+        $this->assertIsString($fresh);
+        $this->assertNotSame($planted, $fresh, 'rotation must yield a different id');
+        $this->assertTrue(
+            zeal_valid_session_id($fresh),
+            'the server-minted replacement must itself be a valid session id'
+        );
+    }
+
+    // --- the fluent setter --------------------------------------------------
+
+    public function testSetterDefaultsToTrue(): void
+    {
+        // Security-first default: strict mode is ON unless explicitly disabled.
+        App::$session_strict_mode = true;
+        $this->assertTrue(App::sessionStrictMode(), 'no-arg call reads the current value');
+    }
+
+    public function testSetterRoundTrips(): void
+    {
+        $this->assertFalse(App::sessionStrictMode(false), 'setter returns the new value');
+        $this->assertFalse(App::$session_strict_mode, 'backing property updated');
+        $this->assertFalse(App::sessionStrictMode(), 'read-back reflects the set value');
+
+        $this->assertTrue(App::sessionStrictMode(true));
+        $this->assertTrue(App::$session_strict_mode);
+        $this->assertTrue(App::sessionStrictMode());
+    }
+
+    public function testSetterNullArgDoesNotMutate(): void
+    {
+        App::$session_strict_mode = false;
+        $this->assertFalse(App::sessionStrictMode(null), 'null arg is a pure read — no mutation');
+        $this->assertFalse(App::$session_strict_mode);
+    }
+}


### PR DESCRIPTION
Closes #244.

## The bug

`zeal_session_id()` accepts any **well-formed** client-supplied `PHPSESSID` verbatim — it checks id **format** only (empty / >256 / `/\\\0` / `..`). A well-formed but server-**never-issued** id passes, so an attacker can plant a known id into the victim's browser and wait for them to authenticate under it (classic **session fixation**). The `zeal_valid_session_id()` docblock claimed `session.use_strict_mode` parity, but only the *malformed-id* half was implemented; the *provenance* half (reject an id the server has no record of) was missing. `zeal_session_regenerate_id()` existed but no auth path called it.

## The fix — provenance half of `session.use_strict_mode`

- **`App::$session_strict_mode`** (`bool`, **default `true`**) + fluent **`App::sessionStrictMode(?bool)`** setter (mirrors `App::stripTrailingSlash`).
- A shared, unit-testable decision helper **`zeal_session_strict_should_regenerate($strict, $clientSupplied, $loadedSession)`** in `src/Session/utils.php` — returns true iff strict + the id was client-supplied + the store loaded an **empty** session.
- **`CoSessionManager`** (coroutine / default): the cookie/param branch is reached *only* for a client-supplied id, so after `zeal_session_start()` an empty `$g->session` ⇒ mint `session_create_id()` + re-set it; the existing cookie emit sends the fresh id.
- **`SessionManager`** (superglobals): tracks client-supplied vs `idGenerator`-minted; on an empty `$_SESSION` for a client id ⇒ `session_regenerate_id(true)` (deletes old) then re-read `session_id()` for the cookie emit.

A recognised (**non-empty**) session keeps its id — no rotation, no churn for returning users.

## Part 2 — regenerate-on-auth (documented, not forced)

The framework can't know when *your* app changes privilege level, so this is documented rather than enforced: call `session_regenerate_id(true)` on login / logout / role change. Note added to `docs/middleware-and-authentication.md` (new "Session Fixation Defence" section) + the `App::authChecker` property docblock. Strict mode blocks **planting** an id; regenerate-on-auth blocks **reusing** a pre-auth id.

## ⚠️ Two decisions for the maintainer

1. **`$session_strict_mode` defaults to `true` (ON).** I chose security-first to match PHP's modern `session.use_strict_mode=1` default and actually close the vuln out of the box. The trade-off: it's a behaviour change for anyone who *relied* on client ids being honoured verbatim. Flip the property default to `false` if you'd rather ship it opt-in.
2. **Multi-node caveat.** The empty-session signal is only meaningful when the id's store is visible to the serving node — single-node (`TableSessionHandler`, the coroutine default) or shared `Redis`/`Tiered` sessions. A multi-node deploy using the **per-server** `TableSessionHandler` **without** sticky LB or shared storage is *already* broken (sessions don't persist cross-node); with strict mode on it will also rotate the id on every cross-node hop. Such setups should use Redis-backed sessions or `App::sessionStrictMode(false)`. This is documented in the property docblock, the docs note, and inline.

## Scope & verification

- Files: `src/App.php` (one property + one setter + authChecker docblock note), `src/Session/utils.php` (helper + docblock clarification), `src/Session/CoSessionManager.php`, `src/Session/SessionManager.php`, `docs/middleware-and-authentication.md`, `tests/Unit/Session/SessionStrictModeTest.php` (new).
- **PHPStan level 10**: zero new errors on the changed files (the 2 pre-existing closure-arity errors in the managers — `process_state_clean` arity — are unchanged; verified by stashing).
- **PHPUnit**: new `SessionStrictModeTest` (9 tests) green; full `tests/Unit/Session/` suite green (70 tests, 125 assertions), no regressions. (The whole-`tests/Unit/` coroutine deadlock is pre-existing and reproduces identically with these changes stashed — unrelated.)