### PR TITLE
fix(session): RedisSessionHandler connects lazily, not in constructor (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RedisSessionHandler` no longer connects eagerly in its constructor — coroutine-safe under HOOK_ALL (#271).** Constructing the handler at a non-coroutine point (boot / middleware registration — e.g. with `App::sessionLifecycle(false)`, where the app installs its own save handler before the request loop) fataled "API must be called in the coroutine": the constructor called `\Redis->connect()`, which HOOK_ALL turns into a coroutine API. The connection is now established lazily on first use in `redis()` — a per-coroutine socket inside a request, or the already-lazy `$fallback` (`??=`) outside one. No change to the in-request path; only the eager construction-time connect is removed (so configuration errors now surface on first `open()`/`read()` instead of at construction).
+
 ### Security & hardening (architecture-review pass)
 
 A focused hardening pass closing the highest-blast-radius gaps from a full architectural review — scalability backpressure, session edge cases, and the cross-node Redis/WebSocket fabric. Most reuse patterns the framework already had elsewhere; defaults that were unsafe for production are now safe-by-default or surfaced with a boot advisory.

--- a/src/Session/Handler/RedisSessionHandler.php
+++ b/src/Session/Handler/RedisSessionHandler.php
@@ -59,10 +59,14 @@ class RedisSessionHandler implements \SessionHandlerInterface
         $this->port = $port;
         $this->prefix = $prefix;
         $this->ttl = $ttl;
-        // Connect eagerly to validate configuration at construction (preserves
-        // the prior constructor behaviour); this becomes the non-coroutine
-        // fallback connection.
-        $this->fallback = $this->connect();
+        // #271 — do NOT connect eagerly here. Under HOOK_ALL, `\Redis->connect()`
+        // is a coroutine API, so constructing the handler at a non-coroutine point
+        // (boot / middleware registration — e.g. with `sessionLifecycle(false)`,
+        // where the app installs its own save handler before the request loop)
+        // fataled with "API must be called in the coroutine". The connection is
+        // now established lazily in `redis()` on first use — a per-coroutine socket
+        // inside a request, or the `$fallback` (`??=`) outside one — both of which
+        // are always safe contexts. `$fallback` is already nullable + lazy.
     }
 
     /**

--- a/tests/Unit/RedisSessionHandlerTest.php
+++ b/tests/Unit/RedisSessionHandlerTest.php
@@ -102,12 +102,25 @@ class RedisSessionHandlerTest extends TestCase
         if (!extension_loaded('redis')) {
             $this->markTestSkipped('ext-redis not loaded — connected tests skipped.');
         }
+        // #271 — the handler no longer connects in its constructor (the eager
+        // connect would fatal under HOOK_ALL outside a coroutine), so the old
+        // "construct → catch" probe can't detect an unreachable Redis: the
+        // constructor now always succeeds. Probe explicitly with a raw client.
+        $ok = false;
         try {
-            $h = new RedisSessionHandler('127.0.0.1', 6379, 'PHPREDIS_SESSION_TEST:', 60);
+            $probe = new \Redis();
+            if (@$probe->connect('127.0.0.1', 6379, 0.5)) {
+                $probe->ping();
+                $probe->close();
+                $ok = true;
+            }
         } catch (\Throwable $e) {
-            $this->markTestSkipped('Redis not reachable at 127.0.0.1:6379 — connected tests skipped: ' . $e->getMessage());
+            $ok = false;
         }
-        return $h;
+        if ($ok !== true) {
+            $this->markTestSkipped('Redis not reachable at 127.0.0.1:6379 — connected tests skipped.');
+        }
+        return new RedisSessionHandler('127.0.0.1', 6379, 'PHPREDIS_SESSION_TEST:', 60);
     }
 
     public function testOpenReturnsTrueOnConnected(): void

--- a/tests/Unit/RedisSessionHandlerTest.php
+++ b/tests/Unit/RedisSessionHandlerTest.php
@@ -43,6 +43,23 @@ class RedisSessionHandlerTest extends TestCase
         );
     }
 
+    public function testConstructorDoesNotConnectEagerly(): void
+    {
+        // #271 — the constructor must NOT call connect(). Under HOOK_ALL,
+        // \Redis->connect() is a coroutine API, so connecting at construction
+        // (a non-coroutine point — boot / middleware registration with
+        // sessionLifecycle(false)) fataled "API must be called in the coroutine".
+        // Construction with an unreachable host must succeed without touching the
+        // socket; the connection is established lazily on first redis() use.
+        $handler = new RedisSessionHandler('192.0.2.1', 6379); // TEST-NET-1 (non-routable)
+        $ref = new \ReflectionProperty($handler, 'fallback');
+        $ref->setAccessible(true);
+        $this->assertNull(
+            $ref->getValue($handler),
+            'constructor must not establish the fallback connection (#271)'
+        );
+    }
+
     public function testExposesAllSessionHandlerInterfaceMethods(): void
     {
         $required = ['open', 'close', 'read', 'write', 'destroy', 'gc'];


### PR DESCRIPTION
Closes #271.

`superglobals(true)` + `sessionLifecycle(false)` + a custom `RedisSessionHandler` crashed every session request with **"API must be called in the coroutine"** (status=255, workers cycling).

**Root cause:** the constructor eagerly called `$this->connect()` → `\Redis->connect()`, which HOOK_ALL turns into a coroutine API. Constructing the handler at a **non-coroutine point** — boot / middleware registration, exactly where a `sessionLifecycle(false)` app installs its own save handler — fatals.

**Fix:** the eager connect was redundant — `redis()` already builds the fallback lazily via `$this->fallback ??= $this->connect()`. Removed the constructor connect, so the handler is built without touching the socket; the connection is established on first use (per-coroutine inside a request, `$fallback` outside). Config errors now surface on first `open()`/`read()` instead of at construction.

**Validated:** new `RedisSessionHandlerTest::testConstructorDoesNotConnectEagerly` (constructs against a non-routable host, asserts no fallback connection); 13-test suite green; PHPStan L10 clean.