### PR TITLE
chore: refresh agent reference for v0.4.3 docs

### DIFF
--- a/examples/agents/zealphp_reference.txt
+++ b/examples/agents/zealphp_reference.txt
@@ -5497,7 +5497,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.2 .
+docker build -t zealphp:0.4.3 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -5508,8 +5508,8 @@ versions with the build args:
 ```bash
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
-    --build-arg ZEALPHP_EXT_VERSION=v0.3.26 \
-    -t zealphp:0.4.2 .
+    --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
+    -t zealphp:0.4.3 .
 ```
 
 ### Run (single container)
@@ -5521,7 +5521,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.2
+    zealphp:0.4.3
 ```
 
 ### Production compose
@@ -5532,7 +5532,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.2
+    image: registry.example.com/zealphp-app:0.4.3
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
Regenerated `examples/agents/zealphp_reference.txt` from `docs/*.md` after the v0.4.3 release (deployment doc version + ext-default refs → 0.4.3 / v0.3.33). The scaffold's `llms.txt` is a copy of this file. Docs-only.