### PR TITLE
chore: ext-zealphp pin → v0.3.41 (ext#37 request-state steal fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **ext-zealphp pin bumped to v0.3.41** — fixes [ext#37](https://github.com/sibidharan/ext-zealphp/issues/37): in coroutine-legacy, a fire-and-forget `go()` child's first yield or a service coroutine's mid-request resume (one `elog()` call suffices — the async-log runner) could steal/wipe the live request's `$GLOBALS` (user globals read back as NULL), orphan `define()`s, and roll class statics/ini back to stale copies. All per-request-state stages are now gated on a request-coroutine claim set, both save and restore sides; raw OpenSwoole usage (no claims) is unchanged. Pinned by ext `tests/057`; validated at 40-concurrent with zero leaks.
+
+
 ## [0.4.6] - 2026-06-10
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM php:8.4-cli-bookworm@sha256:ca4b9f44c281f6214a08313185b306368b9ec1e9a73b54b
 
 ARG OPENSWOOLE_VERSION=
 ARG UOPZ_VERSION=
-# ext-zealphp git tag to build (see setup.sh). Defaults to v0.3.39 there.
+# ext-zealphp git tag to build (see setup.sh). Defaults to v0.3.41 there.
 ARG ZEALPHP_EXT_VERSION=
 # Optional: rebuild opcache with the function-dups-fix patch so opcache can stay
 # fully ON in coroutine-legacy mode for legacy require_once apps (e.g. WordPress)

--- a/setup.sh
+++ b/setup.sh
@@ -162,13 +162,13 @@ docker_setup() {
     docker-php-ext-enable --ini-name zz-openswoole.ini openswoole
     php -r 'exit(extension_loaded("openswoole") ? 0 : 1);' || { echo -e "${RED}OpenSwoole built but failed to load.${RESET}"; exit 1; }
 
-    echo -e "${YELLOW}Installing ext-zealphp ${ZEALPHP_EXT_VERSION:-v0.3.39} for Docker image.${RESET}"
+    echo -e "${YELLOW}Installing ext-zealphp ${ZEALPHP_EXT_VERSION:-v0.3.41} for Docker image.${RESET}"
     # Pinned for reproducibility + to dodge the pre-0.3.16 compile break on modern
     # toolchains (GCC 14 hardens -Wincompatible-pointer-types to an error; the old
     # zend_alter_ini_entry_ex call passed the entry struct instead of the name).
     # NOTE: the ext has its OWN 0.3.x version line — do NOT confuse it with the
     # framework's 0.3.x. Override with ZEALPHP_EXT_VERSION.
-    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.39}" https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
+    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.41}" https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
     if (cd /tmp/ext-zealphp && phpize && ./configure --enable-zealphp && make -j"${ZEALPHP_BUILD_JOBS}" && make install); then
         docker-php-ext-enable --ini-name zz-zealphp.ini zealphp
         rm -rf /tmp/ext-zealphp
@@ -600,7 +600,7 @@ install_zealphp_ext() {
 
     local tmpdir
     tmpdir="$(mktemp -d)"
-    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.39}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir/ext-zealphp" || {
+    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.41}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir/ext-zealphp" || {
         echo -e "${YELLOW}Failed to clone ext-zealphp repo. Falling back to uopz.${RESET}"
         rm -rf "$tmpdir"
         install_uopz_fallback
@@ -734,7 +734,7 @@ macos_setup() {
     echo -e "${GREEN}Installing ext-zealphp.${RESET}"
     local tmpdir
     tmpdir="$(mktemp -d)"
-    if git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.39}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir" && \
+    if git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.41}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir" && \
        (cd "$tmpdir" && phpize && ./configure --enable-zealphp && make -j"${ZEALPHP_BUILD_JOBS}" && make install); then
         echo "extension=zealphp.so" > "${php_ini_dir}/zz-zealphp.ini"
         rm -rf "$tmpdir"


### PR DESCRIPTION
Bumps the default ext pin v0.3.39 → v0.3.41. v0.3.41 fixes [ext#37](https://github.com/sibidharan/ext-zealphp/issues/37) — the #31-family steal in coroutine-legacy where a `go()` child's yield or a service-runner resume (one `elog()` call) nulled user `$GLOBALS`, orphaned `define()`s, and staled statics/ini. (v0.3.40 was the zealphp/ext rename release.) Validated: ext suite 56/56, ASAN+Valgrind green, framework E2E 40-concurrent 0 leaks.