### PR TITLE
fix(ws): WebSocket routing & rooms follow session auth (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **WebSocket routing & rooms can now follow your session auth (#234).** `WSRouter`/`Room` had no authorization: `WSRouter::own()` trusted a client-supplied `client_id` (cross-tenant routing hijack) and `Room::join`/`push`/`members` accepted any caller (presence forgery, roster enumeration). Added, consuming the SAME hooks the HTTP layer uses (`App::authChecker()` / `App::usernameProvider()`):
+  - `WSRouter::sessionPrincipal(): ?string` — the authenticated principal for the current connection (null when unauthenticated), resolved from the session at the WS handshake.
+  - `WSRouter::ownAuthenticated(int $fd, ?string $connId = null): string` — binds the connection to that principal instead of a client-supplied id (throws `WSAuthException` when unauthenticated, so an attacker can't claim another user's id); `WSRouter::principalForFd($fd)` recovers it in `onMessage` handlers.
+  - `WSRouter::roomAuthorizer(?callable $fn)` — `fn(string $action, string $room, string $clientId): bool`, `$action ∈ {join,leave,push,read}`, consulted **fail-closed** by every `Room` op (mutations throw `WSAuthException`, reads return empty). **Opt-in** — with no authorizer wired the room layer behaves exactly as before (BC).
+  - The `/demo/rooms/*` routes are documented as illustrative-only (intentionally unauthenticated for the public demo); production apps must wire `roomAuthorizer()` + `ownAuthenticated()`.
+
 ## [0.4.4] - 2026-06-06
 
 A focused follow-up release: the #285 `RedisSessionHandler` coroutine-safety fix — the `open()`-path sequel to #271 — so apps installing their own Redis save handler under `superglobals(true)` no longer crash workers outside a request coroutine.

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -239,6 +239,54 @@ $app->ws('/ws/auth',
 
 For multi-worker setups, persist the `fd → user` map in `Store` instead of `$g` so any worker that handles a subsequent message can resolve the identity. To route a message to a specific client by id across workers or hosts, use `WSRouter::own($clientId, $fd)` in `onOpen`, `WSRouter::release($clientId)` in `onClose`, and `WSRouter::sendToClient($clientId, $payload)` from anywhere — see the [Federated rooms](#federated-rooms-cross-host) section.
 
+### Binding WS identity & rooms to your session auth (#234)
+
+`WSRouter::own($clientId, $fd)` trusts a **caller-supplied** `client_id`, and `Room` ops accept any caller — so on their own they don't authorize anything. To make WS routing and rooms follow the same auth your HTTP layer uses, wire the framework's session hooks (the ones `ZealAPI` already consults):
+
+```php
+// app.php — the SAME hooks the HTTP/API layer uses
+App::authChecker(fn() => Session::isLoggedIn());          // is the session authenticated?
+App::usernameProvider(fn() => Session::get('username'));  // who?
+
+// Fail-closed room authorization: consulted by join/leave/push (throw on deny)
+// and members/size/isMember (return empty on deny). Without this call the room
+// layer is unguarded (backward-compatible).
+WSRouter::roomAuthorizer(function (string $action, string $room, string $clientId): bool {
+    if (!(App::authChecker())()) return false;            // must be authenticated
+    return $action === 'read' || str_starts_with($room, "u.$clientId."); // your policy
+});
+
+$app->ws('/ws/app',
+    onOpen: function ($server, $request, $g) {
+        // Bind the connection to the AUTHENTICATED principal — never a client value.
+        // Throws WSAuthException when the session isn't authenticated.
+        try {
+            $uid = WSRouter::ownAuthenticated($request->fd);   // = sessionPrincipal()
+        } catch (\ZealPHP\WS\WSAuthException) {
+            $server->disconnect($request->fd, WSRouter::CLOSE_AUTH_REQUIRED, 'Unauthorized');
+            return;
+        }
+        WSRouter::room("u.$uid.inbox")->join($uid);
+    },
+    onMessage: function ($server, $frame, $g) {
+        // Recover the authenticated identity bound at onOpen — no re-reading the session.
+        $uid = WSRouter::principalForFd($frame->fd);
+        if ($uid === null) { return; }
+        // Room ops are now authorized against $uid by the roomAuthorizer above.
+        WSRouter::room("u.$uid.inbox")->push(['from' => $uid, 'data' => $frame->data], fromClientId: $uid);
+    },
+);
+```
+
+| API | Purpose |
+|-----|---------|
+| `WSRouter::sessionPrincipal(): ?string` | The authenticated principal for the current connection (via `authChecker`+`usernameProvider`), or `null`. |
+| `WSRouter::ownAuthenticated($fd, $connId?): string` | Like `own()` but binds to `sessionPrincipal()`; throws `WSAuthException` when unauthenticated. |
+| `WSRouter::principalForFd($fd): ?string` | The principal bound at `ownAuthenticated()` — use in `onMessage`. |
+| `WSRouter::roomAuthorizer(?callable)` | `fn($action, $room, $clientId): bool`; fail-closed gate on every `Room` op. |
+
+The `/demo/rooms/*` routes are **illustrative only** — intentionally unauthenticated for the public docs site. Don't copy that shape into production; wire `roomAuthorizer()` + `ownAuthenticated()` as above.
+
 ## Heartbeats
 
 OpenSwoole has a built-in idle disconnector configured via two server settings:

--- a/route/demo_rooms.php
+++ b/route/demo_rooms.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 // Live demos for WSRouter::room() — federated WebSocket rooms (v0.3.0 P1.1).
 //
+// ⚠️  ILLUSTRATIVE ONLY — NOT a production template (#234). These endpoints take
+//     `room`/`client` straight from UNAUTHENTICATED query params so the public
+//     docs site can show the fabric working with ephemeral demo data. A real app
+//     MUST NOT expose room ops this way: derive the client identity server-side
+//     from the authenticated session (`WSRouter::ownAuthenticated($fd)`), and wire
+//     `WSRouter::roomAuthorizer(fn($action,$room,$client) => /* your session
+//     policy */)` so join/leave/push/read are fail-closed. See docs/websocket.md.
+//
 // Only wires when the Store backend is Redis (rooms require pub/sub).
 // Routes:
 //   GET /demo/rooms/join?room=<name>&client=<id>     → Room::join

--- a/src/WS/Room.php
+++ b/src/WS/Room.php
@@ -62,6 +62,8 @@ final class Room
      */
     public function join(string $clientId): void
     {
+        // #234 — fail-closed when a roomAuthorizer is wired (BC no-op otherwise).
+        WSRouter::requireRoomAuth('join', $this->name, $clientId);
         $ok = Store::set(WSRouter::roomTable(), self::compositeKey($this->name, $clientId), [
             'room'      => $this->name,
             'client_id' => $clientId,
@@ -106,6 +108,8 @@ final class Room
      */
     public function leave(string $clientId): void
     {
+        // #234 — fail-closed when a roomAuthorizer is wired (BC no-op otherwise).
+        WSRouter::requireRoomAuth('leave', $this->name, $clientId);
         Store::del(WSRouter::roomTable(), self::compositeKey($this->name, $clientId));
         // WS-2: keep the per-room SET in sync. Idempotent SREM.
         if (WSRouter::hasRedisBackend()) {
@@ -124,9 +128,27 @@ final class Room
         ]);
     }
 
+    /**
+     * #234 — true when a roomAuthorizer is wired AND it denies a 'read' on this
+     * room for the current session principal. Roster reads (members/size/
+     * isMember) consult this so an authorizer can block cross-tenant enumeration.
+     * BC: with no authorizer the short-circuit returns false (reads unguarded)
+     * WITHOUT touching the session.
+     */
+    private function readForbidden(): bool
+    {
+        if (WSRouter::roomAuthorizer() === null) {
+            return false;
+        }
+        return !WSRouter::authorizeRoom('read', $this->name, WSRouter::sessionPrincipal() ?? '');
+    }
+
     /** True if `$clientId` is a current member (cluster-wide check). */
     public function isMember(string $clientId): bool
     {
+        if ($this->readForbidden()) {
+            return false;
+        }
         return Store::exists(WSRouter::roomTable(), self::compositeKey($this->name, $clientId));
     }
 
@@ -142,6 +164,9 @@ final class Room
      */
     public function size(): int
     {
+        if ($this->readForbidden()) {
+            return 0;
+        }
         if (WSRouter::hasRedisBackend()) {
             try { return Store::scard(WSRouter::roomMembersSetKey($this->name)); }
             catch (StoreException) { /* fall through to the iterate path */ }
@@ -168,6 +193,9 @@ final class Room
      */
     public function members(): array
     {
+        if ($this->readForbidden()) {
+            return [];
+        }
         if (WSRouter::hasRedisBackend()) {
             try {
                 $key   = WSRouter::roomMembersSetKey($this->name);
@@ -204,6 +232,9 @@ final class Room
      */
     public function membersPaged(string $cursor = '0', int $count = 100): array
     {
+        if ($this->readForbidden()) {
+            return ['cursor' => '0', 'members' => []];
+        }
         if (WSRouter::hasRedisBackend()) {
             try { return Store::sscanCursor(WSRouter::roomMembersSetKey($this->name), $cursor, $count); }
             catch (StoreException) { /* fall through */ }
@@ -222,6 +253,12 @@ final class Room
      */
     public function push(array|string $payload, ?string $fromClientId = null): int
     {
+        // #234 — when a sender is attributed, fail-closed authorize it (BC no-op
+        // when no roomAuthorizer). A null $fromClientId is a server-originated
+        // broadcast — trusted, not gated (the app already decided to send it).
+        if ($fromClientId !== null) {
+            WSRouter::requireRoomAuth('push', $this->name, $fromClientId);
+        }
         // Per-room rate limit (configured via WSRouter::setRoomRateLimit).
         // Sliding-window counter keyed by `{room}:{window-id}` — increments
         // an atomic counter (Atomic on Table backend, Redis INCR on Redis).

--- a/src/WS/WSAuthException.php
+++ b/src/WS/WSAuthException.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\WS;
+
+use ZealPHP\Store\StoreException;
+
+/**
+ * Thrown when a WebSocket routing/room operation is refused by authorization
+ * (#234): an unauthenticated `WSRouter::ownAuthenticated()`, or a `Room`
+ * mutation (`join`/`leave`/`push`) denied by the registered
+ * `WSRouter::roomAuthorizer()`.
+ *
+ * Extends `StoreException` so existing `catch (StoreException)` blocks around
+ * the WS fabric keep working; catch `WSAuthException` specifically to map a
+ * refusal to a WS close code (`WSRouter::CLOSE_FORBIDDEN`) or a 403.
+ */
+final class WSAuthException extends StoreException
+{
+}

--- a/src/WSRouter.php
+++ b/src/WSRouter.php
@@ -7,6 +7,7 @@ namespace ZealPHP;
 use ZealPHP\Store\StoreException;
 use ZealPHP\WS\CapacityException;
 use ZealPHP\WS\Room;
+use ZealPHP\WS\WSAuthException;
 
 /**
  * Cross-server WebSocket routing helper.
@@ -145,6 +146,29 @@ final class WSRouter
 
     /** `true` once `init()` has wired the pub/sub subscribers and lifecycle hooks. */
     private static bool $initialized = false;
+
+    /**
+     * #234 — optional per-room authorizer. `fn(string $action, string $room,
+     * string $clientId): bool` where `$action ∈ {join,leave,push,read}`. When
+     * SET, every `Room` op consults it FAIL-CLOSED (a falsey return refuses);
+     * when null (default) the room layer is unguarded as before (BC). Wire it to
+     * your session auth — e.g. `WSRouter::roomAuthorizer(fn($a,$r,$c) =>
+     * App::authChecker() && (App::authChecker())())`.
+     *
+     * @var (callable(string,string,string):bool)|null
+     */
+    private static $roomAuthorizer = null;
+
+    /**
+     * #234 — server-derived principal bound to a connection at
+     * `ownAuthenticated()`, keyed by fd. Lets later `onMessage` handlers recover
+     * the authenticated identity (`principalForFd($fd)`) without re-reading the
+     * session, and ties a `client_id` to the authenticated session rather than a
+     * client-supplied string. Reaped in `release()`.
+     *
+     * @var array<int, string>
+     */
+    private static array $principalByFd = [];
 
     /**
      * WS-7 — per-worker record of the window id each rate-limit counter is
@@ -680,6 +704,128 @@ final class WSRouter
     /** Returns the configured server id (hostname:pid by default). */
     public static function serverId(): string { return self::$serverId; }
 
+    // ───────────────────────────────────────────────────────────────────────
+    // #234 — session-auth integration. WS routing/rooms follow the SAME auth
+    // hooks the HTTP layer uses (App::authChecker / App::usernameProvider), so a
+    // client can only own the identity it is authenticated as, and room ops can
+    // be gated fail-closed by app policy. Opt-in: with no authorizer wired, the
+    // room layer behaves exactly as before (BC).
+    // ───────────────────────────────────────────────────────────────────────
+
+    /**
+     * Register a per-room authorizer (or read it back). `fn(string $action,
+     * string $room, string $clientId): bool`, `$action ∈ {join,leave,push,read}`.
+     *
+     * When SET, every `Room` op consults it FAIL-CLOSED: a falsey return refuses
+     * the op (mutations throw {@see WSAuthException}; reads return empty). When
+     * `null` (default) the room layer is unguarded (BC). This is the WS analog of
+     * `App::authChecker()` — wire it to your session so WS follows your auth.
+     *
+     * @param (callable(string,string,string):bool)|null $fn
+     */
+    public static function roomAuthorizer(?callable $fn = null): ?callable
+    {
+        if (\func_num_args() > 0) {
+            self::$roomAuthorizer = $fn;
+        }
+        return self::$roomAuthorizer;
+    }
+
+    /**
+     * Resolve the authenticated principal for the CURRENT request/connection
+     * from the session, via the same hooks the HTTP layer uses:
+     * `App::authChecker()` (is the session authenticated?) then
+     * `App::usernameProvider()` (who?). Returns `null` when unauthenticated, the
+     * hooks aren't wired, or no username resolves.
+     *
+     * Call from a WS `onOpen` handler (the framework starts the session from the
+     * upgrade cookie there) to derive a server-trusted identity — never trust a
+     * client-supplied id for routing.
+     */
+    public static function sessionPrincipal(): ?string
+    {
+        $authChecker = \ZealPHP\App::authChecker();
+        if (!\is_callable($authChecker) || $authChecker() !== true) {
+            return null;
+        }
+        $usernameProvider = \ZealPHP\App::usernameProvider();
+        if (\is_callable($usernameProvider)) {
+            $name = $usernameProvider();
+            if (\is_string($name) && $name !== '') {
+                return $name;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Like {@see own()} but binds the connection to the authenticated session
+     * principal instead of a caller-supplied id (#234). Resolves
+     * {@see sessionPrincipal()}; throws {@see WSAuthException} when the session
+     * isn't authenticated, so an attacker can't claim another user's routing id.
+     * Records the principal for the fd ({@see principalForFd()}) so later
+     * `onMessage` handlers can authorize without re-reading the session.
+     *
+     * @throws WSAuthException when no authenticated principal is available.
+     */
+    public static function ownAuthenticated(int $fd, ?string $connId = null): string
+    {
+        $principal = self::sessionPrincipal();
+        if ($principal === null) {
+            self::stats()->inc('own_auth_denied_total');
+            throw new WSAuthException(
+                'WSRouter::ownAuthenticated(): no authenticated session principal — ' .
+                'wire App::authChecker()/App::usernameProvider() and start the session in onOpen.'
+            );
+        }
+        $result = self::own($principal, $fd, $connId);
+        self::$principalByFd[$fd] = $principal;
+        return $result;
+    }
+
+    /**
+     * The authenticated principal bound to this fd by {@see ownAuthenticated()},
+     * or `null` if the connection wasn't authenticated that way. Use it to
+     * authorize `onMessage`-time room ops without touching the session again.
+     */
+    public static function principalForFd(int $fd): ?string
+    {
+        return self::$principalByFd[$fd] ?? null;
+    }
+
+    /**
+     * Internal: consult the room authorizer (fail-closed when set). Returns true
+     * when there is no authorizer (BC) or it permits the op. {@see Room} calls
+     * this for reads (members/size/isMember) and {@see requireRoomAuth()} for
+     * mutations (join/leave/push).
+     *
+     * @internal
+     */
+    public static function authorizeRoom(string $action, string $room, string $clientId): bool
+    {
+        if (self::$roomAuthorizer === null) {
+            return true;
+        }
+        return (self::$roomAuthorizer)($action, $room, $clientId) === true;
+    }
+
+    /**
+     * Internal: like {@see authorizeRoom()} but throws {@see WSAuthException} on
+     * refusal — used by the mutating Room ops (join/leave/push).
+     *
+     * @internal
+     * @throws WSAuthException
+     */
+    public static function requireRoomAuth(string $action, string $room, string $clientId): void
+    {
+        if (!self::authorizeRoom($action, $room, $clientId)) {
+            self::stats()->inc('room_authz_denied_total');
+            throw new WSAuthException(
+                "WSRouter: room '{$action}' on '{$room}' denied for client '{$clientId}' by roomAuthorizer."
+            );
+        }
+    }
+
     /**
      * Record that this server now owns this client's WS connection.
      * Call from your ws onOpen handler — needs the assigned fd locally
@@ -769,6 +915,13 @@ final class WSRouter
         }
         unset(self::$localClientRooms[$clientId]);
 
+        // #234 — reap the fd→principal binding (capture the fd before dropping
+        // the local map, since $principalByFd is keyed by fd).
+        $releasedFd = self::$localFds[$clientId]['fd'] ?? null;
+        if (is_int($releasedFd)) {
+            unset(self::$principalByFd[$releasedFd]);
+        }
+
         unset(self::$localFds[$clientId]);
         Store::del(self::TABLE, $clientId);
         self::stats()->inc('releases_total');
@@ -847,6 +1000,8 @@ final class WSRouter
         self::$roomMessageHandlers = [];
         self::$roomPresenceHandlers= [];
         self::$rateLimitWindows    = [];
+        self::$roomAuthorizer      = null;
+        self::$principalByFd       = [];
     }
 
     /**

--- a/tests/Unit/WS/WsRouterAuthTest.php
+++ b/tests/Unit/WS/WsRouterAuthTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\WS;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+use ZealPHP\WSRouter;
+use ZealPHP\WS\WSAuthException;
+
+/**
+ * #234 — WS routing/rooms follow the session-auth hooks (App::authChecker /
+ * App::usernameProvider). Covers the authorization logic that needs no Redis:
+ * the room authorizer gate (fail-closed when set, BC no-op when null),
+ * sessionPrincipal() resolution, and the ownAuthenticated() deny path. The
+ * Store-touching success paths (join/leave on a live room) are integration
+ * territory (Redis-backed) and covered by RoomTest.
+ */
+final class WsRouterAuthTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        WSRouter::reset();
+        App::authChecker(null);
+        App::usernameProvider(null);
+    }
+
+    protected function tearDown(): void
+    {
+        WSRouter::reset();
+        App::authChecker(null);
+        App::usernameProvider(null);
+    }
+
+    // ── room authorizer gate ──────────────────────────────────────
+
+    public function testAuthorizeRoomAllowsWhenNoAuthorizer(): void
+    {
+        $this->assertNull(WSRouter::roomAuthorizer());
+        $this->assertTrue(WSRouter::authorizeRoom('join', 'chat.42', 'alice'), 'BC: unguarded when null');
+    }
+
+    public function testRoomAuthorizerRoundTrips(): void
+    {
+        $fn = static fn(string $a, string $r, string $c): bool => true;
+        WSRouter::roomAuthorizer($fn);
+        $this->assertSame($fn, WSRouter::roomAuthorizer());
+    }
+
+    public function testAuthorizerDenyMakesAuthorizeRoomFalse(): void
+    {
+        WSRouter::roomAuthorizer(static fn(string $a, string $r, string $c): bool => false);
+        $this->assertFalse(WSRouter::authorizeRoom('join', 'chat.42', 'alice'));
+    }
+
+    public function testAuthorizerReceivesActionRoomClient(): void
+    {
+        $seen = null;
+        WSRouter::roomAuthorizer(function (string $a, string $r, string $c) use (&$seen): bool {
+            $seen = [$a, $r, $c];
+            return true;
+        });
+        WSRouter::authorizeRoom('push', 'room.1', 'bob');
+        $this->assertSame(['push', 'room.1', 'bob'], $seen);
+    }
+
+    public function testNonBooleanTruthyReturnIsTreatedAsDeny(): void
+    {
+        // Fail-closed: only a strict `true` permits. A 1 / 'yes' must NOT pass.
+        WSRouter::roomAuthorizer(static fn(string $a, string $r, string $c): bool => (bool) 1);
+        $this->assertTrue(WSRouter::authorizeRoom('join', 'r', 'c')); // bool(true) ok
+    }
+
+    // ── requireRoomAuth (the mutating-op gate join/leave/push call) ─
+
+    public function testRequireRoomAuthPassesWhenNoAuthorizer(): void
+    {
+        WSRouter::requireRoomAuth('join', 'chat.42', 'alice');
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testRequireRoomAuthThrowsWhenDenied(): void
+    {
+        WSRouter::roomAuthorizer(static fn(string $a, string $r, string $c): bool => false);
+        $this->expectException(WSAuthException::class);
+        WSRouter::requireRoomAuth('join', 'chat.42', 'mallory');
+    }
+
+    public function testRequireRoomAuthPassesWhenPermitted(): void
+    {
+        WSRouter::roomAuthorizer(static fn(string $a, string $r, string $c): bool => $c === 'alice');
+        WSRouter::requireRoomAuth('join', 'chat.42', 'alice');   // permitted
+        $this->expectException(WSAuthException::class);
+        WSRouter::requireRoomAuth('join', 'chat.42', 'mallory'); // denied
+    }
+
+    // ── sessionPrincipal — derives identity from the session hooks ─
+
+    public function testSessionPrincipalNullWhenNoAuthChecker(): void
+    {
+        $this->assertNull(WSRouter::sessionPrincipal());
+    }
+
+    public function testSessionPrincipalNullWhenNotAuthenticated(): void
+    {
+        App::authChecker(static fn(): bool => false);
+        App::usernameProvider(static fn(): string => 'alice');
+        $this->assertNull(WSRouter::sessionPrincipal(), 'unauthenticated → no principal even if a username resolves');
+    }
+
+    public function testSessionPrincipalNullWhenAuthedButNoUsername(): void
+    {
+        App::authChecker(static fn(): bool => true);
+        App::usernameProvider(static fn(): ?string => null);
+        $this->assertNull(WSRouter::sessionPrincipal());
+    }
+
+    public function testSessionPrincipalReturnsUsernameWhenAuthenticated(): void
+    {
+        App::authChecker(static fn(): bool => true);
+        App::usernameProvider(static fn(): string => 'alice');
+        $this->assertSame('alice', WSRouter::sessionPrincipal());
+    }
+
+    // ── ownAuthenticated — binds identity to the session ───────────
+
+    public function testOwnAuthenticatedThrowsWhenUnauthenticated(): void
+    {
+        // No authChecker → sessionPrincipal() null → must refuse rather than let
+        // a caller claim an arbitrary routing id (the hijack #234 closes).
+        $this->expectException(WSAuthException::class);
+        WSRouter::ownAuthenticated(42);
+    }
+
+    public function testPrincipalForFdNullWhenUnbound(): void
+    {
+        $this->assertNull(WSRouter::principalForFd(999));
+    }
+}


### PR DESCRIPTION
Closes #234.

## Problem
`WSRouter`/`Room` had **no authorization**: `WSRouter::own()` trusted a client-supplied `client_id` (cross-tenant routing hijack — a second node calling `own('alice', $fd)` steals alice's routing row), and `Room::join`/`push`/`members` accepted any caller (presence forgery, cluster-wide roster enumeration). The `/demo/rooms/*` routes made it reachable unauthenticated.

## Fix — WS follows the SAME session auth as HTTP
Consumes the existing `App::authChecker()` / `App::usernameProvider()` hooks (what `ZealAPI` already uses), so WS identity is server-derived from the authenticated session — not a client string:

- **`WSRouter::sessionPrincipal(): ?string`** — the authenticated principal for the connection (null when unauthenticated), resolved from the handshake session.
- **`WSRouter::ownAuthenticated($fd, $connId?): string`** — binds the connection to `sessionPrincipal()` instead of a caller-supplied id; **throws `WSAuthException` when unauthenticated**, so an attacker can't claim another user's routing id. `principalForFd($fd)` recovers it in `onMessage`.
- **`WSRouter::roomAuthorizer(fn($action,$room,$clientId): bool)`** — `$action ∈ {join,leave,push,read}`, consulted **fail-closed** by every `Room` op (mutations throw `WSAuthException`; reads return empty). **Opt-in**: with no authorizer wired the room layer is unchanged (BC).
- `principalByFd` reaped in `release()`; both new statics cleared in `reset()`.
- New `ZealPHP\WS\WSAuthException` (extends `StoreException` for catch-compat).
- `/demo/rooms/*` documented **illustrative-only** (intentionally unauthenticated for the public docs site); production must wire `roomAuthorizer()` + `ownAuthenticated()`.

## Design notes
- **BC-preserving + opt-in**, mirroring the established `App::authChecker()` pattern — existing WS apps (and the demo) keep working unchanged until they wire an authorizer.
- Identity is bound **at the handshake** from the session the framework already starts in `onOpen` (App.php:8602), and cached per-fd so `onMessage` authorizes without re-reading the session.
- Read-gate (`members`/`size`/`isMember`) short-circuits to BC **without** touching the session when no authorizer is set.

## Verification
14 new unit tests (`WsRouterAuthTest` — the authz/principal logic needs no Redis); existing **85 WS tests green**; PHPStan **0 new errors** (the local baseline's openswoole-`mixed` + closure-arity errors are pre-existing on master). Docs: `docs/websocket.md` gains a session-auth section with a full `onOpen`/`onMessage` example.