### PR TITLE
fix(cgi): preserve multiple same-name response headers in CGI workers (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- **CGI workers no longer collapse multiple same-name response headers to the last (#260).** In `proc` / `pool` / `fork` dispatch (and the FastCGI + CGI-interpreter paths), a script emitting multiple same-name headers (multi `Set-Cookie`, `Link`, `Vary`, …) lost all but the last on the wire: the worker captured them correctly, but the parent applied each with the wrapper's default `$replace = true`, and the FastCGI / interpreter parsers stored a name-keyed map. Fixed via one replace-aware `Dispatcher::applyCgiHeaders()` (first occurrence of a name replaces any framework default; subsequent same-name pairs append) routed through all four dispatch sites, plus `FastCgiClient::parseStdout()` and `parseCgiResponse()` now return an ordered `[name, value]` pair list. (The earlier #264 fix covered only the in-process path.) Pinned by `CgiPoolDispatchTest::testMultipleSameNameHeadersAllReachResponse` (two `Set-Cookie` survive end-to-end through the pool) + the CGI parser tests.
+
 ### Security & hardening (architecture-review pass)
 
 A focused hardening pass closing the highest-blast-radius gaps from a full architectural review — scalability backpressure, session edge cases, and the cross-node Redis/WebSocket fabric. Most reuse patterns the framework already had elsewhere; defaults that were unsafe for production are now safe-by-default or surfaced with a boot advisory.

--- a/src/App.php
+++ b/src/App.php
@@ -6617,7 +6617,7 @@ class App
      * {@see \ZealPHP\CGI\Dispatcher::parseCgiResponse()} (Phase 2 refactor).
      * Kept on App for BC so external callers/tests reach it via App::parseCgiResponse().
      *
-     * @return array{status: int|null, headers: array<string, string>, body: string}
+     * @return array{status: int|null, headers: list<array{0:string,1:string}>, body: string}
      */
     public static function parseCgiResponse(string $raw): array
     {

--- a/src/CGI/Dispatcher.php
+++ b/src/CGI/Dispatcher.php
@@ -288,11 +288,10 @@ class Dispatcher
         // Apply status
         response_set_status($response['status']);
 
-        // Apply headers — $response['headers'] is array<string,string> per FastCgiClient return type
-        foreach ($response['headers'] as $name => $value) {
-            // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any route dispatches
-            $g->zealphp_response->header($name, $value);
-        }
+        // #260 — apply replace-aware so an upstream's multiple same-name headers
+        // (multi Set-Cookie, Link, …) all reach the wire. FastCgiClient returns an
+        // ordered list of [name, value] pairs; Status is consumed above.
+        self::applyCgiHeaders($g->zealphp_response, $response['headers']);
 
         return $response['body'];
     }
@@ -461,28 +460,10 @@ class Dispatcher
             response_set_status(is_numeric($statusCode) ? (int)$statusCode : 200);
             $metaHeaders = is_array($meta['headers'] ?? null) ? $meta['headers'] : [];
 
-            foreach ($metaHeaders as $pair) {
-                if (!is_array($pair) || count($pair) < 2) continue;
-                $p0 = is_scalar($pair[0]) ? (string)$pair[0] : '';
-                $p1 = is_scalar($pair[1]) ? (string)$pair[1] : '';
-
-                // mod_cgi parity: CGI/1.1 RFC 3875 §6.3.3 — "Status: NNN Reason"
-                // sets the HTTP response code. Apache: ap_scan_script_header_err_brigade_ex().
-                // Strip the Status: pseudo-header so it never reaches the client.
-                if (strcasecmp($p0, 'Status') === 0) {
-                    $codeStr = strtok($p1, ' ');
-                    if ($codeStr !== false && ctype_digit($codeStr)) {
-                        $parsed = (int)$codeStr;
-                        if ($parsed >= 100 && $parsed <= 599) {
-                            response_set_status($parsed);
-                        }
-                    }
-                    continue;
-                }
-
-                // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any route dispatches
-                $g->zealphp_response->header($p0, $p1);
-            }
+            // #260 — apply replace-aware so MULTIPLE same-name headers (multi
+            // Set-Cookie, Link, Vary, …) all reach the wire instead of collapsing
+            // to the last. Status: is consumed as the response code, not forwarded.
+            self::applyCgiHeaders($g->zealphp_response, $metaHeaders);
             $metaCookies = is_array($meta['cookies'] ?? null) ? $meta['cookies'] : [];
             foreach ($metaCookies as $args) {
                 if (is_array($args) && !empty($args)) {
@@ -616,6 +597,60 @@ class Dispatcher
     }
 
     /**
+     * Apply CGI-captured response headers to the live response, preserving
+     * MULTIPLE same-name headers (multi `Set-Cookie`, `Link`, `Vary`, …).
+     *
+     * #260 — the proc/pool/fork workers capture headers as an ordered list of
+     * `[name, value]` pairs (the uopz `header()` override already honours each
+     * `header(..., $replace)` call), but applying every captured pair with the
+     * wrapper's default `$replace = true` collapsed each same-name header to the
+     * LAST on the wire. Here the FIRST occurrence of a name replaces any
+     * framework default; every subsequent same-name pair is appended, so the
+     * worker's exact multi-header set reaches the client.
+     *
+     * The CGI/1.1 "Status:" pseudo-header (RFC 3875 §6.3.3) is consumed as the
+     * response code and never forwarded (mod_cgi parity).
+     *
+     * @param mixed           $resp  a Response-like object exposing
+     *                               `header(string, string, bool)` — the live
+     *                               `$g->zealphp_response` (typed `mixed`) or a
+     *                               test double; null/non-object emits nothing
+     * @param iterable<mixed> $pairs each element a `[string $name, string $value]` pair
+     */
+    private static function applyCgiHeaders(mixed $resp, iterable $pairs): void
+    {
+        // Duck-typed: $g->zealphp_response is `mixed`, so accept any object that
+        // exposes header() (the real wrapper or a test stub); null otherwise.
+        $emitter = (is_object($resp) && method_exists($resp, 'header')) ? $resp : null;
+        $seen = [];
+        foreach ($pairs as $pair) {
+            if (!is_array($pair) || count($pair) < 2
+                || !is_scalar($pair[0]) || !is_scalar($pair[1])) {
+                continue;
+            }
+            $name  = (string) $pair[0];
+            $value = (string) $pair[1];
+            if (strcasecmp($name, 'Status') === 0) {
+                $codeStr = strtok($value, ' ');
+                if ($codeStr !== false && ctype_digit($codeStr)) {
+                    $code = (int) $codeStr;
+                    if ($code >= 100 && $code <= 599) {
+                        response_set_status($code);
+                    }
+                }
+                continue;
+            }
+            if ($emitter === null) {
+                continue;
+            }
+            $lc = strtolower($name);
+            // First occurrence overrides any framework default; the rest append.
+            $emitter->header($name, $value, !isset($seen[$lc]));
+            $seen[$lc] = true;
+        }
+    }
+
+    /**
      * Parse a raw CGI/1.1 interpreter response (RFC 3875) into status, headers
      * and body — pure, side-effect-free string handling.
      *
@@ -633,7 +668,7 @@ class Dispatcher
      * whether that's a malformed-header error (cgiInterpreterResponse() already
      * does, before calling this) or a bodies-only response.
      *
-     * @return array{status: int|null, headers: array<string, string>, body: string}
+     * @return array{status: int|null, headers: list<array{0:string,1:string}>, body: string}
      */
     public static function parseCgiResponse(string $raw): array
     {
@@ -676,7 +711,10 @@ class Dispatcher
                 continue;
             }
 
-            $headers[$name] = $value;
+            // #260 — ordered [name, value] pair, not $headers[$name], so an
+            // interpreter that emits multiple same-name headers (multi
+            // Set-Cookie, …) doesn't collapse them to the last on the wire.
+            $headers[] = [$name, $value];
         }
 
         return ['status' => $status, 'headers' => $headers, 'body' => $body];
@@ -778,16 +816,18 @@ class Dispatcher
             response_set_status($parsed['status']);
         }
 
+        // #260 — $headers is now an ordered [name, value] pair list. Detect SSE
+        // by scanning the pairs, then apply replace-aware so multiple same-name
+        // headers (multi Set-Cookie, …) survive instead of collapsing to the last.
         $streaming = false;
-        foreach ($headers as $name => $value) {
-            if (strcasecmp($name, 'Content-Type') === 0
-                && stripos($value, 'text/event-stream') !== false) {
+        foreach ($headers as $pair) {
+            if (strcasecmp($pair[0], 'Content-Type') === 0
+                && stripos($pair[1], 'text/event-stream') !== false) {
                 $streaming = true;
+                break;
             }
-
-            // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any route dispatches
-            $g->zealphp_response->header($name, $value);
         }
+        self::applyCgiHeaders($g->zealphp_response, $headers);
 
         // SSE / event-stream: flush headers + body immediately so EventSource
         // clients see events without waiting for the whole response.
@@ -965,18 +1005,10 @@ class Dispatcher
 
         $respW = $g->zealphp_response;
         if ($respW !== null) {
-            foreach ((array) ($resp['headers'] ?? []) as $pair) {
-                if (is_array($pair) && count($pair) >= 2
-                    && is_scalar($pair[0]) && is_scalar($pair[1])) {
-                    // CGI/1.1 RFC 3875 §6.3.3 — the "Status:" pseudo-header sets the
-                    // response code (already applied from $resp['status']); it must
-                    // NOT be forwarded to the client as a real header (mod_cgi parity).
-                    if (strcasecmp((string) $pair[0], 'Status') === 0) {
-                        continue;
-                    }
-                    $respW->header((string) $pair[0], (string) $pair[1]);
-                }
-            }
+            // #260 — apply replace-aware so multiple same-name headers (multi
+            // Set-Cookie, Link, …) all reach the wire instead of collapsing to the
+            // last. Status: is consumed as the response code (already applied above).
+            self::applyCgiHeaders($respW, (array) ($resp['headers'] ?? []));
             $applyCookie = static function (callable $fn, mixed $args): void {
                 if (!is_array($args) || !isset($args[0]) || !is_scalar($args[0])) return;
                 $s = static fn(int $i, string $d): string =>

--- a/src/CGI/FastCgiClient.php
+++ b/src/CGI/FastCgiClient.php
@@ -68,7 +68,7 @@ final class FastCgiClient
      *
      * @param array<string,string> $params    FCGI `PARAMS` (CGI environment variables).
      * @param string               $stdinBody Request body (`POST` data).
-     * @return array{status:int,headers:array<string,string>,body:string,stderr:string}
+     * @return array{status:int,headers:list<array{0:string,1:string}>,body:string,stderr:string}
      * @throws FastCgiException on protocol error, timeout, or connection failure.
      */
     public function request(array $params, string $stdinBody = ''): array
@@ -272,7 +272,7 @@ final class FastCgiClient
      * Header state machine mirrors `mod_proxy_fcgi.c:543-594` and
      * `ngx_http_fastcgi_module.c:1690-1857`.
      *
-     * @return array{status:int,headers:array<string,string>,body:string,stderr:string}
+     * @return array{status:int,headers:list<array{0:string,1:string}>,body:string,stderr:string}
      */
     public function readResponse(CoClient $conn, int $reqId): array
     {
@@ -351,7 +351,7 @@ final class FastCgiClient
      * `Status:` header is extracted and removed (nginx: `ngx_http_fastcgi_module.c:648-656`;
      * Apache: `ap_scan_script_header_err_brigade_ex`).
      *
-     * @return array{status:int,headers:array<string,string>,body:string,stderr:string}
+     * @return array{status:int,headers:list<array{0:string,1:string}>,body:string,stderr:string}
      */
     public function parseStdout(string $stdout, string $stderr, int $appStatus): array
     {
@@ -391,7 +391,10 @@ final class FastCgiClient
                 continue;
             }
 
-            $headers[$name] = $value;
+            // #260 — append as an ordered [name, value] pair, not $headers[$name],
+            // so an upstream that sends multiple same-name headers (multi
+            // Set-Cookie, Link, Vary, …) doesn't collapse them to the last.
+            $headers[] = [$name, $value];
         }
 
         return [

--- a/tests/Unit/CGI/CgiPoolDispatchTest.php
+++ b/tests/Unit/CGI/CgiPoolDispatchTest.php
@@ -126,6 +126,26 @@ final class CgiPoolDispatchTest extends TestCase
         $this->assertContains('X-Pool-Test', $headerNames);
     }
 
+    public function testMultipleSameNameHeadersAllReachResponse(): void
+    {
+        // #260 — two Set-Cookie headers (appended via header(..., false)) must
+        // BOTH reach the response end-to-end through the pool dispatch, not
+        // collapse to the last on the wire (the capture is a pair list; the apply
+        // is replace-aware: first occurrence replaces, the rest append).
+        $file = $this->fixture(
+            'multicookie.php',
+            'header("Set-Cookie: a=1", false); header("Set-Cookie: b=2", false); echo "ok";'
+        );
+        $stub = RequestContext::instance()->zealphp_response;
+        $this->cgiPool->invoke(null, $file);
+        $setCookies = array_values(array_filter(
+            (array) $stub->headers,
+            static fn ($p): bool => is_array($p) && ($p[0] ?? null) === 'Set-Cookie'
+        ));
+        $this->assertCount(2, $setCookies, 'both Set-Cookie headers must survive');
+        $this->assertSame(['a=1', 'b=2'], array_column($setCookies, 1));
+    }
+
     public function testCookieCaptureFlowsToResponseStub(): void
     {
         $file = $this->fixture('cookie.php', 'setcookie("sid", "abc123", time() + 3600, "/"); echo "ok";');

--- a/tests/Unit/CgiFcgiDispatchTest.php
+++ b/tests/Unit/CgiFcgiDispatchTest.php
@@ -248,8 +248,12 @@ class CgiFcgiDispatchTest extends TestCase
             0
         );
         $this->assertSame('{"ok":true}', $result['body']);
-        $this->assertSame('application/json', $result['headers']['Content-Type']);
-        $this->assertSame('zealphp', $result['headers']['X-App']);
+        // #260 — headers is an ordered [name, value] pair list, not a name-keyed
+        // map, so an upstream's multiple same-name headers are preserved.
+        $this->assertSame(
+            [['Content-Type', 'application/json'], ['X-App', 'zealphp']],
+            $result['headers']
+        );
     }
 
     public function testParseStdoutStatusHeaderExtracted(): void
@@ -262,7 +266,7 @@ class CgiFcgiDispatchTest extends TestCase
         );
         $this->assertSame(404, $result['status']);
         $this->assertSame('not found', $result['body']);
-        $this->assertArrayNotHasKey('Status', $result['headers']);
+        $this->assertNotContains('Status', array_column($result['headers'], 0));
     }
 
     public function testParseStdoutNoBlankLineReturnedAsBody(): void
@@ -286,7 +290,7 @@ class CgiFcgiDispatchTest extends TestCase
 
         $this->mockFastCgiClient([
             'status'  => 200,
-            'headers' => ['Content-Type' => 'text/html'],
+            'headers' => [['Content-Type', 'text/html']],
             'body'    => 'hello from fpm',
             'stderr'  => '',
         ]);
@@ -311,7 +315,7 @@ class CgiFcgiDispatchTest extends TestCase
 
         $this->mockFastCgiClient([
             'status'  => 301,
-            'headers' => ['Location' => 'https://example.com/'],
+            'headers' => [['Location', 'https://example.com/']],
             'body'    => '',
             'stderr'  => '',
         ]);

--- a/tests/Unit/CgiResponseParserTest.php
+++ b/tests/Unit/CgiResponseParserTest.php
@@ -9,6 +9,10 @@ use ZealPHP\App;
  * Unit coverage for App::parseCgiResponse() — the pure RFC 3875 CGI response
  * parser extracted out of cgiInterpreterResponse() (which is itself
  * integration-only: subprocess spawn + $g->response emission).
+ *
+ * #260 — `headers` is an ordered list of `[name, value]` pairs (NOT a
+ * name-keyed map), so multiple same-name headers (multi `Set-Cookie`, …) are
+ * preserved instead of collapsing to the last.
  */
 final class CgiResponseParserTest extends TestCase
 {
@@ -17,7 +21,7 @@ final class CgiResponseParserTest extends TestCase
         $raw = "Content-Type: text/plain\r\n\r\nhello world";
         $r = App::parseCgiResponse($raw);
         $this->assertNull($r['status']);
-        $this->assertSame(['Content-Type' => 'text/plain'], $r['headers']);
+        $this->assertSame([['Content-Type', 'text/plain']], $r['headers']);
         $this->assertSame('hello world', $r['body']);
     }
 
@@ -26,7 +30,7 @@ final class CgiResponseParserTest extends TestCase
         $raw = "Content-Type: text/plain\n\nhello";
         $r = App::parseCgiResponse($raw);
         $this->assertNull($r['status']);
-        $this->assertSame(['Content-Type' => 'text/plain'], $r['headers']);
+        $this->assertSame([['Content-Type', 'text/plain']], $r['headers']);
         $this->assertSame('hello', $r['body']);
     }
 
@@ -35,8 +39,8 @@ final class CgiResponseParserTest extends TestCase
         $raw = "Status: 418 I'm a teapot\r\nContent-Type: text/plain\r\n\r\nbrew";
         $r = App::parseCgiResponse($raw);
         $this->assertSame(418, $r['status']);
-        $this->assertArrayNotHasKey('Status', $r['headers']);
-        $this->assertSame(['Content-Type' => 'text/plain'], $r['headers']);
+        $this->assertNotContains('Status', array_column($r['headers'], 0));
+        $this->assertSame([['Content-Type', 'text/plain']], $r['headers']);
         $this->assertSame('brew', $r['body']);
     }
 
@@ -45,8 +49,8 @@ final class CgiResponseParserTest extends TestCase
         $raw = "status: 503\r\n\r\ndown";
         $r = App::parseCgiResponse($raw);
         $this->assertSame(503, $r['status']);
-        $this->assertArrayNotHasKey('status', $r['headers']);
-        $this->assertArrayNotHasKey('Status', $r['headers']);
+        // Only a Status pseudo-header was sent — it is consumed, not forwarded.
+        $this->assertSame([], $r['headers']);
     }
 
     public function testStatusOutOfRangeIgnored(): void
@@ -69,10 +73,22 @@ final class CgiResponseParserTest extends TestCase
         $raw = "Content-Type: application/json\r\nX-Custom: yes\r\n\r\n{}";
         $r = App::parseCgiResponse($raw);
         $this->assertSame(
-            ['Content-Type' => 'application/json', 'X-Custom' => 'yes'],
+            [['Content-Type', 'application/json'], ['X-Custom', 'yes']],
             $r['headers']
         );
         $this->assertSame('{}', $r['body']);
+    }
+
+    public function testMultipleSameNameHeadersPreserved(): void
+    {
+        // #260 — two Set-Cookie headers must BOTH survive as ordered pairs, not
+        // collapse to the last (a name-keyed map would lose the first).
+        $raw = "Set-Cookie: a=1\r\nSet-Cookie: b=2\r\nContent-Type: text/html\r\n\r\nx";
+        $r = App::parseCgiResponse($raw);
+        $this->assertSame(
+            [['Set-Cookie', 'a=1'], ['Set-Cookie', 'b=2'], ['Content-Type', 'text/html']],
+            $r['headers']
+        );
     }
 
     public function testNoHeadersBlankLineFirstIsAllBody(): void
@@ -90,7 +106,7 @@ final class CgiResponseParserTest extends TestCase
         // The body itself has a blank line; only the FIRST blank line splits.
         $raw = "Content-Type: text/plain\r\n\r\npara1\r\n\r\npara2";
         $r = App::parseCgiResponse($raw);
-        $this->assertSame(['Content-Type' => 'text/plain'], $r['headers']);
+        $this->assertSame([['Content-Type', 'text/plain']], $r['headers']);
         $this->assertSame("para1\r\n\r\npara2", $r['body']);
     }
 
@@ -99,7 +115,7 @@ final class CgiResponseParserTest extends TestCase
         // First colon splits; colons inside the value (URL with port) survive.
         $raw = "Location: http://x/y:8080\r\n\r\n";
         $r = App::parseCgiResponse($raw);
-        $this->assertSame('http://x/y:8080', $r['headers']['Location']);
+        $this->assertSame([['Location', 'http://x/y:8080']], $r['headers']);
         $this->assertSame('', $r['body']);
     }
 
@@ -124,7 +140,7 @@ final class CgiResponseParserTest extends TestCase
     {
         $raw = "Content-Type: text/html\r\ngarbage-line-no-colon\r\n\r\nbody";
         $r = App::parseCgiResponse($raw);
-        $this->assertSame(['Content-Type' => 'text/html'], $r['headers']);
+        $this->assertSame([['Content-Type', 'text/html']], $r['headers']);
         $this->assertSame('body', $r['body']);
     }
 
@@ -136,7 +152,7 @@ final class CgiResponseParserTest extends TestCase
         // because it is searched first regardless of position.
         $raw = "Content-Type: text/plain\r\n\r\nbody-with-\n\n-inside";
         $r = App::parseCgiResponse($raw);
-        $this->assertSame(['Content-Type' => 'text/plain'], $r['headers']);
+        $this->assertSame([['Content-Type', 'text/plain']], $r['headers']);
         $this->assertSame("body-with-\n\n-inside", $r['body']);
     }
 }

--- a/tests/Unit/FastCgiClientTest.php
+++ b/tests/Unit/FastCgiClientTest.php
@@ -224,7 +224,7 @@ class FastCgiClientTest extends TestCase
         $stdout = "Content-Type: text/html\r\n\r\n<html/>";
         $result = $this->invokeParseStdout($stdout, '', 0);
         $this->assertSame(200, $result['status']);
-        $this->assertSame('text/html', $result['headers']['Content-Type']);
+        $this->assertContains(['Content-Type', 'text/html'], $result['headers']);
         $this->assertSame('<html/>', $result['body']);
         $this->assertSame('', $result['stderr']);
     }
@@ -235,8 +235,8 @@ class FastCgiClientTest extends TestCase
         $stdout = "Status: 302 Found\r\nLocation: /new\r\n\r\n";
         $result = $this->invokeParseStdout($stdout, '', 0);
         $this->assertSame(302, $result['status']);
-        $this->assertArrayNotHasKey('Status', $result['headers']);
-        $this->assertSame('/new', $result['headers']['Location']);
+        $this->assertNotContains('Status', array_column($result['headers'], 0));
+        $this->assertContains(['Location', '/new'], $result['headers']);
     }
 
     public function testParseStdoutStatus404(): void
@@ -253,7 +253,7 @@ class FastCgiClientTest extends TestCase
         $stdout = "Content-Type: text/plain\nX-Foo: bar\n\nbody text";
         $result = $this->invokeParseStdout($stdout, '', 0);
         $this->assertSame(200, $result['status']);
-        $this->assertSame('bar', $result['headers']['X-Foo']);
+        $this->assertContains(['X-Foo', 'bar'], $result['headers']);
         $this->assertSame('body text', $result['body']);
     }
 
@@ -279,8 +279,8 @@ class FastCgiClientTest extends TestCase
         $stdout = "Content-Type: application/json\r\nX-Custom: value\r\nSet-Cookie: id=1\r\n\r\n{\"ok\":true}";
         $result = $this->invokeParseStdout($stdout, '', 0);
         $this->assertSame(200, $result['status']);
-        $this->assertSame('application/json', $result['headers']['Content-Type']);
-        $this->assertSame('value', $result['headers']['X-Custom']);
+        $this->assertContains(['Content-Type', 'application/json'], $result['headers']);
+        $this->assertContains(['X-Custom', 'value'], $result['headers']);
         $this->assertSame('{"ok":true}', $result['body']);
     }
 
@@ -312,7 +312,7 @@ class FastCgiClientTest extends TestCase
         fclose($b);
 
         $this->assertSame(200, $result['status']);
-        $this->assertSame('text/plain', $result['headers']['Content-Type']);
+        $this->assertContains(['Content-Type', 'text/plain'], $result['headers']);
         $this->assertSame($responseBody, $result['body']);
     }
 
@@ -553,8 +553,8 @@ class FastCgiClientTest extends TestCase
         // A header line without a colon must be silently ignored.
         $stdout = "Content-Type: text/plain\r\nBadLineWithoutColon\r\nX-Ok: yes\r\n\r\nbody";
         $result = $this->invokeParseStdout($stdout, '', 0);
-        $this->assertSame('yes', $result['headers']['X-Ok']);
-        $this->assertArrayNotHasKey('BadLineWithoutColon', $result['headers']);
+        $this->assertContains(['X-Ok', 'yes'], $result['headers']);
+        $this->assertNotContains('BadLineWithoutColon', array_column($result['headers'], 0));
         $this->assertSame('body', $result['body']);
     }
 }


### PR DESCRIPTION
Closes #260.

A CGI script emitting multiple same-name headers (multi `Set-Cookie`, `Link`, `Vary`, …) lost all but the last on the wire in **proc / pool / fork** dispatch (and the FastCGI + interpreter paths). My earlier #264 fix covered only the in-process path; this completes it for the CGI worker strategies.

**Root cause (two parts):**
- The parent applied each captured pair with the wrapper's default `$replace = true` → every same-name header overwrote the previous.
- `FastCgiClient::parseStdout()` + `parseCgiResponse()` stored a **name-keyed map**, which can't hold duplicates at all.

**Fix:** one replace-aware `Dispatcher::applyCgiHeaders()` (first occurrence of a name replaces any framework default; subsequent same-name pairs append) routed through all four dispatch sites; both parsers now return an ordered `list<[name, value]>`. Response param is duck-typed (`zealphp_response` is `mixed`; tests inject stubs) via `method_exists` narrowing — no `@phpstan-ignore`.

**Validated:** new `CgiPoolDispatchTest::testMultipleSameNameHeadersAllReachResponse` proves two `Set-Cookie` survive end-to-end through the real pool dispatch; parser tests updated to the pair-list shape (+ a multi-same-name case). All CGI suites green; PHPStan L10 clean (only the 2 pre-existing session-manager arity errors).

(#261 — `cgiMode('fcgi')` fatal — is deferred; it needs an fcgi upstream to validate. Priority shifted to the coroutine-legacy migration batch #24/#25/#26/#270–274.)