### PR TITLE
fix: boot-time $GLOBALS visible to all request coroutines — App::refreshGlobalsBaseline() (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Boot-time `$GLOBALS` writes are now visible to every request coroutine in coroutine-legacy (#26, needs ext-zealphp 0.3.33+).** Under coroutine-legacy the per-coroutine `$GLOBALS` baseline is snapshotted once, when isolation activates; a boot write that lands after activation (e.g. an app bootstrap include like `load.php` at worker start) wasn't in the baseline, so it survived only for the *first* request coroutine and vanished for every subsequent one once a yield reset `$GLOBALS` to the stale baseline (reproduced: 1/8 concurrent requests saw the boot global). The framework now calls the new `App::refreshGlobalsBaseline()` once after the `onWorkerStart` hooks complete, folding those boot writes into the baseline so all requests see them; apps that populate `$GLOBALS` later in boot can call it explicitly. No-op on older ext / when isolation is inactive. Backed by ext-zealphp `zealphp_globals_baseline_refresh()` (validated 8/8 concurrent, ASAN-clean).
+
 ### Security & hardening (architecture-review pass)
 
 A focused hardening pass closing the highest-blast-radius gaps from a full architectural review — scalability backpressure, session edge cases, and the cross-node Redis/WebSocket fabric. Most reuse patterns the framework already had elsewhere; defaults that were unsafe for production are now safe-by-default or surfaced with a boot advisory.

--- a/src/App.php
+++ b/src/App.php
@@ -3039,6 +3039,32 @@ class App
     }
 
     /**
+     * Re-capture the per-coroutine `$GLOBALS` baseline from the current symbol table.
+     *
+     * Under coroutine-legacy, ext-zealphp snapshots the parent `$GLOBALS` baseline
+     * once — when `coroutineGlobalsIsolation` activates. Boot-time `$GLOBALS` writes
+     * that happen AFTER that (e.g. an app bootstrap include such as `load.php` at
+     * worker start) aren't in the baseline, so they'd be visible only to the FIRST
+     * request coroutine and vanish for every subsequent one once a yield resets
+     * `$GLOBALS` to the stale baseline (#26). The framework calls this once after the
+     * `onWorkerStart` hooks complete (where such bootstraps run) to fold those writes
+     * into the baseline; apps that populate `$GLOBALS` later in boot can call it
+     * explicitly afterwards.
+     *
+     * No-op returning `false` when ext-zealphp lacks the function (< 0.3.33) or
+     * per-coroutine `$GLOBALS` isolation isn't active — always safe to call.
+     *
+     * @return bool True if the baseline was refreshed.
+     */
+    public static function refreshGlobalsBaseline(): bool
+    {
+        if (!\function_exists('zealphp_globals_baseline_refresh')) {
+            return false;
+        }
+        return (bool) \zealphp_globals_baseline_refresh();
+    }
+
+    /**
      * Keep `$GLOBALS` across requests within the worker. See $keep_globals
      * docblock for the full semantics + when to use it.
      */
@@ -8408,6 +8434,12 @@ class App
             foreach (self::$workerStartHooks as $hook) {
                 $hook($server, $workerId);
             }
+
+            // #26 — fold any boot-time $GLOBALS writes made during the onWorkerStart
+            // hooks (app bootstrap includes like load.php) into the per-coroutine
+            // baseline, so every request coroutine sees them — not just the first.
+            // No-op unless coroutine-legacy $GLOBALS isolation is active (ext 0.3.33+).
+            self::refreshGlobalsBaseline();
 
             // Dev route hot-reload: each worker polls route/*.php mtimes and
             // rebuilds its route table in-place on change — "save file → routes

--- a/tests/Unit/AppStaticHelpersTest.php
+++ b/tests/Unit/AppStaticHelpersTest.php
@@ -462,4 +462,16 @@ class AppStaticHelpersTest extends TestCase
         $this->assertSame(500, $res->getStatusCode());
         $this->assertStringContainsString('500 Internal Server Error', (string) $res->getBody());
     }
+
+    public function testRefreshGlobalsBaselineIsSafeNoOpWithoutExt(): void
+    {
+        // #26 — without ext-zealphp 0.3.33+ the helper is a safe no-op returning
+        // false, so the worker-start auto-call never errors on a stock PHP build.
+        // The real refresh behaviour (post-activation boot $GLOBALS visible to every
+        // request coroutine, not just the first) is validated against the ASAN ext.
+        if (\function_exists('zealphp_globals_baseline_refresh')) {
+            $this->markTestSkipped('ext-zealphp 0.3.33+ present — no-op contract not exercised here.');
+        }
+        $this->assertFalse(\ZealPHP\App::refreshGlobalsBaseline());
+    }
 }


### PR DESCRIPTION
Closes #26 (framework side; companion ext PR **sibidharan/ext-zealphp#27**, needs ext-zealphp **0.3.33+**).

**Bug:** under coroutine-legacy the per-coroutine `$GLOBALS` baseline is snapshotted **once**, when isolation activates. A boot-time `$GLOBALS` write that lands **after** activation — an app bootstrap include (`load.php`) at worker start — isn't in the baseline, so it survives only for the **first** request coroutine and vanishes for every subsequent one once a yield resets `$GLOBALS` to the stale baseline. Reproduced on the ASAN ext: **1/8** concurrent requests saw the boot global.

**Fix:** new `App::refreshGlobalsBaseline()` (delegates to ext `zealphp_globals_baseline_refresh()`), called once **after the `onWorkerStart` hooks complete** — where app bootstraps run — folding those writes into the baseline. No-op on older ext / when isolation is inactive, so it's safe on every build; apps that populate `$GLOBALS` later in boot can call it explicitly.

**Validated 8/8** concurrent (was 1/8) on the ASAN ext build, ASAN-clean; PHPStan L10 clean; no-op contract pinned by `AppStaticHelpersTest::testRefreshGlobalsBaselineIsSafeNoOpWithoutExt`.

> The `setup.sh` default ext-version bump to v0.3.33 will follow once ext PR #27 is merged + tagged.