### PR TITLE
docs(security): update Supported Versions to 0.4.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,11 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.4.x   | Yes       |
+| < 0.4   | No        |
+
+ZealPHP is pre-1.0 (alpha): only the latest minor (currently **0.4.x**) receives
+security fixes. Upgrade to the newest `0.4.z` patch for the current fixes.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
The SECURITY.md "Supported Versions" table still said `0.1.x` (shown on GitHub's security overview). ZealPHP is at v0.4.2 — updated to `0.4.x` supported, `< 0.4` unsupported, with an alpha note to upgrade to the newest 0.4.z patch.