### PR TITLE
fix: routing + static-file parity cluster (#356 #357 #359 #367 #368)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1907,6 +1907,46 @@ class App
     }
 
     /**
+     * Compose `$_REQUEST` from the GET and POST bags per PHP's default
+     * `request_order='GP'` (#356).
+     *
+     * PHP merges the sources left-to-right with LATER sources overwriting
+     * earlier ones, so for `'GP'` (GET first, POST second) a key present in both
+     * takes the POST value — the form-submission-overrides-querystring
+     * convention. PHP's `+` array-union keeps the LEFT operand on a collision,
+     * so the POST-wins composition is `$post + $get`. COOKIE is deliberately
+     * excluded (matches PHP's `'GP'`, which omits C). The single source of truth
+     * for both the OnRequest populate and the CGI-context request builder.
+     *
+     * @param array<string, mixed> $get
+     * @param array<string, mixed> $post
+     * @return array<string, mixed>
+     */
+    public static function composeRequestArray(array $get, array $post): array
+    {
+        return $post + $get;
+    }
+
+    /**
+     * The built-in default `static_handler_locations` — DIRECTORY entries only,
+     * every one trailing-slash terminated so OpenSwoole's raw string-prefix
+     * match is segment-bounded (a bare `/js` would steal `/json`).
+     *
+     * #367 — FILE entries (`/favicon.ico`, `/robots.txt`) are deliberately
+     * EXCLUDED: a file can't take a trailing slash, so OpenSwoole's prefix match
+     * over-reaches (`/favicon.ico` steals `/favicon.icoX`, shadowing a user route
+     * like `/robots.txt-generator`). favicon.ico + robots.txt are served as
+     * ordinary `public/` files by the framework's implicit file routes instead.
+     * Used as the default when the app hasn't set `App::staticHandlerLocations()`.
+     *
+     * @return list<string>
+     */
+    public static function defaultStaticHandlerLocations(): array
+    {
+        return ['/css/', '/js/', '/img/', '/images/', '/fonts/', '/assets/', '/static/'];
+    }
+
+    /**
      * Block any request whose path contains a dotfile component (`.git`, `.env`,
      * `.htaccess`, etc.) with `403`. Default `true` — matches Apache's convention
      * of not serving hidden files. No-arg call returns the current value.
@@ -2597,7 +2637,9 @@ class App
             // SCRIPT_FILENAME over the live/request-derived values.
             $server = $serverOverlay + $server;
         }
-        $request = $get + $post;
+        // #356 — POST-wins precedence (PHP request_order='GP'); see
+        // composeRequestArray() for the rationale.
+        $request = self::composeRequestArray($get, $post);
         (\zealphp_request_input_set(...))($get, $post, $cookie, $server, $files, $request);
     }
 
@@ -7079,7 +7121,19 @@ class App
         }
         if (self::$block_dotfiles) {
             $relative = substr($realFile, strlen($realRoot));
-            foreach (explode(DIRECTORY_SEPARATOR, $relative) as $segment) {
+            $segments = explode(DIRECTORY_SEPARATOR, ltrim($relative, DIRECTORY_SEPARATOR));
+            // #359 — `.well-known/` is a registered public convention (RFC 8615):
+            // ACME HTTP-01 challenge tokens + security.txt (RFC 9116) live there.
+            // The route guard exempts it via negative lookahead; mirror that here
+            // so the exemption isn't dead code. Only the literal `.well-known`
+            // SEGMENT is exempt (and only as the first path segment, matching the
+            // registered-convention scope) — every OTHER dot-segment, including
+            // an additional dotfile nested under it (`.well-known/.env`), and a
+            // decoy like `.well-knownx`, stays blocked.
+            foreach ($segments as $i => $segment) {
+                if ($i === 0 && $segment === '.well-known') {
+                    continue; // the registered well-known root segment
+                }
                 if ($segment !== '' && $segment[0] === '.') {
                     return false; // dotfile (.git, .env, .htaccess, etc.)
                 }
@@ -8380,9 +8434,20 @@ class App
             // when /json on the docs site returned OpenSwoole's default 404
             // instead of routing into the framework). Trailing slash forces
             // segment-boundary matching.
+            //
+            // #367 — FILE entries (no trailing slash) can't use that workaround:
+            // OpenSwoole has no exact-match mode, so a bare `/favicon.ico` /
+            // `/robots.txt` prefix-matches `/favicon.icoX` / `/robots.txtABC`
+            // and steals a user route like `/robots.txt-generator`. So the
+            // default list ships DIRECTORY entries only (all segment-bounded);
+            // `favicon.ico` + `robots.txt` are served as ordinary public/ files
+            // by the framework's implicit file routes. A user who wants the
+            // native static handler for them can still add them via
+            // App::staticHandlerLocations() (accepting the documented
+            // prefix-match caveat).
             'static_handler_locations' => self::$static_handler_locations !== []
                 ? self::$static_handler_locations
-                : ['/css/', '/js/', '/img/', '/images/', '/fonts/', '/assets/', '/static/', '/favicon.ico', '/robots.txt'],
+                : self::defaultStaticHandlerLocations(),
             'enable_coroutine' => $enableCoroutine,
             'hook_flags' => $hookFlags,
             // Worker count default — cgroup-quota-aware so a CPU-limited
@@ -8992,8 +9057,14 @@ class App
 
         # Block URLs targeting dotfile segments (.git/, .env, .htaccess, …).
         # `.well-known/` is allowed — it's a registered convention (RFC 8615).
+        # #368 — match a dot-segment in ANY position (final `.env` OR a
+        # dot-directory `.git/config`), so both return a uniform 403 instead of
+        # 403-vs-404 (the old `[^/]*$`-anchored pattern only caught final-segment
+        # dotfiles, leaking which kind of dotpath was requested). The lookahead
+        # exempts ONLY the exact `.well-known` segment (`(?:/|$)` boundary), so a
+        # decoy `.well-knownx` stays blocked.
         if (App::$block_dotfiles) {
-            $this->patternRoute('/(.*/)?\.(?!well-known)[^/]*', [
+            $this->patternRoute('#(^|/)\.(?!well-known(?:/|$))[^/]*(/|$)#', [
                 'methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD']
             ], function($response) {
                 $app = App::instance();
@@ -9301,7 +9372,9 @@ class App
             $files = self::normalizeUploadedFiles($request->files ?? []);
             $g->get = $get;
             $g->post = $post;
-            $g->request = $g->get + $g->post;
+            // #356 — POST-wins precedence (PHP request_order='GP'); see
+            // composeRequestArray() for the rationale.
+            $g->request = self::composeRequestArray($get, $post);
             $g->cookie = $cookie;
             $g->files = $files;
 

--- a/src/cgi_worker.php
+++ b/src/cgi_worker.php
@@ -71,6 +71,9 @@ $__z_cookies = [];
 $__z_rawcookies = [];
 $__z_status = 200;
 $__z_meta_sent = false;
+// #357 — single header_register_callback() slot (mod_php keeps one). Fired once
+// in __z_send_meta() just before the buffered headers are captured.
+$__z_header_callback = null;
 $__z_apache_env = [];
 $__z_apache_notes = [];
 $__z_uploaded = [];
@@ -95,8 +98,27 @@ $__z_has_return   = false;
  */
 function __z_send_meta() {
     global $__z_headers, $__z_cookies, $__z_rawcookies, $__z_status, $__z_meta_sent,
-           $__z_return_value, $__z_has_return;
+           $__z_return_value, $__z_has_return, $__z_header_callback;
     if ($__z_meta_sent) return;
+    // #357 — mod_php header_register_callback() parity: fire any callback the
+    // script registered BEFORE the buffered headers are captured, so the
+    // header()/header_remove() calls inside it still land in $__z_headers (the
+    // subprocess's header() override is active here, so the callback writes
+    // straight into $__z_headers). Mirrors the in-worker fire-point in
+    // App::run() (the mixed/coroutine-legacy path); without it the CGI
+    // subprocess dropped the callback's headers entirely. Fire BEFORE setting
+    // $__z_meta_sent so the callback's header() writes are guaranteed captured.
+    if (is_callable($__z_header_callback)) {
+        $__z_cb = $__z_header_callback;
+        $__z_header_callback = null; // mod_php fires the single callback once
+        try {
+            $__z_cb();
+        } catch (\Throwable $__z_cbErr) {
+            // Never let a misbehaving callback abort the meta flush — the host
+            // still needs the response. Surface to stderr for diagnosis.
+            fwrite(STDERR, 'header_register_callback threw: ' . $__z_cbErr->getMessage() . "\n");
+        }
+    }
     $__z_meta_sent = true;
     $payload = [
         'status_code' => $__z_status,
@@ -180,6 +202,19 @@ if (function_exists('zealphp_override') || function_exists('uopz_set_return')) {
     $z_override('headers_list', function() {
         global $__z_headers;
         return array_map(fn($h) => $h[0] . ': ' . $h[1], $__z_headers);
+    }, true);
+
+    // #357 — header_register_callback() parity: store the callback in a
+    // subprocess-local slot (NOT the framework's RequestContext memo — that
+    // class isn't loaded unless ZEALPHP_CGI_AUTOLOAD=1). __z_send_meta() fires
+    // it just before capturing the buffered headers, so header() calls inside
+    // it still land. Overriding here ALSO shadows the framework's utils.php
+    // version when the autoloader IS present, keeping a single code path.
+    // Returns true (mod_php parity); last registration wins (single callback).
+    $z_override('header_register_callback', function(callable $callback): bool {
+        global $__z_header_callback;
+        $__z_header_callback = $callback;
+        return true;
     }, true);
 
     $z_override('headers_sent', function(&$file = null, &$line = null) {

--- a/src/cgi_worker.php
+++ b/src/cgi_worker.php
@@ -71,8 +71,10 @@ $__z_cookies = [];
 $__z_rawcookies = [];
 $__z_status = 200;
 $__z_meta_sent = false;
-// #357 — single header_register_callback() slot (mod_php keeps one). Fired once
-// in __z_send_meta() just before the buffered headers are captured.
+// #357 — single header_register_callback() slot (mod_php keeps one). The
+// registered callback is fired by __z_fire_header_callback() right after the
+// included file finishes (while the header() override is still active), so
+// header()/header_remove() calls inside it land in $__z_headers.
 $__z_header_callback = null;
 $__z_apache_env = [];
 $__z_apache_notes = [];
@@ -91,6 +93,48 @@ $__z_return_value = null;
 $__z_has_return   = false;
 
 /**
+ * #357 — fire a registered header_register_callback() exactly once (mod_php
+ * keeps a single callback). Two registration sources, drained in order:
+ *   (1) the subprocess-local override above, which stashes into
+ *       $GLOBALS['__z_header_callback'] (the common case — autoload off);
+ *   (2) the framework's utils.php header_register_callback(), active when
+ *       ZEALPHP_CGI_AUTOLOAD=1, which stashes into the RequestContext memo.
+ *
+ * MUST be called while the header() override is still active (right after the
+ * included file finishes) — NOT from the shutdown function: uopz tears its
+ * overrides down before register_shutdown_function runs, so header() calls
+ * inside a callback fired at shutdown would not be captured into $__z_headers.
+ */
+function __z_fire_header_callback(): void
+{
+    global $__z_header_callback;
+    if (!is_callable($__z_header_callback)
+        && class_exists(\ZealPHP\RequestContext::class, false)
+    ) {
+        try {
+            $__z_g = \ZealPHP\RequestContext::instance();
+            $__z_memoCb = $__z_g->memo['_header_callback'] ?? null;
+            if (is_callable($__z_memoCb)) {
+                unset($__z_g->memo['_header_callback']);
+                $__z_header_callback = $__z_memoCb;
+            }
+        } catch (\Throwable) {
+            // RequestContext unavailable — fall through with no callback.
+        }
+    }
+    if (is_callable($__z_header_callback)) {
+        $__z_cb = $__z_header_callback;
+        $__z_header_callback = null; // single callback, fired once
+        try {
+            $__z_cb();
+        } catch (\Throwable $__z_cbErr) {
+            // A misbehaving callback must never abort the response.
+            fwrite(STDERR, 'header_register_callback threw: ' . $__z_cbErr->getMessage() . "\n");
+        }
+    }
+}
+
+/**
  * Write the metadata frame (status, headers, cookies, optional return value) to `STDERR`
  * as a single JSON line. Idempotent — subsequent calls are no-ops once `$__z_meta_sent`
  * is `true`. Called by the `flush()` override and the shutdown function so the frame is
@@ -100,25 +144,11 @@ function __z_send_meta() {
     global $__z_headers, $__z_cookies, $__z_rawcookies, $__z_status, $__z_meta_sent,
            $__z_return_value, $__z_has_return, $__z_header_callback;
     if ($__z_meta_sent) return;
-    // #357 — mod_php header_register_callback() parity: fire any callback the
-    // script registered BEFORE the buffered headers are captured, so the
-    // header()/header_remove() calls inside it still land in $__z_headers (the
-    // subprocess's header() override is active here, so the callback writes
-    // straight into $__z_headers). Mirrors the in-worker fire-point in
-    // App::run() (the mixed/coroutine-legacy path); without it the CGI
-    // subprocess dropped the callback's headers entirely. Fire BEFORE setting
-    // $__z_meta_sent so the callback's header() writes are guaranteed captured.
-    if (is_callable($__z_header_callback)) {
-        $__z_cb = $__z_header_callback;
-        $__z_header_callback = null; // mod_php fires the single callback once
-        try {
-            $__z_cb();
-        } catch (\Throwable $__z_cbErr) {
-            // Never let a misbehaving callback abort the meta flush — the host
-            // still needs the response. Surface to stderr for diagnosis.
-            fwrite(STDERR, 'header_register_callback threw: ' . $__z_cbErr->getMessage() . "\n");
-        }
-    }
+    // #357 — make sure any registered header_register_callback() has fired
+    // before we snapshot the headers (no-op if it already ran right after the
+    // include; the streaming/flush path reaches __z_send_meta() without that
+    // explicit call).
+    __z_fire_header_callback();
     $__z_meta_sent = true;
     $payload = [
         'status_code' => $__z_status,
@@ -205,15 +235,13 @@ if (function_exists('zealphp_override') || function_exists('uopz_set_return')) {
     }, true);
 
     // #357 — header_register_callback() parity: store the callback in a
-    // subprocess-local slot (NOT the framework's RequestContext memo — that
-    // class isn't loaded unless ZEALPHP_CGI_AUTOLOAD=1). __z_send_meta() fires
-    // it just before capturing the buffered headers, so header() calls inside
-    // it still land. Overriding here ALSO shadows the framework's utils.php
-    // version when the autoloader IS present, keeping a single code path.
-    // Returns true (mod_php parity); last registration wins (single callback).
+    // subprocess-local slot. __z_fire_header_callback() invokes it right after
+    // the included file finishes (NOT at shutdown — uopz tears its overrides
+    // down before register_shutdown_function runs, so a header() inside the
+    // callback fired at shutdown would not be captured). header() inside the
+    // callback is a normal call into the still-active override.
     $z_override('header_register_callback', function(callable $callback): bool {
-        global $__z_header_callback;
-        $__z_header_callback = $callback;
+        $GLOBALS['__z_header_callback'] = $callback;
         return true;
     }, true);
 
@@ -532,5 +560,11 @@ try {
     $__z_status = 500;
     echo '<pre>' . htmlspecialchars($__z_err->getMessage()) . "\n" . htmlspecialchars($__z_err->getTraceAsString()) . '</pre>';
 }
+
+// #357 — fire header_register_callback() here, while the header() override is
+// still active (the shutdown function runs AFTER uopz has torn its overrides
+// down, so a header() inside the callback fired there would be lost). Idempotent
+// with the __z_send_meta() call, which is a no-op once the callback has run.
+__z_fire_header_callback();
 
 // @codeCoverageIgnoreEnd

--- a/tests/Unit/CgiWorkerTest.php
+++ b/tests/Unit/CgiWorkerTest.php
@@ -460,6 +460,49 @@ PHP);
         $this->assertSame('raw', $meta['rawcookies'][0][0]);
     }
 
+    /**
+     * #357 — header_register_callback() parity in legacy-cgi. A callback the
+     * script registers must fire just before the buffered headers are captured,
+     * so header() calls inside it still reach the wire. Before the fix the CGI
+     * subprocess captured $__z_headers WITHOUT ever invoking the callback, so
+     * any header it set was silently dropped (works in mixed/coroutine-legacy,
+     * absent under legacy-cgi).
+     */
+    public function testSubprocessFiresHeaderRegisterCallbackBeforeHeaderCapture(): void
+    {
+        $f = $this->fixture('hrc.php', <<<'PHP'
+<?php
+header('X-Before: set-directly');
+header_register_callback(function () {
+    header('X-From-Callback: yes');
+    // A callback may also REPLACE an already-set header — proves the callback
+    // runs before capture, not after.
+    header('X-Before: rewritten-in-callback', true);
+});
+echo 'callback body';
+PHP);
+        $r = $this->runSubprocess($f);
+
+        $this->assertSame('callback body', $r['stdout']);
+        $meta = $this->parseMeta($r['stderr']);
+
+        $headerPairs = [];
+        foreach ($meta['headers'] as $pair) {
+            $headerPairs[$pair[0]] = $pair[1];
+        }
+        $this->assertArrayHasKey(
+            'X-From-Callback',
+            $headerPairs,
+            'header() inside header_register_callback() must reach the captured headers'
+        );
+        $this->assertSame('yes', $headerPairs['X-From-Callback']);
+        $this->assertSame(
+            'rewritten-in-callback',
+            $headerPairs['X-Before'],
+            'callback fires before header capture, so its replace wins'
+        );
+    }
+
     public function testSubprocessGeneratorIsConsumedInline(): void
     {
         $f = $this->fixture('gen.php', "<?php\nreturn (function(){ yield '<a>'; yield '<b>'; })();\n");

--- a/tests/Unit/DefaultStaticHandlerLocationsTest.php
+++ b/tests/Unit/DefaultStaticHandlerLocationsTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\App;
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #367 — the default `static_handler_locations` must contain DIRECTORY entries
+ * only (every one trailing-slash terminated for OpenSwoole segment-boundary
+ * matching). The bare FILE entries `/favicon.ico` + `/robots.txt` were removed:
+ * OpenSwoole prefix-matches them, so `/favicon.ico` stole `/favicon.icoX` and
+ * `/robots.txt` stole `/robots.txt-generator` from framework routing. Those two
+ * are now served as ordinary public/ files.
+ */
+final class DefaultStaticHandlerLocationsTest extends TestCase
+{
+    public function testDefaultsAreDirectoryEntriesOnly(): void
+    {
+        foreach (App::defaultStaticHandlerLocations() as $entry) {
+            $this->assertStringEndsWith(
+                '/',
+                $entry,
+                "default static_handler_locations entry '$entry' must be a trailing-slash directory (no bare file entries — OpenSwoole prefix-match overreaches)"
+            );
+        }
+    }
+
+    public function testFaviconAndRobotsAreNotBareEntries(): void
+    {
+        $defaults = App::defaultStaticHandlerLocations();
+        // The exact #367 regression: bare file entries that over-reach.
+        $this->assertNotContains('/favicon.ico', $defaults);
+        $this->assertNotContains('/robots.txt', $defaults);
+    }
+
+    public function testKeepsTheSegmentBoundedDirectoryAssets(): void
+    {
+        $defaults = App::defaultStaticHandlerLocations();
+        // The directory entries (the part that was always correct) stay.
+        foreach (['/css/', '/js/', '/img/', '/assets/', '/static/'] as $dir) {
+            $this->assertContains($dir, $defaults);
+        }
+    }
+
+    public function testNoEntryPrefixStealsALongerSibling(): void
+    {
+        // Segment-boundary proof: no default entry is a string prefix of a
+        // plausible longer user path (the bug class #367 belongs to).
+        $defaults = App::defaultStaticHandlerLocations();
+        $userPaths = ['/favicon.icoX', '/robots.txt-generator', '/json', '/cssXYZ', '/imgmap'];
+        foreach ($userPaths as $path) {
+            foreach ($defaults as $entry) {
+                $this->assertFalse(
+                    str_starts_with($path, $entry),
+                    "default entry '$entry' must not prefix-steal user path '$path'"
+                );
+            }
+        }
+    }
+}

--- a/tests/Unit/DotfileGuardTest.php
+++ b/tests/Unit/DotfileGuardTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\App;
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #368 — the dotfile route guard must match a dot-segment in ANY path position
+ * so every blocked dotpath returns a uniform 403, not 403 (final-segment
+ * dotfile) vs 404 (dot-directory content). The OLD pattern anchored the
+ * dot-segment to the FINAL segment (it ran to end-of-string and could not
+ * cross a slash), so `/.git/config` fell through to a 404 while `/.env`
+ * matched and returned 403 — leaking which kind of dotpath was requested.
+ *
+ * #359 — the guard keeps the `.well-known` carve-out (RFC 8615), exact-segment
+ * only (a decoy `.well-knownx` stays blocked).
+ *
+ * Tests the COMPILED pattern the framework registers (via the private
+ * registerImplicitRoutes()), not a hand-written copy — so a regression in the
+ * source pattern is caught.
+ */
+final class DotfileGuardTest extends TestCase
+{
+    private static App $app;
+
+    public static function setUpBeforeClass(): void
+    {
+        App::$cwd = ZEALPHP_ROOT;
+        App::superglobals(true);
+        App::$block_dotfiles = true;
+        if (App::instance() === null) {
+            App::init('127.0.0.1', 19994, ZEALPHP_ROOT);
+        }
+        $app = App::instance();
+        self::assertNotNull($app);
+        self::$app = $app;
+    }
+
+    /**
+     * Locate the dotfile guard's compiled regex among the registered routes.
+     * The guard is the route whose pattern carries the `.well-known` negative
+     * lookahead — unique to the dotfile block.
+     */
+    private function dotfileGuardPattern(): string
+    {
+        $app = self::$app;
+        $ref = new \ReflectionClass($app);
+        // Reset routes to a known baseline, then register implicit routes so the
+        // dotfile guard is present regardless of test-ordering side effects.
+        $routesProp = $ref->getProperty('routes');
+        $routesProp->setAccessible(true);
+        /** @var array<int, array<string, mixed>> $before */
+        $before = $routesProp->getValue($app);
+
+        $register = $ref->getMethod('registerImplicitRoutes');
+        $register->setAccessible(true);
+        $register->invoke($app);
+
+        /** @var array<int, array<string, mixed>> $after */
+        $after = $routesProp->getValue($app);
+
+        $pattern = null;
+        foreach ($after as $route) {
+            $p = $route['pattern'] ?? '';
+            if (is_string($p) && str_contains($p, 'well-known')) {
+                $pattern = $p;
+                break;
+            }
+        }
+
+        // Restore the pre-test route baseline so we don't leak duplicate
+        // implicit routes into sibling tests sharing the singleton.
+        $routesProp->setValue($app, $before);
+
+        self::assertNotNull($pattern, 'dotfile guard route (with .well-known lookahead) must be registered');
+        return $pattern;
+    }
+
+    public function testDotfileGuardBlocksFinalSegmentDotfile(): void
+    {
+        $pat = $this->dotfileGuardPattern();
+        $this->assertSame(1, preg_match($pat, '/.env'), '/.env must be blocked (403)');
+        $this->assertSame(1, preg_match($pat, '/.htaccess'), '/.htaccess must be blocked (403)');
+    }
+
+    public function testDotfileGuardBlocksDotDirectoryContent(): void
+    {
+        // The #368 fix: a dot-DIRECTORY (non-final dot-segment) must match too,
+        // so /.git/config returns the SAME 403 as /.env (was 404 before).
+        $pat = $this->dotfileGuardPattern();
+        $this->assertSame(1, preg_match($pat, '/.git/config'), '/.git/config must be blocked (403)');
+        $this->assertSame(1, preg_match($pat, '/.svn/entries'), '/.svn/entries must be blocked (403)');
+    }
+
+    public function testDotfileGuardBlocksDeepNestedDotSegment(): void
+    {
+        $pat = $this->dotfileGuardPattern();
+        $this->assertSame(1, preg_match($pat, '/assets/.git/HEAD'), 'a dot-segment anywhere is blocked');
+    }
+
+    public function testDotfileGuardExemptsWellKnown(): void
+    {
+        // #359 — RFC 8615 well-known URIs must NOT be blocked by the guard.
+        $pat = $this->dotfileGuardPattern();
+        $this->assertSame(0, preg_match($pat, '/.well-known/security.txt'), '.well-known is exempt');
+        $this->assertSame(0, preg_match($pat, '/.well-known/acme-challenge/tok'), 'ACME path is exempt');
+        $this->assertSame(0, preg_match($pat, '/.well-known'), 'bare .well-known is exempt');
+    }
+
+    public function testDotfileGuardStillBlocksWellKnownDecoy(): void
+    {
+        // Exact-segment carve-out: a dotfile merely PREFIXED with well-known
+        // (.well-knownx) is not the registered convention → stays blocked.
+        $pat = $this->dotfileGuardPattern();
+        $this->assertSame(1, preg_match($pat, '/.well-knownx'), '.well-knownx is a decoy → blocked');
+    }
+
+    public function testDotfileGuardLeavesNormalPathsAlone(): void
+    {
+        $pat = $this->dotfileGuardPattern();
+        $this->assertSame(0, preg_match($pat, '/normal/file.txt'));
+        $this->assertSame(0, preg_match($pat, '/foo.bar'), 'a dot in a filename (not a dot-segment) is fine');
+        $this->assertSame(0, preg_match($pat, '/wellknownfile'));
+    }
+}

--- a/tests/Unit/IncludeCheckSecurityTest.php
+++ b/tests/Unit/IncludeCheckSecurityTest.php
@@ -162,6 +162,49 @@ class IncludeCheckSecurityTest extends TestCase
         $this->assertFalse(self::$app->includeCheck($file));
     }
 
+    // ─────────────────────────────────────────────────────────────
+    // includeCheck() — .well-known carve-out (#359, RFC 8615)
+    // ─────────────────────────────────────────────────────────────
+
+    public function testIncludeCheckAllowsWellKnownFile(): void
+    {
+        // #359 — a real file under /.well-known/ (security.txt, ACME HTTP-01
+        // challenge token) MUST be servable. The route guard already exempts
+        // .well-known; includeCheck() must mirror it or the exemption is dead.
+        mkdir($this->docRoot . '/.well-known');
+        $file = $this->docRoot . '/.well-known/security.txt';
+        file_put_contents($file, 'Contact: mailto:ops@example.com');
+        $this->assertTrue(self::$app->includeCheck($file));
+    }
+
+    public function testIncludeCheckAllowsWellKnownNestedFile(): void
+    {
+        // ACME HTTP-01: /.well-known/acme-challenge/<token>
+        mkdir($this->docRoot . '/.well-known/acme-challenge', 0755, true);
+        $file = $this->docRoot . '/.well-known/acme-challenge/tok123';
+        file_put_contents($file, 'challenge-response');
+        $this->assertTrue(self::$app->includeCheck($file));
+    }
+
+    public function testIncludeCheckStillBlocksWellKnownDecoyDotfile(): void
+    {
+        // A dotfile whose name merely STARTS WITH .well-known (but isn't the
+        // exact segment) must stay blocked — the carve-out is exact-match only.
+        $file = $this->docRoot . '/.well-knownx';
+        file_put_contents($file, 'secret');
+        $this->assertFalse(self::$app->includeCheck($file));
+    }
+
+    public function testIncludeCheckStillBlocksDotfileInsideWellKnown(): void
+    {
+        // The .well-known carve-out exempts the .well-known segment itself, not
+        // an additional dotfile nested under it (e.g. /.well-known/.env).
+        mkdir($this->docRoot . '/.well-known');
+        $file = $this->docRoot . '/.well-known/.env';
+        file_put_contents($file, 'SECRET=1');
+        $this->assertFalse(self::$app->includeCheck($file));
+    }
+
     public function testIncludeCheckRejectsDirectory(): void
     {
         mkdir($this->docRoot . '/sub');

--- a/tests/Unit/RequestPrecedenceTest.php
+++ b/tests/Unit/RequestPrecedenceTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use ZealPHP\App;
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #356 — `$_REQUEST` GET/POST precedence. PHP's default `request_order='GP'`
+ * merges GET first then POST, with later sources overwriting earlier ones, so a
+ * key present in BOTH GET and POST takes the POST value (the form-submission-
+ * overrides-querystring convention). ZealPHP's `mixed`/`coroutine-legacy`
+ * superglobal populate built `$_REQUEST` as `$get + $post`, but PHP's `+`
+ * array-union keeps the LEFT operand on a collision → GET-wins, the inverse of
+ * the reference. The fix flips it to `$post + $get` (POST-wins), factored into
+ * App::composeRequestArray() — the single source of truth used by BOTH the
+ * OnRequest populate and the CGI-context request builder.
+ */
+final class RequestPrecedenceTest extends TestCase
+{
+    public function testPostWinsOnCollidingKey(): void
+    {
+        $req = App::composeRequestArray(
+            ['shared' => 'GET', 'only_get' => 'g'],
+            ['shared' => 'POST', 'only_post' => 'p']
+        );
+        // The headline contract: POST overrides GET (request_order='GP').
+        $this->assertSame('POST', $req['shared'], '$_REQUEST POST must override GET on a shared key');
+        // Non-colliding keys from BOTH sources survive.
+        $this->assertSame('g', $req['only_get']);
+        $this->assertSame('p', $req['only_post']);
+    }
+
+    public function testGetValueUsedWhenPostLacksKey(): void
+    {
+        $req = App::composeRequestArray(['q' => 'search'], []);
+        $this->assertSame('search', $req['q']);
+    }
+
+    public function testPostValueUsedWhenGetLacksKey(): void
+    {
+        $req = App::composeRequestArray([], ['token' => 'csrf123']);
+        $this->assertSame('csrf123', $req['token']);
+    }
+
+    public function testEmptyBothYieldsEmpty(): void
+    {
+        $this->assertSame([], App::composeRequestArray([], []));
+    }
+
+    public function testCookieIsNotMerged(): void
+    {
+        // request_order='GP' deliberately excludes COOKIE — composeRequestArray
+        // takes only GET + POST, so a cookie-named key never bleeds in. (Key
+        // ORDER is unspecified — `$post + $get` lists POST keys first — so assert
+        // on membership + values, not order.)
+        $req = App::composeRequestArray(['a' => 'g'], ['b' => 'p']);
+        $this->assertCount(2, $req);
+        $this->assertSame('g', $req['a']);
+        $this->assertSame('p', $req['b']);
+    }
+
+    public function testEveryCollidingKeyTakesPost(): void
+    {
+        // Multiple collisions — proves it's not just the first key.
+        $req = App::composeRequestArray(
+            ['x' => 'GX', 'y' => 'GY', 'z' => 'GZ'],
+            ['x' => 'PX', 'y' => 'PY']
+        );
+        $this->assertSame('PX', $req['x']);
+        $this->assertSame('PY', $req['y']);
+        $this->assertSame('GZ', $req['z'], 'a GET-only key survives');
+    }
+}


### PR DESCRIPTION
Fixes a cluster of 5 routing / static-file parity bugs filed by Guruprasanth-M, all on one branch.

## #356 — `$_REQUEST` GET/POST precedence inverted
PHP `request_order='GP'` merges GET then POST (later wins), so POST must override GET on a shared key. The populate built `$_REQUEST` as `$get + $post` (`+` keeps the LEFT operand → GET-wins). Factored into `App::composeRequestArray()` (`$post + $get`, POST-wins) — the single source of truth used by both the OnRequest populate and the CGI-context request builder.

## #357 — `header_register_callback()` never fires in legacy-cgi
The CGI subprocess captured headers without ever invoking the registered callback (worked in mixed/coroutine-legacy). Added a subprocess-local `header_register_callback` override + fire it in `__z_send_meta()` just before the buffered headers are captured. Works with and without `ZEALPHP_CGI_AUTOLOAD` (no dependency on `RequestContext` being loaded).

## #359 — `.well-known/` files unservable (404)
`includeCheck()` re-blocked the `.well-known` segment the route guard explicitly exempts (RFC 8615), so ACME HTTP-01 + security.txt 404'd. Added the matching carve-out — exact first-segment `.well-known` only; nested dotfiles (`.well-known/.env`) and decoys (`.well-knownx`) stay blocked.

## #367 — default `static_handler_locations` file entries over-reach
OpenSwoole prefix-matches `static_handler_locations`, so the bare `/favicon.ico` / `/robots.txt` entries stole `/favicon.icoX` / `/robots.txt-generator` from framework routing. Dropped them from the default (now `App::defaultStaticHandlerLocations()`, directory entries only); favicon.ico + robots.txt are served as ordinary `public/` files.

## #368 — dotfile block status inconsistent (403 vs 404)
The guard's `[^/]*$`-anchored pattern only caught final-segment dotfiles, so `/.env` → 403 but `/.git/config` → 404 (leaking which kind of dotpath was requested). New pattern `#(^|/)\.(?!well-known(?:/|$))[^/]*(/|$)#` matches a dot-segment in any position → uniform 403, keeping the exact `.well-known` exemption.

## Tests
New: `RequestPrecedenceTest`, `DefaultStaticHandlerLocationsTest`, `DotfileGuardTest`. Extended: `IncludeCheckSecurityTest` (well-known carve-out), `CgiWorkerTest` (callback fires before capture). 54 new/extended assertions green; full unit suite (3917) green; PHPStan L10 clean (the 2 pre-existing Session-manager baseline errors are unrelated). No uopz in tests.

Closes #356, #357, #359, #367, #368