### PR TITLE
fix: seed $g->server CGI/SAPI vars at worker start + per-request UNIQUE_ID (#270, #274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- **`$g->server` CGI/SAPI keys seeded at worker start + a per-request `UNIQUE_ID` (#270, #274).** App bootstrap that read `$g->server['PHP_SELF']` (or `SCRIPT_NAME` / `SCRIPT_FILENAME` / `REQUEST_URI`) at class-load — *before* the first request populates them per-request — hit "Undefined array key" floods under `MODE_COROUTINE_LEGACY` (the per-coroutine `$_SERVER` isolation hands the worker-start coroutine a fresh empty array). `App::run()` now seeds the static CGI/SAPI vars (`App::baseServerVars()`) into `$g->server` at worker start — existing keys win, and the per-request handler overlays the real values (mod_php parity). Separately, `buildServerVars()` now mints a fresh per-request `UNIQUE_ID` when one isn't already set (Apache `mod_unique_id` parity), so a class-load `$_SERVER['UNIQUE_ID'] = …` is no longer needed — that pattern produces one worker-wide id shared by every coroutine, breaking log correlation.
+
 ### Security & hardening (architecture-review pass)
 
 A focused hardening pass closing the highest-blast-radius gaps from a full architectural review — scalability backpressure, session edge cases, and the cross-node Redis/WebSocket fabric. Most reuse patterns the framework already had elsewhere; defaults that were unsafe for production are now safe-by-default or surfaced with a boot advisory.

--- a/src/App.php
+++ b/src/App.php
@@ -1873,6 +1873,35 @@ class App
     }
 
     /**
+     * The static CGI/SAPI server vars mod_php exposes even OUTSIDE a request
+     * (PHP_SELF, SCRIPT_NAME, SCRIPT_FILENAME, REQUEST_URI, DOCUMENT_ROOT).
+     * Seeded into `$g->server` at worker start so app bootstrap that reads them
+     * at class-load — before the first request populates the real per-request
+     * values via {@see buildServerVars()} — doesn't hit "Undefined array key"
+     * (#270). buildServerVars() overlays the real per-request values on top.
+     *
+     * @return array<string, string>
+     */
+    private static function baseServerVars(): array
+    {
+        $docRoot = self::resolveDocumentRoot();
+        $phpSelf = (string)(self::$default_php_self ?? '');
+        if ($phpSelf === '') {
+            $phpSelf = '/app.php';
+        }
+        return [
+            'REQUEST_METHOD'  => 'GET',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_NAME'     => $phpSelf,
+            'PHP_SELF'        => $phpSelf,
+            'DOCUMENT_ROOT'   => $docRoot,
+            'SCRIPT_FILENAME' => $docRoot . $phpSelf,
+            'SERVER_SOFTWARE' => 'ZealPHP/dev (' . php_uname('s') . ') PHP/' . phpversion(),
+            'SERVER_NAME'     => site_host(),
+        ];
+    }
+
+    /**
      * Build the per-request `$_SERVER` array from an OpenSwoole request —
      * mod_php parity. Merges `$request->server` (upper-cased keys), the
      * `HTTP_*` header vars, and the constant CGI keys mod_php always provides
@@ -1923,6 +1952,15 @@ class App
             // null, so a direct (string) cast is safe.
             $srv['SCRIPT_FILENAME'] = (string)($srv['DOCUMENT_ROOT'] ?? '')
                 . (string)($srv['PHP_SELF'] ?? '');
+        }
+
+        // Apache mod_unique_id parity (#274): a FRESH per-request correlation id.
+        // Under coroutine concurrency a class-load `$_SERVER['UNIQUE_ID'] = …`
+        // assignment is worker-wide — every request on that worker shares one id,
+        // breaking log correlation. Minting it here gives each request its own.
+        // Kept as-is if an upstream (Apache mod_unique_id / a proxy) already set one.
+        if (!isset($srv['UNIQUE_ID'])) {
+            $srv['UNIQUE_ID'] = bin2hex(random_bytes(12));
         }
 
         if ($srv['REQUEST_METHOD'] === 'POST' && isset($srv['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
@@ -8405,6 +8443,19 @@ class App
             @stream_wrapper_unregister("php");
             stream_wrapper_register("php", \ZealPHP\IOStreamWrapper::class);
             self::$workerStartedAt = microtime(true);
+            // #270 — seed the static CGI/SAPI server vars (PHP_SELF, SCRIPT_NAME,
+            // SCRIPT_FILENAME, REQUEST_URI, DOCUMENT_ROOT) so app bootstrap that
+            // reads $g->server / $_SERVER at worker start — BEFORE the first
+            // request populates them per-request via buildServerVars() — doesn't
+            // hit "Undefined array key". Existing keys win, and the per-request
+            // handler overlays the real values; this is mod_php parity (the SAPI
+            // exposes these even outside a request). Especially relevant in
+            // coroutine-legacy, where the per-coroutine $_SERVER isolation gives
+            // the worker-start coroutine a fresh empty $_SERVER.
+            $g    = RequestContext::instance();
+            // Existing keys win (left operand of +), so a stale value is never
+            // clobbered; the per-request handler overlays real values later.
+            $g->server = $g->server + self::baseServerVars();
             foreach (self::$workerStartHooks as $hook) {
                 $hook($server, $workerId);
             }

--- a/tests/Unit/AppStaticHelpersTest.php
+++ b/tests/Unit/AppStaticHelpersTest.php
@@ -65,6 +65,22 @@ class AppStaticHelpersTest extends TestCase
         $g->status = 200;
     }
 
+    public function testBaseServerVarsProvidesCgiSapiKeys(): void
+    {
+        // #270 — the static CGI/SAPI keys seeded into $g->server at worker start
+        // so app bootstrap that reads them BEFORE the first request doesn't warn
+        // "Undefined array key" (the per-request handler overlays real values).
+        $m = new \ReflectionMethod(App::class, 'baseServerVars');
+        $m->setAccessible(true);
+        /** @var array<string, string> $base */
+        $base = $m->invoke(null);
+        foreach (['PHP_SELF', 'SCRIPT_NAME', 'SCRIPT_FILENAME', 'REQUEST_URI', 'DOCUMENT_ROOT', 'REQUEST_METHOD'] as $key) {
+            $this->assertArrayHasKey($key, $base, "baseServerVars must provide {$key}");
+            $this->assertNotSame('', $base[$key], "{$key} must not be empty");
+        }
+        $this->assertStringEndsWith($base['PHP_SELF'], $base['SCRIPT_FILENAME']);
+    }
+
     // ─────────────────────────────────────────────────────────────
     // coerceStatusCode()
     // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #270, #274 (framework side of the labs-migration batch).

**#270** — app bootstrap reading `$g->server['PHP_SELF']` (and `SCRIPT_NAME` / `SCRIPT_FILENAME` / `REQUEST_URI`) at **class-load** — before the first request populates them per-request — hit "Undefined array key" floods under `MODE_COROUTINE_LEGACY` (the per-coroutine `$_SERVER` isolation gives the worker-start coroutine a fresh empty array). `App::run()`'s workerStart handler now seeds the static CGI/SAPI vars (`App::baseServerVars()`) into `$g->server` — existing keys win, per-request overlays real values (mod_php parity).

**#274** — `buildServerVars()` now mints a fresh per-request `UNIQUE_ID` when absent (Apache `mod_unique_id` parity). A class-load `$_SERVER['UNIQUE_ID'] = …` is worker-wide (every coroutine shares one id → broken log correlation); the framework value is per-request.

**Validated:** PHPStan L10 clean; boots 0 warnings in coroutine mode; new `AppStaticHelpersTest::testBaseServerVarsProvidesCgiSapiKeys` + 39-test suite green. The seed is mode-agnostic (existing-keys-win + per-request overlay), safe in all modes — please confirm on your coroutine-legacy app that the worker-start warnings are gone, since the ext is needed to exercise that exact path here.