### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.5] - 2026-06-09
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project sibidharan/zealphp-project:^0.4.4 my-project
+composer create-project sibidharan/zealphp-project:^0.4.5 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -461,8 +461,8 @@ The fine-grained setters (`App::superglobals()`, `App::isolation()`, `App::enabl
 2. Run `composer validate` and confirm tests pass.
 3. Tag both `zealphp` and `zealphp-project` with the same version:
    ```bash
-   git tag -a v0.4.4 -m "Release v0.4.4"
-   git push origin master && git push origin v0.4.4
+   git tag -a v0.4.5 -m "Release v0.4.5"
+   git push origin master && git push origin v0.4.5
    ```
 4. Trigger Packagist webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.4 .
+docker build -t zealphp:0.4.5 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -231,7 +231,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.4 .
+    -t zealphp:0.4.5 .
 ```
 
 ### Run (single container)
@@ -243,7 +243,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.4
+    zealphp:0.4.5
 ```
 
 ### Production compose
@@ -254,7 +254,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.4
+    image: registry.example.com/zealphp-app:0.4.5
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.4.4
+    image: zealphp:0.4.5
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -178,7 +178,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  sibidharan/zealphp-project:^0.4.4 \
+  sibidharan/zealphp-project:^0.4.5 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, coroutines, shared memory, task workers &mdash;
        first&#8209;class because the server never shuts down between requests.</p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.4.4 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.4.5 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -306,7 +306,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.4.4 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.4.4 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project sibidharan/zealphp-project:^0.4.5 my-app</span><button class="qs-copy" data-copy="composer create-project sibidharan/zealphp-project:^0.4.5 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>


### PR DESCRIPTION
## v0.4.5 — 2026-06-09

Patch release carrying the full correctness sweep since v0.4.4:

### Security
- WS rooms/routing follow session auth (#234) · ScopedMiddleware path-normalization bypass (#232) · IpAccessMiddleware trusted proxies (#239)

### Highlights
- **Session correctness sweep**: regenerate-id sid desync (broke `session_regenerate_id(true)` login flows in every mode) + strict-mode rotation of issued-but-empty sessions (ext#2) · superglobal **ownership gating** with ext-zealphp **0.3.36/0.3.37** — go()-child steal (#332 first-request 501s) and the service-coroutine restore wipe (ext#32). Session counters now deterministic across bare Mode 4 + coroutine-legacy on PHP 8.3 + 8.4.
- **mod_php parity batch**: REQUEST_URI query string (#306), $_COOKIE treat-data (#305), $_FILES field-major (#304), Basic-auth $_SERVER (#307), Set-Cookie byte-parity + SameSite=None warning (#293, #319), raw status-line passthrough (#327), filter_input in CGI workers (#316)
- **Pool cold-start TOCTOU** (#322) — connection-leak fix · **sendFile** delegates to ConditionalRequest + MimeResolver (#321, #317) · per-coroutine **CWD isolation** (#323, ext 0.3.35) · quick-wins #308–#311, #318, #320, plus #289/#295 and the earlier batch
- ext-zealphp default pin → **v0.3.37**

### Validation
Unit 3835 ✓ · Integration 296 ✓ · PHPStan L10 ✓ · 18-page demo smoke ✓ · ext 53/53 phpt (ASAN/Valgrind) ✓ · rig E2E (PHP 8.3 + 8.4, all lifecycle modes) ✓