### PR TITLE
docs: refresh README — bring stale content current (v0.4.8 / ext v0.3.49 / four modes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ short_open_tag=on
 pie install zealphp/ext
 
 # Or from source (pin the version setup.sh defaults to):
-git clone --depth 1 --branch v0.3.49 https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
+git clone --depth 1 --branch v0.3.50 https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
 cd /tmp/ext-zealphp && phpize && ./configure && make && sudo make install
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # ZealPHP — A PHP HTTP Server (built on OpenSwoole)
 
-ZealPHP runs PHP as the HTTP server itself — not a CGI worker behind one. Built on **OpenSwoole**, it ships HTTP, WebSocket, SSE, coroutines, shared memory, timers, and task workers as first-class primitives because the server stays alive between requests. Existing PHP code runs unchanged via ext-zealphp function overrides; new features go async without a separate Node or Go service. Alpha — see stability note below.
+ZealPHP runs PHP as the HTTP server itself — not a CGI worker behind one. Built on **OpenSwoole**, it ships HTTP, WebSocket, SSE, coroutines, shared memory, timers, and task workers as first-class primitives because the server stays alive between requests. New features go async without a separate Node or Go service.
+
+The headline mode is **`coroutine-legacy`**: a compatibility runtime where traditional request-style PHP — `$_GET` / `$_POST` / `$_SESSION`, `session_start()`, `header()`, `setcookie()`, `exit`/`die`, `require_once` — runs unchanged **under coroutine concurrency**, with every request-state primitive (the seven superglobals, `$GLOBALS`, function/class statics, constants, `require_once` re-execution, locale/timezone/cwd/umask) isolated per coroutine by [ext-zealphp](https://github.com/sibidharan/ext-zealphp). "Old PHP just works, concurrently" — with one honest conditional: the app's class graph must be **warmed before concurrency hits it** (`App::preloadClassmap()` for Composer apps; pure-`require_once` apps with no autoloader belong in `legacy-cgi`). Alpha — see stability note below.
 
 [![Packagist Version](https://img.shields.io/packagist/v/zealphp/zealphp?style=flat-square&color=orange&logo=packagist&logoColor=white)](https://packagist.org/packages/zealphp/zealphp) [![Packagist Downloads](https://img.shields.io/packagist/dt/zealphp/zealphp?style=flat-square&logo=packagist&logoColor=white)](https://packagist.org/packages/zealphp/zealphp) [![License](https://img.shields.io/packagist/l/zealphp/zealphp?style=flat-square)](https://packagist.org/packages/zealphp/zealphp)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sibidharan/zealphp) [![GitHub stars](https://img.shields.io/github/stars/zealphp/zealphp?style=flat-square&logo=github&logoColor=white)](https://github.com/sibidharan/zealphp/stargazers) [![PHP 8.3+](https://img.shields.io/badge/PHP-8.3%2B-777bb4?style=flat-square&logo=php&logoColor=white)](https://www.php.net/) [![PHP tested](https://img.shields.io/badge/tested-PHP%208.3%20%7C%208.4%20%7C%208.5--experimental-777bb4?style=flat-square&logo=php&logoColor=white)](https://github.com/sibidharan/zealphp/actions/workflows/tests.yml) [![Stability](https://img.shields.io/badge/stability-active%20alpha-orange?style=flat-square)](CHANGELOG.md)
 [![CI](https://github.com/sibidharan/zealphp/actions/workflows/tests.yml/badge.svg)](https://github.com/sibidharan/zealphp/actions/workflows/tests.yml) [![CodeQL](https://github.com/sibidharan/zealphp/actions/workflows/codeql.yml/badge.svg)](https://github.com/sibidharan/zealphp/actions/workflows/codeql.yml) [![gitleaks](https://github.com/sibidharan/zealphp/actions/workflows/gitleaks.yml/badge.svg)](https://github.com/sibidharan/zealphp/actions/workflows/gitleaks.yml) [![Coverage](https://codecov.io/gh/sibidharan/zealphp/branch/master/graph/badge.svg)](https://codecov.io/gh/sibidharan/zealphp) [![PHPStan](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsibidharan%2Fzealphp%2Fmaster%2F.github%2Fbadges%2Fphpstan.json)](phpstan.neon) [![Mutation MSI](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsibidharan%2Fzealphp%2Fmaster%2F.github%2Fbadges%2Fmutation.json)](https://github.com/sibidharan/zealphp/actions/workflows/mutation.yml) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sibidharan/zealphp/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sibidharan/zealphp) [![SBOM](https://img.shields.io/badge/SBOM-CycloneDX-blue?style=flat-square)](https://github.com/sibidharan/zealphp/actions/workflows/sbom.yml)
-[![OpenSwoole](https://img.shields.io/badge/OpenSwoole-22%2B-ff5722?style=flat-square)](https://openswoole.com/) [![Benchmarks](https://img.shields.io/badge/benchmarks-reproducible-success?style=flat-square)](https://github.com/sibidharan/zealphp/tree/master/scripts) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa?style=flat-square)](CODE_OF_CONDUCT.md) [![Sponsor](https://img.shields.io/github/sponsors/sibidharan?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/sibidharan)
+[![OpenSwoole](https://img.shields.io/badge/OpenSwoole-22%20%7C%2026-ff5722?style=flat-square)](https://openswoole.com/) [![Benchmarks](https://img.shields.io/badge/benchmarks-reproducible-success?style=flat-square)](https://github.com/sibidharan/zealphp/tree/master/scripts) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa?style=flat-square)](CODE_OF_CONDUCT.md) [![Sponsor](https://img.shields.io/github/sponsors/sibidharan?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/sibidharan)
 
 **Homepage:** [https://php.zeal.ninja](https://php.zeal.ninja)  
 Running `php app.php` serves the same docs site locally. Set `ZEALPHP_SITE_URL` if you want the rendered example URLs to point somewhere else.
 **Changelog:** [CHANGELOG.md](CHANGELOG.md) · **Design trade-offs:** [/design-tradeoffs](https://php.zeal.ninja/design-tradeoffs) · **Critique retrospective:** [CRITIC.md](CRITIC.md)
+**Compatibility:** [50-app database across all 4 modes](docs/compatibility-database.md) · **Isolation internals:** [stage taxonomy (S1–S12)](docs/architecture/isolation-stages.md)
 
 ### PHP-FPM vs ZealPHP
 
@@ -35,7 +38,7 @@ Running `php app.php` serves the same docs site locally. Set `ZEALPHP_SITE_URL` 
 | **SSR streaming** | Generator `yield`, `$response->stream()`, `$response->sse()` — like React's `renderToPipeableStream` |
 | **WebSocket** | `App::ws($path, $onMessage, $onOpen, $onClose)` — rooms, auth, binary, heartbeat |
 | **Pluggable Store/Counter** | `Store::defaultBackend(Store::BACKEND_REDIS)` (or `ZEALPHP_STORE_BACKEND=redis`) flips storage from local `OpenSwoole\Table`/`Atomic` to Redis/Valkey with zero handler changes — cross-node shared state + persistence with one line. Tracked + TTL modes, per-worker coroutine pool, Lua-backed `Counter::compareAndSet`. |
-| **Cross-node messaging** | `Store::publish($ch, $payload)` + `App::subscribe($ch, $handler)` for fire-and-forget pub/sub (cross-worker AND cross-host). `Store::publishReliable($stream, $payload)` + `App::subscribeReliable($stream, $handler)` for Streams-backed at-least-once delivery via consumer groups. The cross-server WebSocket routing pattern (owner-of-fd pushes; Redis routes to owner) lights up end-to-end. **Driver choice (both validated in v0.2.40):** Both phpredis (preferred when `ext-redis` is loaded) and predis SUBSCRIBE loops yield correctly under `OpenSwoole\Runtime::HOOK_ALL` — the production default in coroutine mode. phpredis is ~2× faster on hot CRUD; pick it when you can. One nuance: phpredis SUBSCRIBE blocks the worker WITHOUT HOOK_ALL — if you disabled HOOK_ALL explicitly, force `ZEALPHP_REDIS_PREFER=predis` for subscribers or re-enable HOOK_ALL. See [`/store#pubsub`](https://php.zeal.ninja/store#pubsub). |
+| **Cross-node messaging** | `Store::publish($ch, $payload)` + `App::subscribe($ch, $handler)` for fire-and-forget pub/sub (cross-worker AND cross-host). `Store::publishReliable($stream, $payload)` + `App::subscribeReliable($stream, $handler)` for Streams-backed at-least-once delivery via consumer groups. The cross-server WebSocket routing pattern (owner-of-fd pushes; Redis routes to owner) lights up end-to-end. **Driver choice:** Both phpredis (preferred when `ext-redis` is loaded) and predis SUBSCRIBE loops yield correctly under `OpenSwoole\Runtime::HOOK_ALL` — the production default in coroutine mode. phpredis is ~2× faster on hot CRUD; pick it when you can. One nuance: phpredis SUBSCRIBE blocks the worker WITHOUT HOOK_ALL — if you disabled HOOK_ALL explicitly, force `ZEALPHP_REDIS_PREFER=predis` for subscribers or re-enable HOOK_ALL. See [`/store#pubsub`](https://php.zeal.ninja/store#pubsub). |
 | **Dynamic routing** | `route()`, `nsRoute()`, `nsPathRoute()`, `patternRoute()` with reflection-based parameter injection |
 | **Middleware** | PSR-15 stack — 30+ built-ins (CORS, ETag, Range, Compression, SessionStart, IniIsolation, Charset, CacheControl, Expires, Header, BasicAuth, IpAccess, RateLimit, ConcurrencyLimit, BlockPhpExt, MimeType, BodyRewrite, HostRouter, BodySizeLimit, Csrf, Redirect, Scoped, MergeSlashes, Referer, RequestHeader, Return, SetEnvIf, ContentEncoding, ContentLanguage, HealthCheck) — full Apache `mod_rewrite` / `mod_headers` / `mod_expires` and nginx `limit_req` / `auth_basic` parity — see the [middleware reference](https://php.zeal.ninja/middleware) for the full list |
 | **HTTP/1.1 compliance** | HEAD, OPTIONS, 301/302/307/308 redirects, Cookie SameSite, ETag, OpenSwoole compression |
@@ -50,9 +53,9 @@ Running `php app.php` serves the same docs site locally. Set `ZEALPHP_SITE_URL` 
 > **Performance:** 117k req/s text · 106k JSON · 50k templated with 4 HTTP workers under the full PSR-15 middleware stack, 0 failures across 150k requests. ZealPHP retains ~82% of OpenSwoole's raw throughput with the framework on top; numbers vary by workload, payload, and hardware.
 >
 > Reproduce in 60s: `./scripts/bench_vs_express.sh`. Full methodology, latency percentiles, concurrency sweep, and caveats: [PERF.md](PERF.md).
-> **Stability:** Alpha (v0.2.x). API may change between minor versions until v1.0. Pin to a specific version in production.
+> **Stability:** Active alpha (v0.4.x). API may change between minor versions until v1.0. Pin to a specific version in production.
 
-> **Common Apache + nginx behavior coverage (v0.2.21).** ZealPHP ships built-in middlewares and server-level setters for the common `.htaccess` / `nginx.conf` patterns used by traditional PHP apps — rewrite-style routing, headers, expiry/cache rules, basic auth, IP access, rate limits, MIME types, request limits. This is coverage for migration use cases, not a byte-for-byte server replacement. 12 new middlewares (`HeaderMiddleware`, `BasicAuthMiddleware`, `RateLimitMiddleware`, `CharsetMiddleware`, `CacheControlMiddleware`, `ExpiresMiddleware`, `IpAccessMiddleware`, `ConcurrencyLimitMiddleware`, `BlockPhpExtMiddleware`, `MimeTypeMiddleware`, `BodyRewriteMiddleware`, `HostRouterMiddleware`) and 8 new configurables (`$server_admin`, `$canonical_name`, `$trusted_proxies` + `App::clientIp()`, `$access_log_format`, `LimitRequestFields` family, `$strip_trailing_slash`, `App::tryInclude()`) landed in v0.2.21. See the [middleware reference](https://php.zeal.ninja/middleware) and the [legacy-apps coverage matrix](https://php.zeal.ninja/legacy-apps) for the full story.
+> **Common Apache + nginx behavior coverage.** ZealPHP ships built-in middlewares and server-level setters for the common `.htaccess` / `nginx.conf` patterns used by traditional PHP apps — rewrite-style routing, headers, expiry/cache rules, basic auth, IP access, rate limits, MIME types, request limits. This is coverage for migration use cases, not a byte-for-byte server replacement. The 30+ built-in middlewares (`HeaderMiddleware`, `BasicAuthMiddleware`, `RateLimitMiddleware`, `CharsetMiddleware`, `CacheControlMiddleware`, `ExpiresMiddleware`, `IpAccessMiddleware`, `ConcurrencyLimitMiddleware`, `BlockPhpExtMiddleware`, `MimeTypeMiddleware`, `BodyRewriteMiddleware`, `HostRouterMiddleware`, …) plus server-level configurables (`$server_admin`, `$canonical_name`, `$trusted_proxies` + `App::clientIp()`, `$access_log_format`, `LimitRequestFields` family, `$strip_trailing_slash`, `App::tryInclude()`, …) map onto the familiar Apache/nginx directives. See the [middleware reference](https://php.zeal.ninja/middleware) and the [legacy-apps coverage matrix](https://php.zeal.ninja/legacy-apps) for the full story.
 
 ---
 
@@ -62,7 +65,7 @@ Running `php app.php` serves the same docs site locally. Set `ZEALPHP_SITE_URL` 
 
 PHP powers ~71% of the web ([W3Techs](https://w3techs.com/technologies/details/pl-php)), but the default request-per-process model (PHP-FPM, mod_php) keeps the interpreter warm yet discards request-local state, and gives PHP no native way to hold a persistent connection — so WebSocket/SSE features land in separate Node/Go sidecar processes. ZealPHP runs on **OpenSwoole** — a long-lived PHP server with native coroutines — and adds a framework layer that:
 
-1. **Accepts many traditional PHP patterns unchanged (compatibility mode).** Drop `.php` files in `public/`. `session_start()`, `header()`, `$_GET`, `$_POST`, `setcookie()`, `echo` all route through ext-zealphp overrides into per-request state. Many WordPress sites run through the CGI worker bridge — see [zealphp-wordpress](https://github.com/sibidharan/zealphp-wordpress) for the showcase and documented limits. Compatibility is a migration on-ramp, not a guarantee that every PHP application is safe to drop in without an audit.
+1. **Accepts many traditional PHP patterns unchanged (compatibility runtime).** Drop `.php` files in `public/`. `session_start()`, `header()`, `$_GET`, `$_POST`, `setcookie()`, `echo`, `exit`/`die` all route through ext-zealphp overrides into per-coroutine request state. `coroutine-legacy` runs request-style PHP under coroutine concurrency; `legacy-cgi` (subprocess, Apache mod_php parity) is the floor for pure-`require_once` apps with no autoloader. The [50-app compatibility database](docs/compatibility-database.md) grades each path honestly — see also [zealphp-wordpress](https://github.com/sibidharan/zealphp-wordpress) for the WordPress showcase and documented limits. Compatibility is a migration on-ramp, not a guarantee that every PHP application is safe to drop in without an audit.
 2. **Adds async primitives when you want them.** `go()`, `Channel`, WebSocket, SSE, shared memory (`Store` / `Counter`), timers, task workers — all framework-native, no extra services.
 3. **Lets you migrate file by file.** Start with fallback routing on day one; opt into coroutine mode when you're ready. No big-bang rewrite.
 
@@ -204,7 +207,8 @@ ZealPHP can run your existing PHP codebase on a high-performance async runtime �
 require_once __DIR__ . '/vendor/autoload.php';
 use ZealPHP\App;
 
-App::superglobals(true);  // legacy mode — $_GET, $_POST, $_SESSION work
+App::mode(App::MODE_COROUTINE_LEGACY);  // request-style PHP, concurrently
+// (or App::MODE_LEGACY_CGI for pure require_once apps — subprocess, mod_php parity)
 $app = App::init('0.0.0.0', 8080);
 
 // Your existing PHP app becomes the fallback handler.
@@ -216,7 +220,7 @@ $app->setFallback(fn() => App::include('/index.php'));
 $app->run();
 ```
 
-Now your WordPress, Drupal, or custom PHP app runs on OpenSwoole — persistent connections, no cold starts, WebSocket and streaming available when you're ready. ZealPHP's **file-execution family** — `App::render()` / `App::renderToString()` / `App::renderStream()` / `App::include()` — share a single core that runs the file, captures its output, and applies the [universal return contract](https://php.zeal.ninja/responses#return-contract). Need htmx-style swap targets without separate partial files? `App::fragment()` (v0.2.24) marks named regions inline so the same `App::render()` call serves either the full page or just one region — see [Template fragments](https://php.zeal.ninja/templates#fragments). `App::includeFile()` is the deprecated alias for `App::include()` and still works. See the [legacy apps page](https://php.zeal.ninja/legacy-apps) for the 12 Apache rewrite recipes and the full `.htaccess` / `nginx.conf` coverage matrices.
+Now your WordPress, Drupal, or custom PHP app runs on OpenSwoole — persistent connections, no cold starts, WebSocket and streaming available when you're ready. ZealPHP's **file-execution family** — `App::render()` / `App::renderToString()` / `App::renderStream()` / `App::include()` — share a single core that runs the file, captures its output, and applies the [universal return contract](https://php.zeal.ninja/responses#return-contract). Need htmx-style swap targets without separate partial files? `App::fragment()` (v0.2.24) marks named regions inline so the same `App::render()` call serves either the full page or just one region — see [Template fragments](https://php.zeal.ninja/templates#fragments). `App::includeFile()` is the deprecated alias for `App::include()` and still works. See the [legacy apps page](https://php.zeal.ninja/legacy-apps) for the Apache rewrite recipes and the full `.htaccess` / `nginx.conf` coverage matrices.
 
 ---
 
@@ -281,12 +285,14 @@ directory.
 
 ## Installation
 
+> **Requirements:** PHP 8.3, 8.4, or 8.5. OpenSwoole 22.1+ covers PHP 8.3 / 8.4; OpenSwoole 26.2+ adds PHP 8.5. ext-zealphp is ZealPHP's own C extension (`uopz` is a legacy fallback for the function overrides). The fastest path is the one-line installer or `setup.sh` below — the manual steps are for fine-grained control.
+
 ### 1. Install OpenSwoole
 
 ```bash
 sudo apt install gcc php-dev openssl libssl-dev curl libcurl4-openssl-dev libpcre3-dev build-essential
 
-sudo pecl install openswoole-22.1.2
+sudo pecl install openswoole
 # Answer yes to: coroutine sockets, openssl, http2, mysqlnd, curl, postgres
 ```
 
@@ -303,8 +309,8 @@ short_open_tag=on
 # Via PIE (recommended):
 pie install zealphp/ext
 
-# Or from source:
-git clone --depth 1 https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
+# Or from source (pin the version setup.sh defaults to):
+git clone --depth 1 --branch v0.3.49 https://github.com/sibidharan/ext-zealphp.git /tmp/ext-zealphp
 cd /tmp/ext-zealphp && phpize && ./configure && make && sudo make install
 ```
 
@@ -457,14 +463,24 @@ The fine-grained setters (`App::superglobals()`, `App::isolation()`, `App::enabl
 
 ## Publishing Releases
 
+`master` is branch-protected — releases land via a PR, then the tag is cut on the merged commit.
+
 1. Update `CHANGELOG.md` with the new version and changes.
-2. Run `composer validate` and confirm tests pass.
-3. Tag both `zealphp` and `zealphp-project` with the same version:
+2. Run `composer validate`, `./vendor/bin/phpunit`, and `./vendor/bin/phpstan analyse --no-progress` (level 10, zero errors).
+3. Open a release PR, wait for required checks to go green, and merge (rebase):
    ```bash
-   git tag -a v0.4.8 -m "Release v0.4.8"
-   git push origin master && git push origin v0.4.8
+   git checkout -b release/v0.4.8
+   git commit -am "chore: release v0.4.8"
+   git push origin1 release/v0.4.8
+   gh pr create --base master --head release/v0.4.8 --title "chore: release v0.4.8"
    ```
-4. Trigger Packagist webhook for both packages.
+4. After merge, tag the merged commit and push to both remotes (tags aren't protected):
+   ```bash
+   git checkout master && git pull origin1 master --ff-only
+   git tag -a v0.4.8 -m "Release v0.4.8"
+   git push origin v0.4.8 && git push origin1 v0.4.8
+   ```
+5. Bump `zealphp/project` (the scaffold) to the same version and refresh its `llms.txt`. Packagist auto-syncs via webhook for both packages.
 
 ---
 


### PR DESCRIPTION
The README had drifted from the current framework state. This refresh removes outdated info and aligns it with the website pitch, CHANGELOG, the compatibility database, and the canonical isolation-stage taxonomy. README.md only — no code changes.

## Removed / corrected (stale)
- **Mode story** — reframed around the **four `App::mode()` presets** (`legacy-cgi` / `mixed` / `coroutine-legacy` / `coroutine`). `coroutine-legacy` is now the **headline** ("old PHP just works, concurrently") with the **honest conditional**: the class graph must be warmed (`preloadClassmap()`) before concurrency; pure-`require_once`-no-autoloader apps belong in `legacy-cgi`. The old "Many WordPress sites run through the CGI worker bridge" framing was the only legacy story.
- **Versions** — stability note `v0.2.x` → `v0.4.x`; OpenSwoole badge `22+` → `22 | 26`; PECL pin `openswoole-22.1.2` → `openswoole`; ext-zealphp source clone now pins **v0.3.49** (matches `setup.sh`).
- **Migrate example** — `App::superglobals(true)` → `App::mode(App::MODE_COROUTINE_LEGACY)` (with the `legacy-cgi` alternative noted).
- **Apache/nginx coverage note** — de-stamped from "(v0.2.21) … 12 new middlewares" to the current **30+ built-in middlewares** + configurables.
- **Publishing Releases** — replaced the direct `git push origin master` flow (master is branch-protected) with the accurate **PR-based** flow + scaffold/`llms.txt` sync step.
- **Feature table** — dropped the "(both validated in v0.2.40)" parenthetical from the Redis driver note.

## Added
- **Requirements callout** in Installation (PHP 8.3/8.4/8.5; OpenSwoole 22.1 vs 26.2 for 8.5; ext-zealphp is the framework's own C extension, uopz the legacy fallback).
- Doc links: **[50-app compatibility database](docs/compatibility-database.md)** and **[isolation stage taxonomy (S1–S12)](docs/architecture/isolation-stages.md)**.

## Kept accurate (unchanged)
- All badge markup/URLs, license/attribution, benchmark numbers (match `home.php`/`PERF.md`), the four-modes preset table, `composer create-project zealphp/project:^0.4.8`, historical "introduced-in vX.Y.Z" provenance stamps.

All local doc links referenced in the README were verified to exist. No invented benchmarks or claims — facts pulled from CHANGELOG, the compatibility database, and the website pages.