### PR TITLE
feat: fatal→500 guard — worker-killing fatals answer the connection instead of hanging it (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Fatal→500 guard** ([#338](https://github.com/sibidharan/zealphp/issues/338)) — a worker-killing fatal mid-request (E_COMPILE_ERROR / E_ERROR / E_PARSE / E_CORE_ERROR) now answers every in-flight connection with a minimal **HTTP 500** (mod_php parity) instead of leaving clients to time out with HTTP 000, and surfaces the fatal (message + file:line) in the PHP error log. The native shutdown guard registers before the framework's `register_shutdown_function` override; the session managers track each request's raw response and release it on normal completion, so only orphaned connections are answered. Works in every lifecycle mode (validated E2E in coroutine and coroutine-legacy: 500 in ~14 ms + worker respawn + service continues). Test endpoint `/demo/fatal500` is gated behind `ZEALPHP_FATAL_TEST=1`; pinned by `tests/Integration/FatalGuardTest.php`. This failure class is what made the wgvpn "password_verify hang" ([ext#36](https://github.com/sibidharan/ext-zealphp/issues/36)) a multi-day chase — fatals are now self-diagnosing.
+
 ### Fixed
 - **ext-zealphp pin bumped to v0.3.41** — fixes [ext#37](https://github.com/sibidharan/ext-zealphp/issues/37): in coroutine-legacy, a fire-and-forget `go()` child's first yield or a service coroutine's mid-request resume (one `elog()` call suffices — the async-log runner) could steal/wipe the live request's `$GLOBALS` (user globals read back as NULL), orphan `define()`s, and roll class statics/ini back to stale copies. All per-request-state stages are now gated on a request-coroutine claim set, both save and restore sides; raw OpenSwoole usage (no claims) is unchanged. Pinned by ext `tests/057`; validated at 40-concurrent with zero leaks.
 

--- a/route/demo.php
+++ b/route/demo.php
@@ -948,3 +948,21 @@ $app->route('/demo/view/chatroom/widget', ['methods' => ['GET']], function () {
         'learn/chatroom', 'Multi-Room Group Chat'
     );
 });
+
+// ── #338 — fatal→500 guard test endpoint ────────────────────────────────
+// Deliberately KILLS the worker with an uncatchable E_COMPILE_ERROR
+// (incompatible interface implementation, unique class names per request so
+// the inheritance-link fatal — not a redeclare — fires every time). The
+// fatalResponseGuard must answer this connection with HTTP 500 instead of
+// leaving the client to time out (mod_php parity). Gated off by default:
+// only enabled when the server is started with ZEALPHP_FATAL_TEST=1, so the
+// public demo site never exposes a crash-the-worker endpoint.
+$app->route('/demo/fatal500', function () {
+    if (getenv('ZEALPHP_FATAL_TEST') !== '1') {
+        return 403;
+    }
+    $n = 'F338_' . str_replace('.', '_', uniqid('', true));
+    eval("interface I{$n} { public function x(): array; }"
+        . "class C{$n} implements I{$n} { public function x(): string { return ''; } }");
+    return ['unreachable' => true]; // the eval above is a worker-killing fatal
+});

--- a/src/App.php
+++ b/src/App.php
@@ -1647,6 +1647,15 @@ class App
         }
         self::$overridesRegistered = true;
 
+        // #338 — fatal→500 guard. MUST use PHP's NATIVE
+        // register_shutdown_function and MUST run before the override below
+        // replaces it globally (uopz/ext-zealphp overrides intercept even
+        // fully-qualified calls). Registered once in the master pre-fork;
+        // forked workers inherit the registration (BG(user_shutdown_function
+        // _names) copies on fork) and run it during THEIR engine shutdown —
+        // including the shutdown a fatal error triggers.
+        \register_shutdown_function([self::class, 'fatalResponseGuard']);
+
         // Response
         self::overrideBuiltin('header', '\ZealPHP\header');
         self::overrideBuiltin('header_remove', '\ZealPHP\header_remove');
@@ -8804,6 +8813,94 @@ class App
             $newStack = self::$middleware_stack->add($middleware);
             assert($newStack instanceof StackHandler);
             self::$middleware_stack = $newStack;
+        }
+    }
+
+    /**
+     * #338 — in-flight raw responses, per worker process. A worker-killing
+     * FATAL (E_COMPILE_ERROR / E_ERROR / …) never reaches the normal emit
+     * path, so the client connection — held open by the master's reactor —
+     * would hang until the CLIENT's timeout (HTTP 000). Apache/mod_php
+     * answers 500. The session managers track every request's raw
+     * OpenSwoole response here and release it on normal completion; the
+     * native shutdown guard below answers whatever is left when a fatal
+     * tears the worker down. Coroutine mode can hold several entries at
+     * once — one fatal kills them all, so all of them get the 500.
+     *
+     * @var array<int, \OpenSwoole\Http\Response>
+     */
+    private static array $fatal_guard_inflight = [];
+
+    /** #338 — track an in-flight raw response; returns the release key. */
+    public static function fatalGuardTrack(\OpenSwoole\Http\Response $response): int
+    {
+        $id = \spl_object_id($response);
+        self::$fatal_guard_inflight[$id] = $response;
+        return $id;
+    }
+
+    /** #338 — release a response tracked by fatalGuardTrack(). */
+    public static function fatalGuardRelease(int $id): void
+    {
+        unset(self::$fatal_guard_inflight[$id]);
+    }
+
+    /**
+     * #338 — native shutdown callback (registered in registerAllOverrides()
+     * BEFORE the register_shutdown_function override installs). On a fatal,
+     * answers every in-flight connection with a minimal 500 — mod_php
+     * parity — instead of leaving clients to time out, and surfaces the
+     * fatal in the PHP error log (debug.log misses engine fatals; that
+     * silence is what made ext-zealphp#36 a multi-day hunt).
+     *
+     * Uses only engine-native calls: during shutdown the coroutine
+     * scheduler (and thus elog()'s async channel) may be unavailable.
+     */
+    public static function fatalResponseGuard(): void
+    {
+        if (self::$fatal_guard_inflight === []) {
+            return;
+        }
+        $e = \error_get_last();
+        if ($e === null || !\in_array($e['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+            return;
+        }
+
+        \error_log(sprintf(
+            'ZealPHP fatal-guard: answering %d in-flight request(s) with 500 after fatal: %s in %s:%d',
+            \count(self::$fatal_guard_inflight),
+            $e['message'],
+            $e['file'],
+            $e['line']
+        ));
+
+        $admin = self::$server_admin !== null && self::$server_admin !== ''
+            ? '<p>Please contact the server administrator at ' . \htmlspecialchars(self::$server_admin, ENT_QUOTES) . '.</p>'
+            : '';
+        $body = '<!DOCTYPE html><html><head><title>500 Internal Server Error</title></head><body>'
+            . '<h1>Internal Server Error</h1>'
+            . '<p>The server encountered an internal error and was unable to complete your request.</p>'
+            . $admin . '</body></html>';
+
+        foreach (self::$fatal_guard_inflight as $id => $response) {
+            unset(self::$fatal_guard_inflight[$id]);
+            try {
+                if (!$response->isWritable()) {
+                    continue;
+                }
+                $response->status(500, 'Internal Server Error');
+                $response->header('Content-Type', 'text/html; charset=utf-8');
+                $response->end($body);
+            } catch (\Throwable $t) {
+                // The connection may already be torn down mid-shutdown; a
+                // failed 500 still beats a silent hang — close so the client
+                // gets an immediate reset instead of a timeout.
+                try {
+                    $response->close();
+                } catch (\Throwable) {
+                    // nothing more we can do from a dying worker
+                }
+            }
         }
     }
 

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -135,6 +135,7 @@ class CoSessionManager
             $g->session = [];
             $g->openswoole_request = $request;
             $g->openswoole_response = $response;
+            $zpFatalGuardId = \ZealPHP\App::fatalGuardTrack($response); // #338 — answer this connection with 500 if a fatal kills the worker
             $request = new \ZealPHP\HTTP\Request($request);
             $response = new \ZealPHP\HTTP\Response($response);
             $g->zealphp_request = $request;
@@ -142,6 +143,7 @@ class CoSessionManager
             try {
                 call_user_func($this->middleware, $request, $response);
             } finally {
+                \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338
                 unset($g->session);
             }
             return;
@@ -261,6 +263,7 @@ class CoSessionManager
             }
         }
 
+        $zpFatalGuardId = \ZealPHP\App::fatalGuardTrack($response); // #338 — answer this connection with 500 if a fatal kills the worker
         try {
             if ($manageSession) {
                 $g->session['__start_time'] = microtime(true);
@@ -275,6 +278,7 @@ class CoSessionManager
 
             call_user_func($this->middleware, $request, $response);
         } finally {
+            \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338
             if ($manageSession && $g->_session_started) {
                 zeal_session_write_close();
                 zeal_session_id('');

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -147,6 +147,7 @@ class SessionManager
             $g->session = [];
             $g->openswoole_request = $request;
             $g->openswoole_response = $response;
+            $zpFatalGuardId = \ZealPHP\App::fatalGuardTrack($response); // #338 — answer this connection with 500 if a fatal kills the worker
             $request = new \ZealPHP\HTTP\Request($request);
             $response = new \ZealPHP\HTTP\Response($response);
             $g->zealphp_request = $request;
@@ -154,6 +155,7 @@ class SessionManager
             try {
                 call_user_func($this->middleware, $request, $response);
             } finally {
+                \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338
                 unset($g->session);
             }
             return;
@@ -312,6 +314,7 @@ class SessionManager
                 );
             }
         }
+        $zpFatalGuardId = \ZealPHP\App::fatalGuardTrack($response); // #338 — answer this connection with 500 if a fatal kills the worker
         try {
             if ($manageSession) {
                 $_SESSION['__start_time'] = microtime(true);
@@ -325,6 +328,7 @@ class SessionManager
             $g->zealphp_response = $response;
             call_user_func($this->middleware, $request, $response);
         } finally {
+            \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338
             if ($manageSession) {
                 elog('SessionManager:: session_write_close took '.get_current_render_time(), 'info');
                 session_write_close();

--- a/tests/Integration/FatalGuardTest.php
+++ b/tests/Integration/FatalGuardTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Integration;
+
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #338 — a worker-killing FATAL mid-request must answer the held connection
+ * with HTTP 500 (mod_php parity) instead of leaving the client to time out
+ * (the HTTP-000 mystery hang that made ext-zealphp#36 a multi-day chase).
+ *
+ * Requires the server to run with ZEALPHP_FATAL_TEST=1 (the /demo/fatal500
+ * crash endpoint is gated off otherwise — these tests SKIP cleanly when the
+ * gate is closed, e.g. in the default CI server boot).
+ */
+class FatalGuardTest extends TestCase
+{
+    private function gateOpen(): bool
+    {
+        $probe = $this->get('/demo/fatal500');
+
+        return ($probe['status'] ?? 0) !== 403;
+    }
+
+    public function testFatalAnswersWith500NotTimeout(): void
+    {
+        if (! $this->gateOpen()) {
+            $this->markTestSkipped('ZEALPHP_FATAL_TEST=1 not set on the server — crash endpoint gated off');
+        }
+
+        $t0 = microtime(true);
+        $res = $this->get('/demo/fatal500');
+        $elapsed = microtime(true) - $t0;
+
+        $this->assertSame(500, $res['status'], 'fatal must yield HTTP 500, never HTTP 0/timeout');
+        $this->assertLessThan(
+            5.0,
+            $elapsed,
+            'the 500 must arrive promptly from the dying worker, not after a client-side timeout'
+        );
+        $this->assertStringContainsString('Internal Server Error', $res['body']);
+        // No fatal detail leaks to the client — the message goes to the error log.
+        $this->assertStringNotContainsString('must be compatible', $res['body']);
+    }
+
+    public function testWorkerRespawnsAndServiceContinues(): void
+    {
+        if (! $this->gateOpen()) {
+            $this->markTestSkipped('ZEALPHP_FATAL_TEST=1 not set on the server — crash endpoint gated off');
+        }
+
+        $this->get('/demo/fatal500'); // kill a worker
+        // OpenSwoole's manager respawns the worker; the very next requests
+        // must be served normally.
+        usleep(300_000);
+        $ok = 0;
+        for ($i = 0; $i < 5; $i++) {
+            $res = $this->get('/demo/inject/request-only');
+            if (($res['status'] ?? 0) === 200) {
+                $ok++;
+            }
+        }
+
+        $this->assertGreaterThanOrEqual(4, $ok, 'service must continue after the worker respawn');
+    }
+}

--- a/tests/Unit/FatalGuardRegistryTest.php
+++ b/tests/Unit/FatalGuardRegistryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+/**
+ * #338 — unit pins for the fatal→500 guard's registry + conservative
+ * behaviors. The actual 500 emission is pinned by the integration test
+ * (tests/Integration/FatalGuardTest.php): a REAL fatal kills the phpunit
+ * process, so it cannot be exercised in-process here.
+ */
+class FatalGuardRegistryTest extends TestCase
+{
+    /** @return array<int, \OpenSwoole\Http\Response> */
+    private function registry(): array
+    {
+        $p = new \ReflectionProperty(App::class, 'fatal_guard_inflight');
+
+        /** @var array<int, \OpenSwoole\Http\Response> */
+        return $p->getValue();
+    }
+
+    private function makeResponse(): \OpenSwoole\Http\Response
+    {
+        return $this->getMockBuilder(\OpenSwoole\Http\Response::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testTrackAndReleaseLifecycle(): void
+    {
+        $r = $this->makeResponse();
+        $id = App::fatalGuardTrack($r);
+
+        $this->assertSame(spl_object_id($r), $id, 'release key is the object id');
+        $this->assertArrayHasKey($id, $this->registry());
+        $this->assertSame($r, $this->registry()[$id]);
+
+        App::fatalGuardRelease($id);
+        $this->assertArrayNotHasKey($id, $this->registry());
+    }
+
+    public function testReleaseIsIdempotent(): void
+    {
+        $r = $this->makeResponse();
+        $id = App::fatalGuardTrack($r);
+        App::fatalGuardRelease($id);
+        App::fatalGuardRelease($id); // second release must not error
+
+        $this->assertArrayNotHasKey($id, $this->registry());
+    }
+
+    public function testConcurrentRequestsTrackIndependently(): void
+    {
+        $a = $this->makeResponse();
+        $b = $this->makeResponse();
+        $ida = App::fatalGuardTrack($a);
+        $idb = App::fatalGuardTrack($b);
+
+        $this->assertNotSame($ida, $idb);
+        App::fatalGuardRelease($ida);
+        $this->assertArrayNotHasKey($ida, $this->registry());
+        $this->assertArrayHasKey($idb, $this->registry(), 'releasing one request must not drop a concurrent one');
+        App::fatalGuardRelease($idb);
+    }
+
+    public function testGuardIsNoOpWithoutAFatal(): void
+    {
+        $r = $this->makeResponse();
+        $r->expects($this->never())->method('status');
+        $r->expects($this->never())->method('end');
+        $id = App::fatalGuardTrack($r);
+
+        // The last error in this process is at worst a non-fatal type —
+        // make that deterministic, then run the guard.
+        @trigger_error('non-fatal marker (#338 test)', E_USER_NOTICE);
+        App::fatalResponseGuard();
+
+        $this->assertArrayHasKey(
+            $id,
+            $this->registry(),
+            'a non-fatal shutdown (normal request end, notices only) must leave in-flight entries untouched'
+        );
+        App::fatalGuardRelease($id);
+    }
+
+    public function testGuardIsNoOpOnEmptyRegistry(): void
+    {
+        $this->assertSame([], $this->registry());
+        App::fatalResponseGuard(); // must not error with nothing in flight
+        $this->assertSame([], $this->registry());
+    }
+}


### PR DESCRIPTION
Closes #338.

## Why
A fatal mid-request kills the worker; the master keeps the connection open; the client waits for its own timeout (**HTTP 000**) with the fatal visible only in stderr. That's the failure mode that made ext-zealphp#36 a multi-day chase. mod_php answers **500** — now ZealPHP does too.

## How
- **Native** `register_shutdown_function` guard registered **before** the framework's override installs (overrides intercept even fully-qualified calls); inherited by forked workers, runs during the fatal-triggered engine shutdown
- In-flight raw-response registry: session managers `track()` before their try, `release()` in the finally — only orphans get answered (coroutine mode: one fatal = all in-flight get the 500)
- Engine-native calls only (no elog — the scheduler may be gone at shutdown); non-writable responses skipped; `close()` fallback = at worst an immediate reset, never a timeout; no fatal detail in the body (ServerAdmin shown when set); fatal logged with file:line
- `/demo/fatal500` crash endpoint gated behind `ZEALPHP_FATAL_TEST=1`

## Validation
- E2E coroutine: **500 in 14 ms** + worker respawn + next request 200 · E2E coroutine-legacy: same
- `FatalGuardTest` 2/2 (skips when gate closed) · core integration 56/56 no regression · PHPStan L10 + unit suite at baseline