### PR TITLE
docs: refresh agent reference / llms.txt source for v0.4.8

### DIFF
--- a/examples/agents/zealphp_reference.txt
+++ b/examples/agents/zealphp_reference.txt
@@ -2942,6 +2942,21 @@ config.
 > Test environment: PHP 8.4.21 + OpenSwoole 26.2.0 + ext-zealphp 0.3.3–0.3.24 (grades vary by section — see per-section notes)  
 > Docker lab sweep — actual boot + first-request tests where marked as tested
 
+> ### 2026-06-10 real-work re-validation (ext-zealphp 0.3.46, coroutine-legacy)
+> A focused real-work pass (beyond boot/first-request) on the post-0.3.46 stack — the session that shipped the child-coroutine superglobal lane (0.3.43), tz/mb/libxml isolation (0.3.45), and the **mysqlnd vio orig_path allocator-consistency shim (0.3.46)**:
+>
+> | App | Real work performed | Result |
+> |---|---|---|
+> | **WordPress** (public) | homepage render, login (auth cookie set), `ab -c10/-c20` concurrency | 200 (real 49 KB page); **0 crashes in steady state** (mysqlnd shim holds — pre-shim this crash-looped 11–14 worker deaths/run) |
+> | **WordPress** (wp-admin) | admin password reset → authenticated dashboard + post-list | **200** (Dashboard 115 KB "At a Glance/Howdy"; edit.php 97 KB real post list) **with `App::globalScopeInclude(true)`** — closes the `$_wp_submenu_nopriv` `array_keys(null)` 500 |
+> | **File upload** (`$_FILES` + `move_uploaded_file`) | 24 concurrent multipart uploads, unique random payloads | **24/24 landed with their own SHA**, 0 cross-coroutine `tmp_name`/`$_FILES` mixing, 0 crashes |
+> | **Adminer 4.8.1** | boot, login form, DB-login POST to MariaDB | 200 boot; login processed (302); deep schema/SQL gated by Adminer's CSRF token (app-auth, not framework); 0 crashes |
+> | **TinyFileManager** | boot, login screen render | 200; login needs `SessionStartMiddleware` for first-visitor sessions (app-config, not framework); 0 crashes |
+>
+> **Cross-app finding:** every app **boots + renders + processes its entry/auth flow under coroutine-legacy with ZERO crashes** on 0.3.46. Cold-concurrent first-wave edges (HAZARD-2 cold-autoload + the residual cold-boot mysqlnd, ext#44) are self-healing and mitigated by `App::preloadClassmap()` (which these unconfigured harnesses don't call); steady state is clean. Deep multi-step authed flows hit each app's own CSRF/nonce/session tokens — a test-harness fidelity matter, not a framework defect.
+>
+> **New issue surfaced:** persistent **userland** streams (`pfsockopen` / `stream_socket_client(STREAM_CLIENT_PERSISTENT)`) hit the same orig_path allocator mismatch as ext#44 on the generic xport path the vio shim doesn't cover (ext#45) — niche (persistent sockets are semantically wrong under coroutines anyway), no real app in this pass tripped it.
+
 This is the reference for which PHP applications work with ZealPHP and in which modes. Use the [Mode Selection Guide](#mode-selection-guide) to quickly find your configuration.
 
 ---
@@ -5139,6 +5154,8 @@ This is the canonical reference for every `ZEALPHP_*` environment variable read 
 | `ZEALPHP_OPCACHE_ADVISORY` | unset (advisory enabled; only literal `'0'` suppresses) | user | Read in `App::opcacheLegacyBootCheck()` via `getenv()==='0'`; when `'0'`, suppresses the boot-time advisory about opcache + coroutine-legacy re-declaring `require_once`'d classes. |
 | `ZEALPHP_FN_STATICS_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineStaticsIsolation()` — when `'1'`, disables per-coroutine isolation of function-local `static $x` (Stage 5) for raw throughput. |
 | `ZEALPHP_CWD_ISOLATION_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineCwdIsolation()` — when `'1'`, disables per-coroutine working-directory isolation (#323), so a request's `chdir()` leaks process-wide again. |
+| `ZEALPHP_LOCALE_ISOLATION_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineLocaleIsolation()` — when `'1'`, disables per-coroutine `setlocale()` isolation. |
+| `ZEALPHP_UMASK_ISOLATION_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineUmaskIsolation()` — when `'1'`, disables per-coroutine `umask()` isolation. |
 | `ZEALPHP_FN_STATICS_RESET_DISABLE` | unset (reset ENABLED; any non-empty value not starting with `'0'` disables) | user | Read in ext-zealphp `zealphp_reset_request_statics()`; when set, disables the per-request reset of function-local `static $x` to their templates. |
 | `ZEALPHP_CLASS_STATICS_RESET_DISABLE` | unset (reset ENABLED; any non-empty value not starting with `'0'` disables) | user | Read in ext-zealphp `zealphp_reset_request_class_statics()`; when set, disables the per-request reset of class static properties to their templates. |
 | `ZEALPHP_POOL_FULL_RESET` | unset (off; only literal `'1'` enables) | user | **EXPERIMENTAL.** Read in `src/pool_worker.php` `pool_reset_request_state()`; when `'1'`, a REUSED `cgiMode('pool')` subprocess (`cgiPoolMaxRequests > 1`) runs the full coroutine-legacy reset stack (`zealphp_reset_request_rtcaches` + `_statics` + `_class_statics`) per request — letting *re-entrant* legacy apps warm-reuse a worker. Cannot make inherited-class-redeclaring apps safe (use the recycle=1 default or `cgiMode('fork')`). Inherited by the subprocess via the parent env. See `docs/architecture/2026-06-02-fork-per-request-cgi-pool.md`. |
@@ -5551,7 +5568,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.5 .
+docker build -t zealphp:0.4.8 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -5563,7 +5580,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.5 .
+    -t zealphp:0.4.8 .
 ```
 
 ### Run (single container)
@@ -5575,7 +5592,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.5
+    zealphp:0.4.8
 ```
 
 ### Production compose
@@ -5586,7 +5603,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.5
+    image: registry.example.com/zealphp-app:0.4.8
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
Regenerated via `make docs-rebuild` after the v0.4.8 release (the protocol step that shipped stale at v0.4.0). 21 insertions from the docs updated since the last rebuild. The scaffold's llms.txt is already synced from this exact file.