### PR TITLE
chore: bump ext-zealphp pin to v0.3.47 (Stage-8 object-global store-corruption fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+- **ext-zealphp pin bumped to v0.3.47 — Stage-8 object-global store-corruption fix.** A `require_once`-legacy app with a **process-global DB connection object** (`$ydb`/`$wpdb`/`$pdo` at file scope) under `App::mode(App::MODE_COROUTINE_LEGACY)` + `App::globalScopeInclude(true)` segfaulted workers under concurrent load (3–13 worker SIGSEGVs per 6-way burst; single-user traffic clean). Root cause (ext): Stage 8's `zealphp_require_global` runs the request in a `ZEND_CALL_TOP_CODE` frame sharing the process-wide `EG(symbol_table)`, so an object global lives as an `IS_INDIRECT` top-frame CV the whole request; a second concurrent coroutine's `zend_attach_symbol_table` alias-copies the object pointer (no addref) into its own frame and repoints the bucket, so first-to-unwind frees it under the peer → `EG(objects_store)` free-list poison → SIGSEGV in the next object allocation in ANY coroutine. ext 0.3.47 isolates these per coroutine (frame-CV-addressed: save + NULL the frame CV on yield, restore into the *resuming* coroutine's own frame CV — `reset_to_parent` untouched). **Validated:** minimal repro + real **YOURLS** + PDO-mysql + mysqli globals all **0 worker deaths** (was 3–13/burst), ext 58/58 phpt, valgrind 0 errors, CI ASAN 8.3/8.4/8.5 green. This generalises across the `require_once`-legacy-with-global-connection class. **WordPress** under heavy concurrency is a separate remaining frontier (the documented mysqlnd/libtasn1 cold-boot teardown corruption — distinct signature; the Stage-8 fix + `USE_ZEND_ALLOC=0` clears its worker SIGSEGVs but leaves request hangs entangled with that teardown class).
+
 
 ## [0.4.8] - 2026-06-10
 

--- a/setup.sh
+++ b/setup.sh
@@ -162,13 +162,13 @@ docker_setup() {
     docker-php-ext-enable --ini-name zz-openswoole.ini openswoole
     php -r 'exit(extension_loaded("openswoole") ? 0 : 1);' || { echo -e "${RED}OpenSwoole built but failed to load.${RESET}"; exit 1; }
 
-    echo -e "${YELLOW}Installing ext-zealphp ${ZEALPHP_EXT_VERSION:-v0.3.46} for Docker image.${RESET}"
+    echo -e "${YELLOW}Installing ext-zealphp ${ZEALPHP_EXT_VERSION:-v0.3.47} for Docker image.${RESET}"
     # Pinned for reproducibility + to dodge the pre-0.3.16 compile break on modern
     # toolchains (GCC 14 hardens -Wincompatible-pointer-types to an error; the old
     # zend_alter_ini_entry_ex call passed the entry struct instead of the name).
     # NOTE: the ext has its OWN 0.3.x version line — do NOT confuse it with the
     # framework's 0.3.x. Override with ZEALPHP_EXT_VERSION.
-    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.46}" https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
+    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.47}" https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
     if (cd /tmp/ext-zealphp && phpize && ./configure --enable-zealphp && make -j"${ZEALPHP_BUILD_JOBS}" && make install); then
         docker-php-ext-enable --ini-name zz-zealphp.ini zealphp
         rm -rf /tmp/ext-zealphp
@@ -600,7 +600,7 @@ install_zealphp_ext() {
 
     local tmpdir
     tmpdir="$(mktemp -d)"
-    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.46}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir/ext-zealphp" || {
+    git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.47}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir/ext-zealphp" || {
         echo -e "${YELLOW}Failed to clone ext-zealphp repo. Falling back to uopz.${RESET}"
         rm -rf "$tmpdir"
         install_uopz_fallback
@@ -734,7 +734,7 @@ macos_setup() {
     echo -e "${GREEN}Installing ext-zealphp.${RESET}"
     local tmpdir
     tmpdir="$(mktemp -d)"
-    if git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.46}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir" && \
+    if git clone --depth 1 --branch "${ZEALPHP_EXT_VERSION:-v0.3.47}" https://github.com/sibidharan/ext-zealphp.git "$tmpdir" && \
        (cd "$tmpdir" && phpize && ./configure --enable-zealphp && make -j"${ZEALPHP_BUILD_JOBS}" && make install); then
         echo "extension=zealphp.so" > "${php_ini_dir}/zz-zealphp.ini"
         rm -rf "$tmpdir"


### PR DESCRIPTION
Bumps the default ext pin in `setup.sh` (4 sites) v0.3.46 → **v0.3.47**.

ext 0.3.47 fixes the Stage-8 object-global store corruption: a `require_once`-legacy app with a process-global DB connection object (`$ydb`/`$wpdb`/`$pdo`) under `MODE_COROUTINE_LEGACY` + `globalScopeInclude(true)` segfaulted workers under concurrent load (object-store free-list poison from a shared-symbol-table top-frame CV collision). Frame-CV-addressed isolation in the ext.

**Validated:** minimal repro + real YOURLS + PDO-mysql + mysqli globals all **0 worker deaths** (was 3–13/burst); ext 58/58 phpt; valgrind 0 errors; CI ASAN 8.3/8.4/8.5 green. ([ext PR #46](https://github.com/sibidharan/ext-zealphp/pull/46), tag v0.3.47)

WordPress under heavy concurrency remains a separate frontier (the documented mysqlnd/libtasn1 teardown class — distinct signature).