### PR TITLE
fix: HTTP Range/conditional-GET parity cluster (#358 #360 #361 #362 #363 #364 #365 #366)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -8445,6 +8445,20 @@ class App
             // native static handler for them can still add them via
             // App::staticHandlerLocations() (accepting the documented
             // prefix-match caveat).
+            //
+            // KNOWN OpenSwoole native-handler RFC divergences (#360, upstream
+            // openswoole/ext-openswoole#392 + #393 — confirmed pure-OpenSwoole,
+            // NOT a ZealPHP bug; the C handler answers before PHP runs, so the
+            // framework cannot guard them from PHP without disabling the handler):
+            //   1. `%00` path truncation — `GET /css/site.css%00.png` serves
+            //      `/css/site.css` (200) instead of 400. Stays inside the doc
+            //      root (no traversal), but defeats suffix/extension decisions.
+            //   2. HEAD returns the full body — RFC 9110 §9.3.2 requires no body
+            //      on HEAD; the native handler ships every byte.
+            // For security-sensitive assets, route them through the PHP
+            // `Response::sendFile()` path instead (it 400s `%00`, strips HEAD
+            // bodies per #358, and computes a proper conditional/range surface),
+            // or scope `static_handler_locations` to non-sensitive subtrees.
             'static_handler_locations' => self::$static_handler_locations !== []
                 ? self::$static_handler_locations
                 : self::defaultStaticHandlerLocations(),

--- a/src/HTTP/ConditionalRequest.php
+++ b/src/HTTP/ConditionalRequest.php
@@ -397,12 +397,15 @@ final class ConditionalRequest
         if ($value === '') {
             return null;
         }
-        // Drop a legacy trailing parameter (e.g. "; length=62") — apr_date_parse_http
-        // tolerates it; strtotime does not.
+        // Drop a legacy trailing parameter (e.g. "; length=62") -- apr_date_parse_http
+        // tolerates it; strtotime does not. No rtrim is needed on the kept head:
+        // strtotime() already ignores surrounding whitespace, and the only way the
+        // head can be all-whitespace is a leading ';' (already removed by trim()),
+        // which substr() turns into '' -- caught by the guard below.
         $semi = \strpos($value, ';');
         if ($semi !== false) {
-            $value = \rtrim(\substr($value, 0, $semi));
-            if ($value === '') {
+            $value = \substr($value, 0, $semi);
+            if (\trim($value) === '') {
                 return null;
             }
         }

--- a/src/HTTP/ConditionalRequest.php
+++ b/src/HTTP/ConditionalRequest.php
@@ -378,15 +378,33 @@ final class ConditionalRequest
 
     /**
      * Parse an HTTP-date into a Unix timestamp, or null when unparseable.
-     * Accepts the three RFC 9110 §5.6.7 formats (`strtotime` covers IMF-fixdate,
-     * RFC 850, and asctime). Empty / malformed values yield null, mirroring
-     * Apache's `APR_DATE_BAD`.
+     *
+     * Tolerant like Apache's `apr_date_parse_http` (the reference this class
+     * ports), not as strict as a bare `strtotime`. `strtotime` already covers
+     * the three RFC 9110 §5.6.7 formats — IMF-fixdate (RFC 1123), RFC 850, and
+     * asctime — but it REJECTS the historical trailing `"; length=NNN"`
+     * parameter some caches still append to `If-Modified-Since`/`If-Unmodified-Since`
+     * (Netscape-era). `strtotime("…GMT; length=62")` returns false, which
+     * downstream becomes `COND_NOMATCH` → a 304→200 cache miss, or on an unsafe
+     * method a 412→bypass (#363). So strip any trailing parameter list (the
+     * first `;` and everything after it) before parsing, then defer to
+     * `strtotime`. Only a date with no recognisable timestamp yields null,
+     * mirroring Apache's `APR_DATE_BAD`.
      */
     private static function parseHttpDate(string $value): ?int
     {
         $value = \trim($value);
         if ($value === '') {
             return null;
+        }
+        // Drop a legacy trailing parameter (e.g. "; length=62") — apr_date_parse_http
+        // tolerates it; strtotime does not.
+        $semi = \strpos($value, ';');
+        if ($semi !== false) {
+            $value = \rtrim(\substr($value, 0, $semi));
+            if ($value === '') {
+                return null;
+            }
         }
         $ts = \strtotime($value);
         return $ts === false ? null : $ts;

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -351,8 +351,9 @@ class Response
      *  - ['status' => 'ignore', 'ranges' => []]
      *        Header is not a `bytes=` range, contains a syntactically invalid
      *        spec (RFC 7233 §2.1: an invalid spec invalidates the whole header),
-     *        or the range count exceeds {@see MAX_RANGES} (CVE-2011-3192
-     *        mitigation). Caller serves the full body (200).
+     *        contains no spec at all (`bytes=,` — the empty byte-range-set, also
+     *        invalid per §2.1, #365), or the range count exceeds {@see MAX_RANGES}
+     *        (CVE-2011-3192 mitigation). Caller serves the full body (200).
      *  - ['status' => 'unsatisfiable', 'ranges' => []]
      *        Every well-formed spec is out of bounds (416).
      *  - ['status' => 'ok', 'ranges' => array<int, array{0: int, 1: int}>]
@@ -371,11 +372,20 @@ class Response
         }
 
         $ranges = [];
+        // Track whether the set contained ANY syntactically-valid spec. RFC 7233
+        // §2.1: byte-range-set = 1#( byte-range-spec / suffix-byte-range-spec ) —
+        // at least one spec is required. A header with none (`bytes=,`, `bytes=,,`,
+        // `bytes=, ,`) is not a valid Range request at all → ignore it and serve
+        // the full 200 (#365), as opposed to a valid spec that fell out of bounds
+        // (→ 416). Without this we can't tell "no parseable spec → ignore" from
+        // "all valid specs unsatisfiable → unsatisfiable".
+        $sawSpec = false;
         foreach ($specs as $spec) {
             $spec = trim($spec);
             if ($spec === '') {
                 continue;
             }
+            $sawSpec = true;
 
             // Strict byte-range-spec grammar (RFC 7233 §2.1):
             //   suffix:  "-" 1*DIGIT          (bytes=-N)
@@ -420,10 +430,15 @@ class Response
             }
         }
 
-        // Every spec was unsatisfiable/degenerate → 416 (RFC 7233 §4.4). A
-        // multi-range header keeps its satisfiable specs (the bad ones skipped above).
         if ($ranges === []) {
-            return ['status' => 'unsatisfiable', 'ranges' => []];
+            // No range survived. Distinguish the two empty cases (#365):
+            //  - No syntactically-valid spec was present at all (`bytes=,`) →
+            //    the header is invalid per RFC 7233 §2.1 → ignore → full 200.
+            //  - ≥1 valid spec parsed but every one fell outside [0, total) /
+            //    was degenerate (`bytes=500-600`, `bytes=-0`) → 416 (§4.4).
+            return $sawSpec
+                ? ['status' => 'unsatisfiable', 'ranges' => []]
+                : ['status' => 'ignore', 'ranges' => []];
         }
 
         // Coalesce overlapping/adjacent specs into disjoint unions before
@@ -604,7 +619,19 @@ class Response
         $this->header('Accept-Ranges', 'bytes');
 
         if ($filename !== '') {
-            $this->header('Content-Disposition', 'attachment; filename="' . addcslashes($filename, '"\\') . '"');
+            // RFC 6266 / RFC 5987: HTTP field values are US-ASCII (RFC 9110 §5.5),
+            // so a non-ASCII download name must travel as the `filename*` ext-value
+            // (UTF-8'' + percent-encoded), NOT raw UTF-8 octets inside the quoted
+            // `filename=` string (which browsers garble/strip). We always emit an
+            // ASCII-downgraded `filename=` fallback for legacy clients, and append
+            // `filename*=UTF-8''…` only when the name actually has non-ASCII bytes
+            // (#361). Matches mod_php / mod_dav download behaviour.
+            $ascii = (string) preg_replace('/[^\x20-\x7e]/', '_', $filename);
+            $disposition = 'attachment; filename="' . addcslashes($ascii, '"\\') . '"';
+            if ($ascii !== $filename) {
+                $disposition .= "; filename*=UTF-8''" . rawurlencode($filename);
+            }
+            $this->header('Content-Disposition', $disposition);
         }
 
         // Conditional preconditions — Apache-style ETag (mtime-size as weak
@@ -637,6 +664,23 @@ class Response
         $cond = ConditionalRequest::evaluate($method, $condHeaders, $etag, $mtime);
         if ($cond === 304 || $cond === 412) {
             $this->status($cond);
+            $this->flush();
+            $this->parent->end('');
+            return;
+        }
+
+        // HEAD (RFC 9110 §9.3.2): "identical to GET except that the server MUST
+        // NOT send content in the response." Emit every header a GET would
+        // (Content-Type / Content-Length / ETag / Last-Modified / Accept-Ranges,
+        // already queued above) but no body bytes. This mirrors the stream()/sse()
+        // HEAD guard (#238); without it the zero-copy sendfile() paths below would
+        // write the full file on HEAD (#358), bypassing ResponseMiddleware's
+        // HEAD body-strip (sendFile sets $g->_streaming = true). We advertise the
+        // full representation's Content-Length here — the body-less HEAD analogue
+        // of the 200 path — never a per-range length, matching Apache static HEAD.
+        if (strcasecmp($method, 'HEAD') === 0) {
+            $this->status(200);
+            $this->header('Content-Length', (string) $total);
             $this->flush();
             $this->parent->end('');
             return;
@@ -715,11 +759,18 @@ class Response
             return true;
         }
 
-        // Entity-tag form: starts with `"` or `W/"`. Strong comparison only —
-        // a weak validator must not be used to short-circuit a Range request,
-        // so a `W/`-prefixed If-Range never matches (mirrors Apache's
-        // ap_condition_if_range, which compares the raw strings).
+        // Entity-tag form: starts with `"` or `W/"`. RFC 9110 §13.1.5 mandates
+        // the STRONG comparison function for If-Range, and §8.8.1 forbids a weak
+        // validator from authorising sub-range retrieval. So if EITHER tag is
+        // weak (`W/`-prefixed) the validator can never satisfy If-Range → fall
+        // through to the full 200 (#362). Only two non-weak, byte-identical
+        // opaque-tags match. sendFile's ETag is always weak, so by-ETag If-Range
+        // on these resources always serves the full body — clients should use
+        // the HTTP-date If-Range form (handled by ifRangeDateMatches()).
         if (str_starts_with($ifRange, '"') || str_starts_with($ifRange, 'W/"')) {
+            if (str_starts_with($ifRange, 'W/') || str_starts_with($etag, 'W/')) {
+                return false;
+            }
             return $ifRange === $etag;
         }
 
@@ -809,9 +860,19 @@ class Response
             $this->parent->end('');
             return;
         }
+
+        // Assemble the whole multipart body and emit it in ONE length-delimited
+        // end($payload) call rather than incremental write()s (#366). The moment
+        // OpenSwoole sees a write() it switches the response to chunked
+        // transfer-encoding and silently drops the Content-Length we queued above
+        // — diverging from Apache, which sends multipart/byteranges length-
+        // delimited. coalesceRanges() in parseRange() caps Σ(slice) ≤ $total, so
+        // the buffered payload is bounded by the file size (the same byte budget
+        // a 200 would write). Result: the precomputed Content-Length survives on
+        // the wire, so clients can show a progress total for the multi-range fetch.
+        $payload = '';
         foreach ($ranges as $i => [$start, $end]) {
-            $part = ($i > 0 ? "\r\n" : '') . $partHeaders[$i];
-            $this->parent->write($part);
+            $payload .= ($i > 0 ? "\r\n" : '') . $partHeaders[$i];
             $remaining = $end - $start + 1;
             fseek($fh, $start);
             while ($remaining > 0) {
@@ -819,13 +880,13 @@ class Response
                 if ($chunk === false || $chunk === '') {
                     break;
                 }
-                $this->parent->write($chunk);
+                $payload .= $chunk;
                 $remaining -= strlen($chunk);
             }
         }
         fclose($fh);
-        $this->parent->write($closing);
-        $this->parent->end();
+        $payload .= $closing;
+        $this->parent->end($payload);
     }
 
     /**

--- a/src/Middleware/RangeMiddleware.php
+++ b/src/Middleware/RangeMiddleware.php
@@ -111,13 +111,22 @@ class RangeMiddleware implements MiddlewareInterface
         $ifRange = $request->getHeaderLine('If-Range');
         if ($ifRange !== '') {
             if (str_starts_with($ifRange, '"') || str_starts_with($ifRange, 'W/"')) {
-                // ETag comparison — exact string match required (strong or weak tag).
+                // ETag comparison — RFC 9110 §13.1.5 requires the STRONG function
+                // for If-Range, and §8.8.1 forbids a weak validator from
+                // authorising sub-range retrieval. If EITHER the If-Range value or
+                // the response ETag is weak (`W/`-prefixed), the validator can
+                // never satisfy If-Range → ignore the Range, serve the full body
+                // (#362). Only two non-weak, byte-identical tags honour the range.
                 $etag = $response->getHeaderLine('ETag');
-                if ($etag !== '' && $ifRange !== $etag) {
-                    // ETag mismatch: ignore range, serve full body.
+                if (str_starts_with($ifRange, 'W/') || str_starts_with($etag, 'W/')) {
+                    // Weak validator on either side — never short-circuit a Range.
                     return $response->withHeader('Accept-Ranges', 'bytes');
                 }
-                // No ETag on response or tags match: fall through and honour range.
+                if ($etag !== '' && $ifRange !== $etag) {
+                    // Strong ETag mismatch: ignore range, serve full body.
+                    return $response->withHeader('Accept-Ranges', 'bytes');
+                }
+                // No ETag on response or strong tags match: honour the range.
             } else {
                 // HTTP-date comparison against Last-Modified — delegated to the
                 // single shared strong-validation helper so this buffered path
@@ -169,14 +178,22 @@ class RangeMiddleware implements MiddlewareInterface
         // the loop, rather than a 416.
         $valid = true;
 
+        // Track whether the set contained ANY syntactically-valid spec. RFC 7233
+        // §2.1: byte-range-set requires ≥1 spec. A header with none at all
+        // (`bytes=,`, `bytes=,,`) is invalid → ignore → full 200 (#365), distinct
+        // from a valid spec that fell out of bounds (→ 416).
+        $sawSpec = false;
+
         foreach ($rawSpecs as $spec) {
             $spec = trim($spec);
             if ($spec === '') {
                 // Empty token after trim (e.g. trailing comma, or bytes= with only
-                // whitespace).  Skip silently — no range added; if no valid spec is
-                // found the empty-$ranges check below will emit 416.
+                // whitespace).  Skip silently — no range added; if at least one
+                // VALID spec was seen the empty-$ranges check below emits 416,
+                // otherwise (#365) the header is invalid → full 200.
                 continue;
             }
+            $sawSpec = true;
 
             if (str_starts_with($spec, '-')) {
                 // Suffix range: bytes=-N → last N bytes
@@ -238,6 +255,11 @@ class RangeMiddleware implements MiddlewareInterface
         }
 
         if (empty($ranges)) {
+            // #365: no valid spec at all (`bytes=,`) → invalid header → full 200;
+            // ≥1 valid spec but all out of bounds → 416.
+            if (!$sawSpec) {
+                return $response->withHeader('Accept-Ranges', 'bytes');
+            }
             return $this->unsatisfiable($total, $g);
         }
 

--- a/src/ResponseMiddleware.php
+++ b/src/ResponseMiddleware.php
@@ -123,7 +123,12 @@ class ResponseMiddleware implements MiddlewareInterface
                     if (!$g->openswoole_response->isWritable()) break;
                     // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
                     $g->openswoole_response->write((string)$chunk);
-                    \OpenSwoole\Coroutine::sleep(0);
+                    // #354 — yield only inside a coroutine; in mixed mode
+                    // (enable_coroutine=false) Coroutine::sleep(0) throws and
+                    // crashes the worker (status=255) with a truncated stream.
+                    if (\OpenSwoole\Coroutine::getCid() > 0) {
+                        \OpenSwoole\Coroutine::sleep(0);
+                    }
                 }
                 // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
                 if ($g->openswoole_response->isWritable()) {
@@ -561,9 +566,9 @@ class ResponseMiddleware implements MiddlewareInterface
         }
 
         // Apache PATH_INFO — `/script.php/extra/path` exposes `/extra/path` to
-        // the script and rewrites REQUEST_URI to just the script. Triggers
-        // only when the literal `.php/` appears in the URL (WordPress/Drupal
-        // permalink style); implicit-extension routing is unaffected.
+        // the script via PATH_INFO/SCRIPT_NAME. Triggers only when the literal
+        // `.php/` appears in the URL (WordPress/Drupal permalink style);
+        // implicit-extension routing is unaffected.
         if (App::$path_info && strpos($path, '.php/') !== false) {
             [$scriptPath, $extra] = explode('.php/', $path, 2);
             $scriptPath .= '.php';
@@ -581,13 +586,23 @@ class ResponseMiddleware implements MiddlewareInterface
                 $rewritten = App::$ignore_php_ext
                     ? substr($scriptPath, 0, -4)
                     : $scriptPath;
-                $uri = $rewritten . ($qs ? '?' . $qs : '');
-                $g->server['REQUEST_URI'] = $uri;
-                // Keep $path in lock-step with the rewritten resource so the
-                // App::when() path-scope match (below) sees exactly what the
-                // router will dispatch — otherwise a `.php/extra` PATH_INFO URL
-                // could be matched by `when()` against the pre-rewrite path and
-                // a path-scoped auth guard could be evaded.
+                // RFC 3875 §4.1.7 / mod_php SAPI: REQUEST_URI is the request
+                // target EXACTLY as received — mod_php derives SCRIPT_NAME /
+                // PATH_INFO from it but NEVER mutates it. Routers, front
+                // controllers and access logs (%r) all rely on the full original
+                // target. So leave $g->server['REQUEST_URI'] alone (#364);
+                // previously it was overwritten with just the script path,
+                // dropping the `/extra/path` suffix.
+                //
+                // The route table dispatches against the *rewritten* resource
+                // path (the implicit file route), so stash it in a request-scoped
+                // memo that matchAndDispatch() prefers over re-parsing REQUEST_URI.
+                // Keep the local $path in lock-step too so the App::when()
+                // path-scope match (below) sees exactly what the router will
+                // dispatch — otherwise a `.php/extra` URL could be matched by
+                // when() against the pre-rewrite path and a path-scoped auth
+                // guard could be evaded.
+                $g->memo['_routing_path'] = $rewritten;
                 $path = $rewritten;
             }
         }
@@ -702,12 +717,21 @@ class ResponseMiddleware implements MiddlewareInterface
     public function matchAndDispatch(ServerRequestInterface $request, string $method): ResponseInterface
     {
         $g = RequestContext::instance();
-        $uri = (string)$g->server['REQUEST_URI'];
-        // REQUEST_URI now carries the query string for mod_php parity (#306); route
-        // keys + patterns are path-only, so match on the path component. parse_url
-        // returns null only for a degenerate target ('*'), where $uri is the right
-        // fallback (and OPTIONS '*' is handled earlier in process(), not here).
-        $matchPath = (string)(parse_url($uri, PHP_URL_PATH) ?: $uri);
+        // A `.php/extra/path` PATH_INFO request keeps REQUEST_URI as the full
+        // original target (#364, RFC 3875 §4.1.7), so the route table — which
+        // dispatches against the *rewritten* resource path (e.g. `/api`) — must
+        // match the stashed routing path, not the un-rewritten REQUEST_URI.
+        $routingPath = $g->memo['_routing_path'] ?? null;
+        if (is_string($routingPath) && $routingPath !== '') {
+            $matchPath = $routingPath;
+        } else {
+            $uri = (string)$g->server['REQUEST_URI'];
+            // REQUEST_URI now carries the query string for mod_php parity (#306); route
+            // keys + patterns are path-only, so match on the path component. parse_url
+            // returns null only for a degenerate target ('*'), where $uri is the right
+            // fallback (and OPTIONS '*' is handled earlier in process(), not here).
+            $matchPath = (string)(parse_url($uri, PHP_URL_PATH) ?: $uri);
+        }
         $app = App::instance();
         assert($app !== null);
 

--- a/tests/Unit/ConditionalRequestTest.php
+++ b/tests/Unit/ConditionalRequestTest.php
@@ -683,6 +683,50 @@ class ConditionalRequestTest extends TestCase
         $this->assertSame(304, $r);
     }
 
+    // ---- #363: tolerant parsing like apr_date_parse_http ------------------
+
+    public function testIfModifiedSinceWithLegacyLengthParameterStill304(): void
+    {
+        // #363 — Apache's apr_date_parse_http tolerates the historical trailing
+        // "; length=NNN" parameter that some caches append. strtotime rejects it,
+        // which downstream became a 304→200 cache miss. parseHttpDate now strips
+        // the trailing parameter, so the date still drives the comparison → 304.
+        $date = $this->dt(self::MTIME) . '; length=62';
+        $r = ConditionalRequest::evaluate('GET', ['if-modified-since' => $date], '', self::MTIME, self::NOW);
+        $this->assertSame(304, $r);
+    }
+
+    public function testIfUnmodifiedSinceWithLengthParameterStillEnforced(): void
+    {
+        // #363 — for an unsafe method, a malformed-but-parseable
+        // If-Unmodified-Since must still protect the resource (a past date →
+        // 412), not silently bypass the precondition because of the trailing
+        // "; length=" parameter. PAST < MTIME → resource modified since → 412.
+        $date = $this->dt(self::PAST) . '; length=128';
+        $r = ConditionalRequest::evaluate('PUT', ['if-unmodified-since' => $date], '', self::MTIME, self::NOW);
+        $this->assertSame(412, $r);
+    }
+
+    public function testIfModifiedSinceLegacyRfc850AndAsctimeFormatsParse(): void
+    {
+        // #363 — the three RFC 9110 §5.6.7 formats all parse (strtotime handles
+        // RFC 850 + asctime); only the trailing-parameter case needed the strip.
+        $rfc850  = gmdate('l, d-M-y H:i:s', self::MTIME) . ' GMT'; // RFC 850
+        $asctime = gmdate('D M j H:i:s Y', self::MTIME);          // asctime
+        $this->assertSame(304, ConditionalRequest::evaluate('GET', ['if-modified-since' => $rfc850], '', self::MTIME, self::NOW));
+        $this->assertSame(304, ConditionalRequest::evaluate('GET', ['if-modified-since' => $asctime], '', self::MTIME, self::NOW));
+    }
+
+    public function testIfModifiedSinceBareSemicolonIsIgnored(): void
+    {
+        // #363 — a value that is ONLY a parameter (no date before the ';') has no
+        // recognisable timestamp → NOMATCH → 200 (well outside the 60s window).
+        $requestTime = time();
+        $mtime = $requestTime - 100_000;
+        $r = ConditionalRequest::evaluate('GET', ['if-modified-since' => '; length=62'], '', $mtime, $requestTime);
+        $this->assertSame(200, $r);
+    }
+
     public function testParseHttpDateWhitespaceOnlyHeaderIsIgnored(): void
     {
         // Without trim(), strtotime('   ') returns the current wall-clock time

--- a/tests/Unit/HTTP/ResponseTest.php
+++ b/tests/Unit/HTTP/ResponseTest.php
@@ -580,11 +580,16 @@ class ResponseTest extends TestCase
         $this->assertNotNull($ct);
         $this->assertStringStartsWith('multipart/byteranges; boundary=zealphp_', (string) $ct);
 
-        // Reconstruct the multipart body from the captured write() calls.
+        // Reconstruct the multipart body from the captured write()/end() calls.
+        // #366: the multipart body is now emitted in a single length-delimited
+        // end($payload) (so the precomputed Content-Length survives instead of
+        // OpenSwoole falling back to chunked), not incremental write()s.
         $body = '';
         foreach ($fake->log as $entry) {
             if (($entry[0] ?? null) === 'write') {
                 $body .= (string) $entry[1];
+            } elseif (($entry[0] ?? null) === 'end') {
+                $body .= (string) ($entry[1] ?? '');
             }
         }
         // boundary token
@@ -606,6 +611,135 @@ class ResponseTest extends TestCase
             }
         }
         $this->assertSame(strlen($body), $contentLength);
+    }
+
+    public function testSendFileMultiRangeIsLengthDelimitedNotChunked(): void
+    {
+        // #366: the multipart/byteranges body must be emitted in ONE
+        // length-delimited end($payload) so the precomputed Content-Length
+        // survives — NOT incremental write()s (which make OpenSwoole fall back
+        // to chunked transfer-encoding, dropping Content-Length). Assert the body
+        // bytes rode end(), not write().
+        $path = $this->makeTempFile('0123456789', 'bin'); // 10 bytes
+        $this->setRequestHeaders(['range' => 'bytes=0-2,5-7']);
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->sendFile($path);
+
+        $writes = array_filter($fake->log, static fn($e) => ($e[0] ?? null) === 'write');
+        $this->assertSame([], $writes, '#366: multipart must not use incremental write()');
+
+        $ends = array_values(array_filter($fake->log, static fn($e) => ($e[0] ?? null) === 'end'));
+        $this->assertCount(1, $ends, 'exactly one end() carries the whole multipart body');
+        $payload = (string) ($ends[0][1] ?? '');
+        $this->assertNotSame('', $payload, 'end() payload must contain the multipart body');
+
+        // Content-Length header must equal the single end() payload length.
+        $contentLength = null;
+        foreach ($this->headerCalls($fake) as $h) {
+            if ($h[1] === 'Content-Length') {
+                $contentLength = (int) $h[2];
+            }
+        }
+        $this->assertSame(strlen($payload), $contentLength);
+    }
+
+    public function testSendFileHeadEmitsHeadersButNoBody(): void
+    {
+        // #358 — RFC 9110 §9.3.2: HEAD MUST NOT send content. sendFile's
+        // zero-copy paths previously wrote the full file on HEAD. Assert HEAD
+        // gets 200 + the full-representation Content-Length but zero body bytes
+        // (no sendfile / no body-bearing write).
+        $path = $this->makeTempFile(str_repeat('z', 62), 'csv');
+        $g = RequestContext::instance();
+        $g->server = ['REQUEST_METHOD' => 'HEAD'];
+        $this->setRequestHeaders([]);
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->sendFile($path);
+
+        $this->assertContains(['status', 200, ''], $fake->log);
+        // No body: no sendfile, and end() carries no payload.
+        foreach ($fake->log as $entry) {
+            $this->assertNotSame('sendfile', $entry[0] ?? null, 'HEAD must not ship the body');
+        }
+        $this->assertContains(['end', ''], $fake->log);
+        // Content-Length is still the FULL representation size.
+        $cl = null;
+        foreach ($this->headerCalls($fake) as $h) {
+            if ($h[1] === 'Content-Length') { $cl = (int) $h[2]; }
+        }
+        $this->assertSame(62, $cl, 'HEAD advertises the full Content-Length');
+        // Validators a GET would emit are present.
+        $names = array_map(static fn($h) => $h[1], $this->headerCalls($fake));
+        $this->assertContains('ETag', $names);
+        $this->assertContains('Accept-Ranges', $names);
+        $g->server = [];
+    }
+
+    public function testSendFileHeadIgnoresRangeAndServesNo206(): void
+    {
+        // #358 — a HEAD with a Range must still be body-less and 200 (HEAD has no
+        // body to take a range of); never a 206 with bytes on the wire.
+        $path = $this->makeTempFile(str_repeat('z', 62), 'csv');
+        $g = RequestContext::instance();
+        $g->server = ['REQUEST_METHOD' => 'HEAD'];
+        $this->setRequestHeaders(['range' => 'bytes=0-9']);
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->sendFile($path);
+
+        foreach ($fake->log as $entry) {
+            $this->assertNotSame('sendfile', $entry[0] ?? null);
+            $this->assertNotSame(206, $entry[1] ?? null);
+        }
+        $this->assertContains(['status', 200, ''], $fake->log);
+        $g->server = [];
+    }
+
+    public function testSendFileNonAsciiFilenameEmitsRfc6266ExtValue(): void
+    {
+        // #361 — a non-ASCII download name must travel as the RFC 6266
+        // `filename*=UTF-8''<pct-encoded>` ext-value, alongside an ASCII
+        // `filename=` fallback (RFC 5987 / RFC 9110 §5.5).
+        $path = $this->makeTempFile('data', 'csv');
+        $this->setRequestHeaders([]);
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->sendFile($path, 'café résumé.csv');
+
+        $disposition = null;
+        foreach ($this->headerCalls($fake) as $h) {
+            if ($h[1] === 'Content-Disposition') { $disposition = (string) $h[2]; }
+        }
+        $this->assertNotNull($disposition);
+        // ASCII fallback: each non-ASCII *byte* downgraded to '_' (é = 2 UTF-8
+        // bytes → '__'), no raw UTF-8 octets in the quoted-string.
+        $this->assertStringContainsString('filename="caf__ r__sum__.csv"', $disposition);
+        $this->assertDoesNotMatchRegularExpression('/filename="[^"]*[\x80-\xff]/', $disposition);
+        // RFC 6266 ext-value with UTF-8 percent-encoding of the true name.
+        $this->assertStringContainsString("filename*=UTF-8''caf%C3%A9%20r%C3%A9sum%C3%A9.csv", $disposition);
+    }
+
+    public function testSendFileAsciiFilenameHasNoExtValue(): void
+    {
+        // #361 — an ASCII name is unaffected: quoted filename only, no filename*.
+        $path = $this->makeTempFile('data', 'csv');
+        $this->setRequestHeaders([]);
+        $fake = $this->fake();
+        $resp = $this->wrap($fake);
+
+        $resp->sendFile($path, 'report.csv');
+
+        $disposition = null;
+        foreach ($this->headerCalls($fake) as $h) {
+            if ($h[1] === 'Content-Disposition') { $disposition = (string) $h[2]; }
+        }
+        $this->assertSame('attachment; filename="report.csv"', $disposition);
     }
 
     public function testSendFileIfMatchMismatchReturns412(): void
@@ -815,12 +949,14 @@ class ResponseTest extends TestCase
         $this->assertContains(['sendfile', $path, 0, 100], $fake->log);
     }
 
-    public function testSendFileIfRangeEtagVerbatimMatchHonoursRange(): void
+    public function testSendFileIfRangeWeakEtagIgnoredServesFullBody(): void
     {
+        // #362 — RFC 9110 §13.1.5 mandates the STRONG comparison for If-Range and
+        // §8.8.1 forbids a weak validator from authorising sub-range retrieval.
+        // sendFile's ETag is ALWAYS weak (W/"<mtime>-<size>"), so even a verbatim
+        // echo of it in If-Range MUST be ignored → full 200, NOT a 206 slice.
         $path = $this->makeTempFile(str_repeat('m', 100), 'bin');
         $mtime = (int) filemtime($path);
-        // sendFile's ETag is weak; a verbatim echo matches via strcmp (Apache
-        // ap_condition_if_range does a raw string compare) → honour the range.
         $etag = 'W/"' . dechex($mtime) . '-' . dechex(100) . '"';
         $this->setRequestHeaders([
             'range'    => 'bytes=0-9',
@@ -831,8 +967,32 @@ class ResponseTest extends TestCase
 
         $resp->sendFile($path);
 
-        $this->assertContains(['status', 206, ''], $fake->log);
-        $this->assertContains(['sendfile', $path, 0, 10], $fake->log);
+        foreach ($fake->log as $entry) {
+            $this->assertNotSame(206, $entry[1] ?? null, 'weak If-Range must not yield 206');
+        }
+        $this->assertContains(['sendfile', $path, 0, 100], $fake->log);
+    }
+
+    public function testSendFileIfRangeStrongEtagMatchHonoursRange(): void
+    {
+        // #362 — the strong path still works: a non-weak If-Range that byte-
+        // matches a non-weak ETag honours the range. sendFile emits a weak ETag,
+        // so we install a custom strong-ETag resolver context is not available;
+        // instead assert via the pure ifRangeMatches() helper that a strong pair
+        // matches and a weak pair does not.
+        $ref = new \ReflectionMethod(ZResponse::class, 'ifRangeMatches');
+        $ref->setAccessible(true);
+        $resp = $this->wrap($this->fake());
+        $strong = '"abc-123"';
+        $weak   = 'W/"abc-123"';
+        // strong If-Range vs strong ETag → match
+        $this->assertTrue($ref->invoke($resp, $strong, $strong, 0));
+        // weak If-Range vs strong ETag → no match (weak validator forbidden)
+        $this->assertFalse($ref->invoke($resp, $weak, $strong, 0));
+        // strong If-Range vs weak ETag → no match (weak validator forbidden)
+        $this->assertFalse($ref->invoke($resp, $strong, $weak, 0));
+        // weak vs weak → no match
+        $this->assertFalse($ref->invoke($resp, $weak, $weak, 0));
     }
 
     public function testSendFileIfRangeEtagMismatchServesFullBody(): void
@@ -939,6 +1099,26 @@ class ResponseTest extends TestCase
     {
         $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('items=0-9', 100));
         $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('not a range', 100));
+    }
+
+    public function testParseRangeEmptyByteRangeSetIgnored(): void
+    {
+        // #365 — RFC 7233 §2.1: byte-range-set requires ≥1 spec. A header with
+        // none at all (`bytes=,`, `bytes=,,`, `bytes=, ,`) is invalid → ignore →
+        // full 200, NOT unsatisfiable (416). 416 is reserved for a VALID spec
+        // that fell outside [0, total).
+        $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('bytes=,', 5000));
+        $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('bytes=,,', 5000));
+        $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('bytes=, ,', 5000));
+        $this->assertSame(['status' => 'ignore', 'ranges' => []], ZResponse::parseRange('bytes= ', 5000));
+    }
+
+    public function testParseRangeDegenerateSuffixStillUnsatisfiable(): void
+    {
+        // #365 boundary vs #185: `bytes=-0` IS a syntactically-valid spec (just
+        // degenerate/zero-length) → it counts as "saw a spec" → 416, distinct
+        // from the empty set above which is "no spec → ignore".
+        $this->assertSame(['status' => 'unsatisfiable', 'ranges' => []], ZResponse::parseRange('bytes=-0', 100));
     }
 
     public function testParseRangeInvalidSpecIgnoresWholeHeader(): void

--- a/tests/Unit/RangeMiddlewareConformanceTest.php
+++ b/tests/Unit/RangeMiddlewareConformanceTest.php
@@ -296,18 +296,20 @@ class RangeMiddlewareConformanceTest extends TestCase
     }
 
     /**
-     * If-Range value is a weak ETag (W/"...") — handled via ETag path, not date path.
-     * Matching weak ETag → range honoured.
+     * If-Range value is a weak ETag (W/"...") — RFC 9110 §13.1.5 mandates the
+     * STRONG comparison for If-Range and §8.8.1 forbids a weak validator from
+     * authorising sub-range retrieval. So even a verbatim-matching weak ETag is
+     * ignored → full 200, never a 206 slice (#362).
      */
-    public function testIfRangeWeakETagMatchHonoursRange(): void
+    public function testIfRangeWeakETagIgnoredServesFullBody(): void
     {
         $response = $this->dispatch(
             ['range' => 'bytes=0-4', 'if-range' => 'W/"v2"'],
             ['ETag' => 'W/"v2"']
         );
 
-        $this->assertSame(206, $response->getStatusCode(), 'Matching weak ETag → 206');
-        $this->assertSame('Hello', (string) $response->getBody());
+        $this->assertSame(200, $response->getStatusCode(), 'Weak ETag If-Range → full 200');
+        $this->assertSame(self::BODY, (string) $response->getBody());
     }
 
     /**

--- a/tests/Unit/RangeMiddlewareTest.php
+++ b/tests/Unit/RangeMiddlewareTest.php
@@ -438,13 +438,26 @@ class RangeMiddlewareTest extends TestCase
         $this->assertSame('bytes 0-4/54', $response->getHeaderLine('Content-Range'));
     }
 
-    public function testEmptyRangeSpecIsUnsatisfiable(): void
+    public function testEmptyByteRangeSetIsIgnored(): void
     {
-        // "bytes= " → (.+) captures the space, spec trims to "" → skipped →
-        // ranges empty → 416.
+        // #365: "bytes= " → (.+) captures the space, spec trims to "" → no
+        // syntactically-valid spec present at all → invalid byte-range-set per
+        // RFC 7233 §2.1 → IGNORE the header → full 200 (not 416). 416 is
+        // reserved for a VALID spec that fell out of bounds.
         $response = $this->dispatchRange('bytes= ');
-        $this->assertSame(416, $response->getStatusCode());
-        $this->assertSame('bytes */54', $response->getHeaderLine('Content-Range'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(self::BODY, (string) $response->getBody());
+        $this->assertSame('bytes', $response->getHeaderLine('Accept-Ranges'));
+    }
+
+    public function testEmptyByteRangeSetCommaOnlyIsIgnored(): void
+    {
+        // #365: `bytes=,` / `bytes=,,` — every token empty, no spec → ignore → 200.
+        foreach (['bytes=,', 'bytes=,,', 'bytes=, ,'] as $hdr) {
+            $response = $this->dispatchRange($hdr);
+            $this->assertSame(200, $response->getStatusCode(), "$hdr must serve full 200");
+            $this->assertSame(self::BODY, (string) $response->getBody());
+        }
     }
 
     public function testUnsatisfiableStatusIsExactly416(): void
@@ -460,9 +473,10 @@ class RangeMiddlewareTest extends TestCase
 
     public function testIfRangeMatchHonoursRange(): void
     {
-        // If-Range == ETag → range applied (206). Kills LogicalAnd split: with
-        // `||`, etag!='' is true so it would short-circuit to 200 even on match.
-        $response = $this->dispatchRange('bytes=0-4', 200, null, 'GET', 'W/"v1"', 'W/"v1"');
+        // If-Range == strong ETag → range applied (206). Kills LogicalAnd split:
+        // with `||`, etag!='' is true so it would short-circuit to 200 even on
+        // match. STRONG tags only — RFC 9110 §13.1.5 (#362).
+        $response = $this->dispatchRange('bytes=0-4', 200, null, 'GET', '"v1"', '"v1"');
         $this->assertSame(206, $response->getStatusCode());
         $this->assertSame('Hello', (string) $response->getBody());
         $this->assertSame('bytes 0-4/54', $response->getHeaderLine('Content-Range'));
@@ -470,20 +484,37 @@ class RangeMiddlewareTest extends TestCase
 
     public function testIfRangeMismatchIgnoresRange(): void
     {
-        // If-Range != ETag → range ignored (200).
-        $response = $this->dispatchRange('bytes=0-4', 200, null, 'GET', 'W/"stale"', 'W/"fresh"');
+        // If-Range != ETag → range ignored (200). Strong tags, different values.
+        $response = $this->dispatchRange('bytes=0-4', 200, null, 'GET', '"stale"', '"fresh"');
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(self::BODY, (string) $response->getBody());
         $this->assertSame('bytes', $response->getHeaderLine('Accept-Ranges'));
     }
 
+    public function testIfRangeWeakEtagIgnoredServesFullBody(): void
+    {
+        // #362 — RFC 9110 §13.1.5 / §8.8.1: a weak validator (either side
+        // W/-prefixed) MUST NOT authorise sub-range retrieval. A verbatim weak
+        // If-Range echo that previously honoured the range now serves the full
+        // 200. Covers both weak-vs-weak and weak-If-Range-vs-strong-ETag.
+        $weakBoth = $this->dispatchRange('bytes=0-4', 200, null, 'GET', 'W/"v1"', 'W/"v1"');
+        $this->assertSame(200, $weakBoth->getStatusCode(), 'weak/weak If-Range → full 200');
+        $this->assertSame(self::BODY, (string) $weakBoth->getBody());
+
+        $weakIfRange = $this->dispatchRange('bytes=0-4', 200, null, 'GET', 'W/"v1"', '"v1"');
+        $this->assertSame(200, $weakIfRange->getStatusCode(), 'weak If-Range vs strong ETag → full 200');
+
+        $weakEtag = $this->dispatchRange('bytes=0-4', 200, null, 'GET', '"v1"', 'W/"v1"');
+        $this->assertSame(200, $weakEtag->getStatusCode(), 'strong If-Range vs weak ETag → full 200');
+    }
+
     public function testIfRangeWithNoEtagOnResponseHonoursRange(): void
     {
-        // If-Range present but response has no ETag ($etag === '') → the
+        // If-Range present (strong) but response has no ETag ($etag === '') → the
         // `$etag !== '' && ...` is false → range applied. Kills LogicalAnd split:
-        // with `||`, `$ifRange !== $etag` ('W/"x"' !== '') is true so it would
-        // WRONGLY return 200.
-        $response = $this->dispatchRange('bytes=0-4', 200, null, 'GET', 'W/"x"', null);
+        // with `||`, `$ifRange !== $etag` ('"x"' !== '') is true so it would
+        // WRONGLY return 200. Strong If-Range so the #362 weak-reject doesn't fire.
+        $response = $this->dispatchRange('bytes=0-4', 200, null, 'GET', '"x"', null);
         $this->assertSame(206, $response->getStatusCode());
         $this->assertSame('Hello', (string) $response->getBody());
     }

--- a/tests/Unit/ResponseMiddlewarePipelineTest.php
+++ b/tests/Unit/ResponseMiddlewarePipelineTest.php
@@ -103,6 +103,7 @@ class ResponseMiddlewarePipelineTest extends TestCase
         $g->status              = 200;
         $g->_streaming          = null;
         $g->server              = [];
+        $g->memo                = [];
     }
 
     private function dispatch(string $uri, string $method = 'GET'): ResponseInterface
@@ -260,6 +261,26 @@ class ResponseMiddlewarePipelineTest extends TestCase
     public function testPostOnlyRouteAcceptsPost(): void
     {
         $this->assertSame('posted', (string) $this->dispatch('/postonly', 'POST')->getBody());
+    }
+
+    // ── #364: PATH_INFO rewrite must NOT truncate REQUEST_URI ─────
+
+    public function testPathInfoKeepsFullRequestUri(): void
+    {
+        // RFC 3875 §4.1.7 / mod_php: REQUEST_URI is the original request target,
+        // unmodified — the PATH_INFO split derives SCRIPT_NAME / PATH_INFO from
+        // it but never mutates REQUEST_URI. ZealPHP previously overwrote
+        // REQUEST_URI with just the script path, dropping the path-info suffix
+        // (#364). public/api.php exists, so `/api.php/extra/path` triggers the
+        // PATH_INFO branch.
+        $g = RequestContext::instance();
+        $this->dispatch('/api.php/extra/path?q=1');
+
+        $this->assertSame('/extra/path', $g->server['PATH_INFO'] ?? null);
+        $this->assertSame('/api.php', $g->server['SCRIPT_NAME'] ?? null);
+        // REQUEST_URI must remain the full original target incl. the path-info
+        // suffix AND the query string — not the truncated `/api?q=1`.
+        $this->assertSame('/api.php/extra/path?q=1', $g->server['REQUEST_URI'] ?? null);
     }
 
     // ── security: traversal / null-byte rejection ─────────────────


### PR DESCRIPTION
HTTP static-file / Range / conditional-GET parity cluster — 8 issues from Guruprasanth-M's Phase-3 verification sweep, all brought into RFC 9110 / 7233 / 6266 / 3875 + Apache parity. Each fix has TDD unit coverage (no uopz; ext-zealphp is the override engine).

## Per-issue
- **#358** `Response::sendFile()` HEAD guard — after conditional eval, a HEAD request emits every header a GET would (incl. the full-representation `Content-Length`, `ETag`, `Accept-Ranges`) but **zero body bytes** on the zero-copy `sendfile()` paths (RFC 9110 §9.3.2), mirroring the existing `stream()`/`sse()` guard. A HEAD-with-Range is a body-less 200, never a 206.
- **#360** native static handler (`enable_static_handler`) `%00`-truncation + HEAD-full-body are **upstream OpenSwoole bugs** (ext-openswoole #392/#393), answered in C *before* PHP runs — so no PHP-side guard is possible without disabling the handler. **Documented** the limitation + the safe `Response::sendFile()` alternative at the `static_handler_locations` config site.
- **#361** `Content-Disposition` now emits the RFC 6266 `filename*=UTF-8''<pct-encoded>` ext-value **and** an ASCII-downgraded `filename=` fallback for non-ASCII names (RFC 5987 / RFC 9110 §5.5). ASCII names unchanged.
- **#362** `If-Range` requires the **strong** comparison — a weak (`W/`) validator on either side never satisfies `If-Range` (RFC 9110 §13.1.5 / §8.8.1) → full 200. Applied to **both** the `sendFile` path and the buffered `RangeMiddleware` path.
- **#363** conditional-GET HTTP-date parsing strips a trailing legacy `"; length=NNN"` parameter before `strtotime`, matching Apache `apr_date_parse_http` leniency — fixes the `304→200` cache miss and the `If-Unmodified-Since` `412→bypass` on unsafe methods.
- **#364** the PATH_INFO (`.php/extra/path`) rewrite no longer truncates `REQUEST_URI` — it stays the **full original target** (RFC 3875 §4.1.7 / mod_php SAPI). Internal routing dispatches against a request-scoped `_routing_path` memo, so routers / `%r` access logs see the unmodified target while the router still resolves the rewritten resource.
- **#365** an empty byte-range-set (`bytes=,`, `bytes=,,`, `bytes=, ,`, `bytes= `) is now **ignored → full 200** (RFC 7233 §2.1), distinct from a valid-but-out-of-bounds spec → 416. Both `parseRange` and `RangeMiddleware` track whether any syntactically-valid spec was seen.
- **#366** the `multipart/byteranges` 206 body is emitted in **one length-delimited `end($payload)`** instead of incremental `write()`s, so the precomputed `Content-Length` survives instead of OpenSwoole falling back to chunked.

## Validation
- `./vendor/bin/phpunit tests/Unit/` — **0 failures** (3911 tests; 310 skipped = server-required integration). New/updated tests in `ResponseTest`, `ConditionalRequestTest`, `RangeMiddlewareTest`, `RangeMiddlewareConformanceTest`, and `ResponseMiddlewarePipelineTest` (`testPathInfoKeepsFullRequestUri` for #364).
- `./vendor/bin/phpstan analyse --no-progress` — only the 2 **pre-existing** baseline errors (`Session/CoSessionManager.php:310`, `Session/SessionManager.php:358`), **zero new** from the changed files.

Closes #358, #360, #361, #362, #363, #364, #365, #366