### PR TITLE
fix(session): RedisSessionHandler open() path fatals outside a request coroutine (#285, follow-up to #271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`RedisSessionHandler` save-handler ops no longer fatal outside a request coroutine (#285, follow-up to #271).** #271 made the *constructor* lazy, but `open()`/`read()`/`write()`/`destroy()` are themselves the first hooked `\Redis` call (`connect()` + `watch`/`get`/`multi`/`exec`/`del`), so under `App::superglobals(true)` WITHOUT `enableCoroutine(true)` — where the `onRequest` handler isn't auto-wrapped in a coroutine but `HOOK_ALL` still hooks `\Redis` (e.g. an app installing its own save handler via `sessionLifecycle(false)` and calling `session_start()` from middleware) — every save-handler call ran at `getCid() == -1` and fataled "API must be called in the coroutine", killing the worker. The handler now routes every Redis op through an `io()` wrapper that runs it inside `Coroutine::run()` when outside a coroutine (reusing the persistent `$fallback` connection so `WATCH`/`MULTI`/`EXEC` optimistic locking still spans `read()` -> `write()`), and directly on the per-coroutine socket when inside one (issue #16 unchanged). Validated on PHP 8.4 + OpenSwoole 26.2.0 + phpredis 6.3: old code fatals, new code completes the full open/read/write/destroy cycle outside a coroutine, 30/30 concurrent sessions stay isolated, ASAN-clean. Canonical validation: `scripts/spike-session-handler-nocoroutine.php` (PHPUnit can't enable HOOK_ALL process-wide).
+
 ## [0.4.3] - 2026-06-05
 
 A migration-hardening release: runtime, CGI, and session fixes surfaced by a downstream

--- a/scripts/spike-session-handler-nocoroutine.php
+++ b/scripts/spike-session-handler-nocoroutine.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * #285 spike — `RedisSessionHandler` save-handler ops outside a request coroutine.
+ *
+ * Under `App::superglobals(true)` WITHOUT `enableCoroutine(true)` the `onRequest`
+ * handler is NOT auto-wrapped in a coroutine, yet `HOOK_ALL` still hooks `\Redis`.
+ * The PHP session save-handler chain (`session_start()` -> `open()` -> `read()`,
+ * later `session_write_close()` -> `write()` -> `close()`) then runs every hooked
+ * `\Redis` call with `getCid() == -1`, fataling "API must be called in the
+ * coroutine". #271 made the *constructor* lazy; #285 is the open()/read() sequel.
+ *
+ * PHPUnit can't enable `HOOK_ALL` process-wide, so this is the canonical
+ * validation (same pattern as `scripts/spike-phpredis-subscribe.php`). It asserts:
+ *   1. OLD behaviour — a bare `\Redis->connect()` outside a coroutine fatals
+ *      (documented; not executed here so the spike can continue).
+ *   2. NEW behaviour — a full open -> write -> read -> destroy cycle on the real
+ *      handler works OUTSIDE a coroutine (the io() wrapper runs each op inside
+ *      `Coroutine::run()` on the persistent $fallback connection).
+ *   3. No regression — the same cycle works INSIDE a coroutine (per-coroutine
+ *      socket, issue #16), and N concurrent coroutines never cross frames.
+ *
+ * Run: `php scripts/spike-session-handler-nocoroutine.php`
+ * Needs ext-redis + a Redis reachable at 127.0.0.1:6379 (override with REDIS_HOST
+ * / REDIS_PORT env). Validated on PHP 8.4 + OpenSwoole 26.2.0 + phpredis 6.3.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenSwoole\Coroutine;
+use OpenSwoole\Coroutine\Channel;
+use OpenSwoole\Runtime;
+use ZealPHP\Session\Handler\RedisSessionHandler;
+
+if (!extension_loaded('redis')) {
+    fwrite(STDERR, "SKIP: ext-redis not loaded.\n");
+    exit(0);
+}
+
+$host = getenv('REDIS_HOST') ?: '127.0.0.1';
+$port = (int) (getenv('REDIS_PORT') ?: 6379);
+
+// Reproduce the production runtime: superglobals(true)-style — HOOK_ALL on, but NO
+// per-request coroutine wrapper. The save-handler chain therefore runs at cid == -1.
+Runtime::enableCoroutine(Runtime::HOOK_ALL);
+
+// Reachability probe (must itself run in a coroutine — connect is hooked).
+$reachable = false;
+Coroutine::run(function () use ($host, $port, &$reachable): void {
+    try {
+        $probe = new \Redis();
+        if (@$probe->connect($host, $port, 0.5)) {
+            $probe->ping();
+            $probe->close();
+            $reachable = true;
+        }
+    } catch (\Throwable) {
+        $reachable = false;
+    }
+});
+if (!$reachable) {
+    fwrite(STDERR, "SKIP: Redis not reachable at {$host}:{$port}.\n");
+    exit(0);
+}
+
+$fail = 0;
+$check = static function (string $label, bool $ok) use (&$fail): void {
+    echo ($ok ? '  ok   ' : '  FAIL ') . $label . "\n";
+    if (!$ok) {
+        $fail++;
+    }
+};
+
+// (2) NEW handler — full cycle OUTSIDE any coroutine (the #285 scenario).
+echo "Outside a coroutine (cid=" . Coroutine::getCid() . "):\n";
+$sid = 't285_' . bin2hex(random_bytes(4));
+$h = new RedisSessionHandler($host, $port, 'SPIKE285:', 60);
+$check('open() does not fatal', $h->open('', 'PHPSESSID') === true);
+$check('write() round-trips', $h->write($sid, 'user_id|i:42;') === true);
+$check('read() returns the written value', $h->read($sid) === 'user_id|i:42;');
+$check('destroy() succeeds', $h->destroy($sid) === true);
+$check('read-after-destroy is empty', $h->read($sid) === '');
+
+// (3a) NEW handler — same cycle INSIDE a coroutine (per-coroutine path, issue #16).
+echo "Inside a coroutine:\n";
+Coroutine::run(function () use ($host, $port, $check): void {
+    $sid = 't285c_' . bin2hex(random_bytes(4));
+    $h = new RedisSessionHandler($host, $port, 'SPIKE285:', 60);
+    $check('in-coroutine open()', $h->open('', 'PHPSESSID') === true);
+    $h->write($sid, 'x|i:7;');
+    $check('in-coroutine write+read', $h->read($sid) === 'x|i:7;');
+    $h->destroy($sid);
+});
+
+// (3b) Concurrency — one shared handler, N coroutines, distinct sessions, zero cross-talk.
+echo "Concurrent (shared handler, 30 coroutines):\n";
+$n = 30;
+$correct = 0;
+$h2 = new RedisSessionHandler($host, $port, 'SPIKE285C:', 60);
+Coroutine::run(function () use ($h2, $n, &$correct): void {
+    $wg = new Channel($n);
+    for ($i = 0; $i < $n; $i++) {
+        go(function () use ($h2, $i, $wg, &$correct): void {
+            $sid = "conc_$i";
+            $val = "v|i:$i;";
+            $h2->open('', 'PHPSESSID');
+            $h2->write($sid, $val);
+            usleep(10000); // hooked under HOOK_ALL — yields, maximising interleave
+            if ($h2->read($sid) === $val) {
+                $correct++;
+            }
+            $h2->destroy($sid);
+            $wg->push(1);
+        });
+    }
+    for ($i = 0; $i < $n; $i++) {
+        $wg->pop(5.0);
+    }
+});
+$check("all $n coroutines read back their OWN value", $correct === $n);
+
+echo $fail === 0 ? "\nPASS — #285 handler is coroutine-safe in every context.\n" : "\nFAIL ($fail).\n";
+exit($fail === 0 ? 0 : 1);

--- a/src/Session/Handler/RedisSessionHandler.php
+++ b/src/Session/Handler/RedisSessionHandler.php
@@ -80,27 +80,83 @@ class RedisSessionHandler implements \SessionHandlerInterface
     }
 
     /**
-     * Per-coroutine Redis connection.
+     * Resolve the Redis connection for the CURRENT context.
      *
-     * Each coroutine gets its own socket so concurrent session I/O never crosses
-     * frames (issue #16). The connection is stored in the coroutine context under
-     * the key `'__zeal_redis_session'` and is reaped automatically when the
-     * coroutine ends. Outside a coroutine, the construction-time `$fallback`
-     * connection is reused.
+     * In a coroutine: a per-coroutine socket stored in the coroutine context
+     * (issue #16 — concurrent coroutines must never share a socket and interleave
+     * RESP frames; the connection is reaped when the coroutine ends). Outside a
+     * coroutine: the shared `$fallback`. The connection is established lazily here.
+     *
+     * Callers reach this only through `io()`, which guarantees a coroutine is live
+     * before `connect()`'s hooked `\Redis->connect()` runs.
      */
-    private function redis(): \Redis
+    private function conn(): \Redis
     {
         $cid = \OpenSwoole\Coroutine::getCid();
         if ($cid < 0) {
             return $this->fallback ??= $this->connect();
         }
         $context = \OpenSwoole\Coroutine::getContext($cid);
-        if (!isset($context['__zeal_redis_session'])) {
-            $context['__zeal_redis_session'] = $this->connect();
+        $existing = $context['__zeal_redis_session'] ?? null;
+        if ($existing instanceof \Redis) {
+            return $existing;
         }
-        $conn = $context['__zeal_redis_session'];
-        assert($conn instanceof \Redis);
-        return $conn;
+        $fresh = $this->connect();
+        $context['__zeal_redis_session'] = $fresh;
+        return $fresh;
+    }
+
+    /**
+     * Run a Redis save-handler operation, guaranteeing it executes inside a
+     * coroutine.
+     *
+     * Every `\Redis` call in this handler — the `connect()` plus
+     * `watch`/`get`/`multi`/`exec`/`del` — is hooked I/O under
+     * `OpenSwoole\Runtime::HOOK_ALL`, so it FATALS with
+     * "API must be called in the coroutine" when the PHP session save-handler
+     * chain fires OUTSIDE a request coroutine. That happens under
+     * `App::superglobals(true)` WITHOUT `enableCoroutine(true)`: the `onRequest`
+     * handler isn't auto-wrapped in a coroutine, yet HOOK_ALL still hooks `\Redis`
+     * — e.g. an app that installs its own save handler via `sessionLifecycle(false)`
+     * and calls `session_start()` from middleware. #271 made the *constructor*
+     * lazy, but `open()`/`read()` are themselves "first use" and still hit the wall
+     * (#285).
+     *
+     * When already in a coroutine, run `$op` directly on the per-coroutine
+     * connection. When NOT, run it inside `Coroutine::run()` on the shared
+     * `$fallback` (the `App::parallel` / #261 sync-mode idiom — `Coroutine::run`
+     * swallows throws, so capture + rethrow to keep a Redis error a catchable
+     * exception, not a worker-killing fatal). `$fallback` persists across these
+     * sequential transient runs, so the connection — and `WATCH` (read) ->
+     * `MULTI`/`EXEC` (write) optimistic locking — spans the whole request.
+     * Validated against a live Redis: a hooked socket created in one
+     * `Coroutine::run()` is reused, with `WATCH`/`MULTI`/`EXEC` intact, in later
+     * runs. (In this no-request-coroutine mode a worker handles requests
+     * sequentially, so there is no concurrent writer for the lock to guard anyway.)
+     *
+     * @param callable(\Redis): mixed $op
+     */
+    private function io(callable $op): mixed
+    {
+        if (\OpenSwoole\Coroutine::getCid() >= 0) {
+            return $op($this->conn());
+        }
+        $result = null;
+        $error  = null;
+        \OpenSwoole\Coroutine::run(function () use ($op, &$result, &$error): void {
+            try {
+                if ($this->fallback === null) {
+                    $this->fallback = $this->connect();
+                }
+                $result = $op($this->fallback);
+            } catch (\Throwable $e) {
+                $error = $e;
+            }
+        });
+        if ($error !== null) {
+            throw $error;
+        }
+        return $result;
     }
 
     /**
@@ -109,7 +165,7 @@ class RedisSessionHandler implements \SessionHandlerInterface
      */
     public function open($savePath, $sessionName): bool
     {
-        return $this->redis()->isConnected();
+        return $this->io(static fn(\Redis $r): bool => $r->isConnected()) === true;
     }
 
     /**
@@ -137,13 +193,16 @@ class RedisSessionHandler implements \SessionHandlerInterface
      */
     public function read($sessionId): string
     {
-        $redis = $this->redis();
         $key = $this->prefix . $sessionId;
-        $redis->watch($key);
-        $data = $redis->get($key);
-        $base = is_string($data) ? $data : '';
-        $this->baseData[(string) $sessionId] = $base;
-        return $base;
+        $sid = (string) $sessionId;
+        $out = $this->io(function (\Redis $redis) use ($key, $sid): string {
+            $redis->watch($key);
+            $data = $redis->get($key);
+            $base = is_string($data) ? $data : '';
+            $this->baseData[$sid] = $base;
+            return $base;
+        });
+        return is_string($out) ? $out : '';
     }
 
     /**
@@ -156,34 +215,34 @@ class RedisSessionHandler implements \SessionHandlerInterface
      */
     public function write($sessionId, $sessionData): bool
     {
-        $redis = $this->redis();
         $key = $this->prefix . $sessionId;
         $sid = (string) $sessionId;
+        return $this->io(function (\Redis $redis) use ($key, $sid, $sessionData): bool {
+            for ($attempt = 0; $attempt < 3; $attempt++) {
+                $pipe = $redis->multi();
+                $pipe->setex($key, $this->ttl, $sessionData);
+                $result = $pipe->exec();
+                if ($result !== false) {
+                    // The read→write merge baseline is consumed; drop it so the
+                    // per-instance map doesn't grow with every distinct session id
+                    // for the worker's lifetime (this is a singleton handler).
+                    unset($this->baseData[$sid]);
+                    return true;
+                }
 
-        for ($attempt = 0; $attempt < 3; $attempt++) {
-            $pipe = $redis->multi();
-            $pipe->setex($key, $this->ttl, $sessionData);
-            $result = $pipe->exec();
-            if ($result !== false) {
-                // The read→write merge baseline is consumed; drop it so the
-                // per-instance map doesn't grow with every distinct session id
-                // for the worker's lifetime (this is a singleton handler).
-                unset($this->baseData[$sid]);
-                return true;
+                // WATCH/MULTI conflict — concurrent writer beat us. Re-WATCH,
+                // read the current state, 3-way merge (base = our original
+                // read, local = our intended write, remote = current). Retry.
+                $redis->watch($key);
+                $remote = $redis->get($key);
+                $remoteStr = is_string($remote) ? $remote : '';
+                $base = $this->baseData[$sid] ?? '';
+                $sessionData = $this->merge3Sessions($base, $sessionData, $remoteStr);
+                $this->baseData[$sid] = $remoteStr;
             }
-
-            // WATCH/MULTI conflict — concurrent writer beat us. Re-WATCH,
-            // read the current state, 3-way merge (base = our original
-            // read, local = our intended write, remote = current). Retry.
-            $redis->watch($key);
-            $remote = $redis->get($key);
-            $remoteStr = is_string($remote) ? $remote : '';
-            $base = $this->baseData[$sid] ?? '';
-            $sessionData = $this->merge3Sessions($base, $sessionData, $remoteStr);
-            $this->baseData[$sid] = $remoteStr;
-        }
-        unset($this->baseData[$sid]); // bound the map even when all retries fail
-        return false;
+            unset($this->baseData[$sid]); // bound the map even when all retries fail
+            return false;
+        }) === true;
     }
 
     /**
@@ -296,9 +355,13 @@ class RedisSessionHandler implements \SessionHandlerInterface
      */
     public function destroy($sessionId): bool
     {
-        $this->redis()->del($this->prefix . $sessionId);
-        unset($this->baseData[(string) $sessionId]);
-        return true;
+        $key = $this->prefix . $sessionId;
+        $sid = (string) $sessionId;
+        return $this->io(function (\Redis $redis) use ($key, $sid): bool {
+            $redis->del($key);
+            unset($this->baseData[$sid]);
+            return true;
+        }) === true;
     }
 
     /**
@@ -319,6 +382,10 @@ class RedisSessionHandler implements \SessionHandlerInterface
      */
     public function getRedis(): \Redis
     {
-        return $this->redis();
+        $conn = $this->io(static fn(\Redis $r): \Redis => $r);
+        if (!$conn instanceof \Redis) {
+            throw new \RuntimeException('RedisSessionHandler: Redis connection unavailable.');
+        }
+        return $conn;
     }
 }


### PR DESCRIPTION
Closes #285.

## Bug
#271 (v0.4.3) made the `RedisSessionHandler` **constructor** lazy — but the save-handler ops are themselves the first hooked `\Redis` call (`connect()` + `watch`/`get`/`multi`/`exec`/`del`). Under `App::superglobals(true)` **without** `enableCoroutine(true)` the `onRequest` handler isn't auto-wrapped in a coroutine, yet `HOOK_ALL` still hooks `\Redis`. So `session_start()` → `open()` → `\Redis->connect()` ran at `getCid() == -1` and fataled `API must be called in the coroutine` — **every worker died, every request timed out**. Triggered by the `sessionLifecycle(false)` pattern (app installs its own save handler and `session_start()`s from middleware).

## Why the issue's option (b) alone wouldn't work
"Use `$fallback` when `getCid()==-1`" doesn't help — `$fallback` **also** connects via the hooked `\Redis->connect()`, which fatals outside a coroutine. The whole op chain (not just connect) needs a coroutine.

## Fix
An `io()` wrapper routes every Redis op:
- **Outside a coroutine** → run it inside `Coroutine::run()` (the `App::parallel` / #261 sync-mode idiom; `Coroutine::run` swallows throws, so capture + rethrow → a Redis error stays a catchable exception, not a worker-killing fatal). Reuses the persistent `$fallback` across the sequential transient runs, so `WATCH` (read) → `MULTI`/`EXEC` (write) optimistic locking still spans the request.
- **Inside a coroutine** → run directly on the per-coroutine socket (**issue #16 unchanged**).

## Validation — bidirectional, on the exact production stack
Built ext-redis into the rig (PHP 8.4 + **OpenSwoole 26.2.0** — same as the reporter — + phpredis 6.3), real handler class:

| Test | Scenario | Result |
|---|---|---|
| A (old) | `\Redis->connect()` outside a coroutine | **FATAL** `API must be called in the coroutine` (reproduces #285) |
| B (new) | full open→write→read→destroy **outside** a coroutine (cid=-1) | **all pass, round-trips, no fatal** |
| C (new) | full cycle **inside** a coroutine (cid=6) | **works, no regression** |
| #16 | 30 concurrent coroutines, shared handler, distinct sessions | **30/30 read their OWN value** |

ASAN-clean throughout. Canonical validation script: **`scripts/spike-session-handler-nocoroutine.php`** (PHPUnit can't enable HOOK_ALL process-wide — same precedent as `spike-phpredis-subscribe.php`). PHPStan L10 clean; `RedisSessionHandlerTest` green.

## Broader note (not in scope here)
This fixes the framework's own session handler, but `HOOK_ALL` + `enableCoroutine(false)` is a general foot-gun: **any** other hooked I/O (curl, PDO-mysqlnd, streams) in a request handler will likewise fatal outside an explicit coroutine. The robust mode is `App::mode(App::MODE_COROUTINE_LEGACY)` (or `enableCoroutine(true)`), which wraps each request in a coroutine. A boot advisory for the `HOOK_ALL` + `!enableCoroutine` combo is a sensible follow-up.