### PR TITLE
fix: 204/304 drop engine-default CT/CL; $_SERVER string ports + SERVER_ADDR (#290/#306 residuals)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -2457,6 +2457,19 @@ class App
             $srv['REQUEST_URI'] = $srv['REQUEST_URI'] . '?' . $query;
         }
 
+        // SERVER_PORT / REMOTE_PORT — CGI/1.1 meta-variables are strings
+        // (RFC 3875 §4.1): mod_php publishes e.g. '443', but OpenSwoole's
+        // $request->server carries both as PHP ints, so the common strict
+        // `$_SERVER['SERVER_PORT'] === '443'` comparison silently fails
+        // (#306). Cast both to the mod_php string form. REQUEST_TIME(_FLOAT)
+        // stay int/float — mod_php itself publishes those numerically.
+        if (isset($srv['SERVER_PORT'])) {
+            $srv['SERVER_PORT'] = (string)$srv['SERVER_PORT'];
+        }
+        if (isset($srv['REMOTE_PORT'])) {
+            $srv['REMOTE_PORT'] = (string)$srv['REMOTE_PORT'];
+        }
+
         // CONTENT_TYPE / CONTENT_LENGTH — bare CGI vars mod_php sets from the
         // body headers (in addition to the HTTP_* copies buildServerVars made).
         if (isset($srv['HTTP_CONTENT_TYPE']) && !isset($srv['CONTENT_TYPE'])) {
@@ -2526,6 +2539,27 @@ class App
                 }
                 $srv[strtoupper($sk)] = is_scalar($sv) || $sv === null ? $sv : null;
             }
+        }
+        // SERVER_ADDR — mod_php always publishes the accepting interface IP;
+        // OpenSwoole's $request->server has no equivalent key, so synthesize
+        // it from the bound listen address (#306). A wildcard bind
+        // (0.0.0.0 / ::) resolves to the host's primary address once per
+        // worker (OpenSwoole doesn't expose the connection's local address);
+        // a hostname bind resolves the same way. Best-effort fallback is the
+        // loopback so the key is never absent (Undefined-array-key in vhost/
+        // multi-homed app code).
+        if (!isset($srv['SERVER_ADDR'])) {
+            /** @var string|null $serverAddr */
+            static $serverAddr = null;
+            if ($serverAddr === null) {
+                $bind = self::$instance !== null ? self::$instance->host : '';
+                if ($bind === '' || $bind === '0.0.0.0' || $bind === '::') {
+                    $bind = (string)gethostname();
+                }
+                $resolved = filter_var($bind, FILTER_VALIDATE_IP) ? $bind : @gethostbyname($bind);
+                $serverAddr = filter_var($resolved, FILTER_VALIDATE_IP) ? $resolved : '127.0.0.1';
+            }
+            $srv['SERVER_ADDR'] = $serverAddr;
         }
         if ($request->header) {
             foreach ($request->header as $key => $value) {
@@ -9589,7 +9623,61 @@ class App
                         }
                     }
                     if ($forbidsBody) {
-                        $response->parent->end();
+                        // The strip above only filters the PSR-side headers —
+                        // the native end() then re-injects its engine defaults
+                        // (`Content-Type: text/html` + `Content-Length: 0`) at
+                        // the C level, where no header() call can reach them:
+                        // a null value restores the default and ''/false emits
+                        // a malformed bare `Content-Type:`. So for 1xx/204/304
+                        // serialize the head ourselves and send it raw on the
+                        // detached connection — the wire-frame carries neither
+                        // (#290, RFC 9110 §6.4.1 / RFC 7230 §3.3.2). Keep-alive
+                        // follows the request's Connection/protocol semantics.
+                        $reason = $g->raw_status_reason ?? self::reasonPhrase($emitStatus);
+                        $head = 'HTTP/1.1 ' . $emitStatus . ' '
+                            . ($reason !== '' ? $reason : 'Status ' . $emitStatus) . "\r\n";
+                        $haveDate = false;
+                        $nativeHeaders = is_array($response->parent->header) ? $response->parent->header : [];
+                        foreach ($nativeHeaders as $hName => $hValues) {
+                            $hName = (string)$hName;
+                            if (strcasecmp($hName, 'Connection') === 0
+                                || strcasecmp($hName, 'Content-Length') === 0
+                                || strcasecmp($hName, 'Content-Type') === 0) {
+                                continue;
+                            }
+                            $haveDate = $haveDate || strcasecmp($hName, 'Date') === 0;
+                            foreach (is_array($hValues) ? $hValues : [$hValues] as $hv) {
+                                if (is_scalar($hv)) {
+                                    $head .= $hName . ': ' . (string)$hv . "\r\n";
+                                }
+                            }
+                        }
+                        $nativeCookies = is_array($response->parent->cookie) ? $response->parent->cookie : [];
+                        foreach ($nativeCookies as $setCookie) {
+                            if (is_string($setCookie)) {
+                                $head .= 'Set-Cookie: ' . $setCookie . "\r\n";
+                            }
+                        }
+                        if (!$haveDate) {
+                            $head .= 'Date: ' . gmdate('D, d M Y H:i:s') . " GMT\r\n";
+                        }
+                        $reqHeader = is_array($request->parent->header) ? $request->parent->header : [];
+                        $reqServer = is_array($request->parent->server) ? $request->parent->server : [];
+                        $connTok = $reqHeader['connection'] ?? '';
+                        $connTok = is_string($connTok) ? strtolower($connTok) : '';
+                        $proto = $reqServer['server_protocol'] ?? 'HTTP/1.1';
+                        $proto = is_string($proto) ? $proto : 'HTTP/1.1';
+                        $keepAlive = $connTok === 'keep-alive'
+                            || ($connTok !== 'close' && $proto === 'HTTP/1.1');
+                        $head .= 'Connection: ' . ($keepAlive ? 'keep-alive' : 'close') . "\r\n\r\n";
+                        $fd = $response->parent->fd;
+                        $response->parent->detach();
+                        if (is_int($fd) && self::$server !== null) {
+                            self::$server->send($fd, $head);
+                            if (!$keepAlive) {
+                                self::$server->close($fd);
+                            }
+                        }
                     } else {
                         $body = $serverResponse->getBody();
                         $body->rewind();

--- a/src/App.php
+++ b/src/App.php
@@ -2556,7 +2556,20 @@ class App
                 if ($bind === '' || $bind === '0.0.0.0' || $bind === '::') {
                     $bind = (string)gethostname();
                 }
-                $resolved = filter_var($bind, FILTER_VALIDATE_IP) ? $bind : @gethostbyname($bind);
+                if (filter_var($bind, FILTER_VALIDATE_IP)) {
+                    $resolved = $bind;
+                } else {
+                    // A first via the system resolver (/etc/hosts-aware;
+                    // returns the input unchanged on failure), then AAAA so
+                    // an IPv6-only host still resolves.
+                    $resolved = gethostbyname($bind);
+                    if (!filter_var($resolved, FILTER_VALIDATE_IP)) {
+                        $aaaa = dns_get_record($bind, DNS_AAAA);
+                        if (is_array($aaaa) && isset($aaaa[0]['ipv6']) && is_string($aaaa[0]['ipv6'])) {
+                            $resolved = $aaaa[0]['ipv6'];
+                        }
+                    }
+                }
                 $serverAddr = filter_var($resolved, FILTER_VALIDATE_IP) ? $resolved : '127.0.0.1';
             }
             $srv['SERVER_ADDR'] = $serverAddr;
@@ -9633,34 +9646,6 @@ class App
                         // detached connection — the wire-frame carries neither
                         // (#290, RFC 9110 §6.4.1 / RFC 7230 §3.3.2). Keep-alive
                         // follows the request's Connection/protocol semantics.
-                        $reason = $g->raw_status_reason ?? self::reasonPhrase($emitStatus);
-                        $head = 'HTTP/1.1 ' . $emitStatus . ' '
-                            . ($reason !== '' ? $reason : 'Status ' . $emitStatus) . "\r\n";
-                        $haveDate = false;
-                        $nativeHeaders = is_array($response->parent->header) ? $response->parent->header : [];
-                        foreach ($nativeHeaders as $hName => $hValues) {
-                            $hName = (string)$hName;
-                            if (strcasecmp($hName, 'Connection') === 0
-                                || strcasecmp($hName, 'Content-Length') === 0
-                                || strcasecmp($hName, 'Content-Type') === 0) {
-                                continue;
-                            }
-                            $haveDate = $haveDate || strcasecmp($hName, 'Date') === 0;
-                            foreach (is_array($hValues) ? $hValues : [$hValues] as $hv) {
-                                if (is_scalar($hv)) {
-                                    $head .= $hName . ': ' . (string)$hv . "\r\n";
-                                }
-                            }
-                        }
-                        $nativeCookies = is_array($response->parent->cookie) ? $response->parent->cookie : [];
-                        foreach ($nativeCookies as $setCookie) {
-                            if (is_string($setCookie)) {
-                                $head .= 'Set-Cookie: ' . $setCookie . "\r\n";
-                            }
-                        }
-                        if (!$haveDate) {
-                            $head .= 'Date: ' . gmdate('D, d M Y H:i:s') . " GMT\r\n";
-                        }
                         $reqHeader = is_array($request->parent->header) ? $request->parent->header : [];
                         $reqServer = is_array($request->parent->server) ? $request->parent->server : [];
                         $connTok = $reqHeader['connection'] ?? '';
@@ -9669,14 +9654,62 @@ class App
                         $proto = is_string($proto) ? $proto : 'HTTP/1.1';
                         $keepAlive = $connTok === 'keep-alive'
                             || ($connTok !== 'close' && $proto === 'HTTP/1.1');
+                        $reason = $g->raw_status_reason ?? self::reasonPhrase($emitStatus);
+                        // Status line mirrors the request protocol (an HTTP/1.0
+                        // client gets an HTTP/1.0 status line, like Apache).
+                        $head = ($proto === 'HTTP/1.0' ? 'HTTP/1.0' : 'HTTP/1.1')
+                            . ' ' . $emitStatus . ' '
+                            . ($reason !== '' ? $reason : 'Status ' . $emitStatus) . "\r\n";
+                        $haveDate = false;
+                        $nativeHeaders = is_array($response->parent->header) ? $response->parent->header : [];
+                        foreach ($nativeHeaders as $hName => $hValues) {
+                            $hName = (string)$hName;
+                            // Body-framing headers can't appear on a body-less
+                            // status (Transfer-Encoding/Trailer included);
+                            // Connection is decided below from the request.
+                            if (strcasecmp($hName, 'Connection') === 0
+                                || strcasecmp($hName, 'Content-Length') === 0
+                                || strcasecmp($hName, 'Content-Type') === 0
+                                || strcasecmp($hName, 'Transfer-Encoding') === 0
+                                || strcasecmp($hName, 'Trailer') === 0) {
+                                continue;
+                            }
+                            // Raw-wire serialization: enforce the RFC 9110
+                            // token grammar on names and reject CR/LF-bearing
+                            // values (response-splitting guard).
+                            if (!preg_match('/^[A-Za-z0-9!#$%&\'*+.^_`|~-]+$/', $hName)) {
+                                continue;
+                            }
+                            $haveDate = $haveDate || strcasecmp($hName, 'Date') === 0;
+                            foreach (is_array($hValues) ? $hValues : [$hValues] as $hv) {
+                                if (is_scalar($hv) && !preg_match('/[\r\n]/', (string)$hv)) {
+                                    $head .= $hName . ': ' . (string)$hv . "\r\n";
+                                }
+                            }
+                        }
+                        $nativeCookies = is_array($response->parent->cookie) ? $response->parent->cookie : [];
+                        foreach ($nativeCookies as $setCookie) {
+                            if (is_string($setCookie) && !preg_match('/[\r\n]/', $setCookie)) {
+                                $head .= 'Set-Cookie: ' . $setCookie . "\r\n";
+                            }
+                        }
+                        if (!$haveDate) {
+                            $head .= 'Date: ' . gmdate('D, d M Y H:i:s') . " GMT\r\n";
+                        }
                         $head .= 'Connection: ' . ($keepAlive ? 'keep-alive' : 'close') . "\r\n\r\n";
                         $fd = $response->parent->fd;
-                        $response->parent->detach();
-                        if (is_int($fd) && self::$server !== null) {
+                        if (is_int($fd) && $fd > 0 && self::$server !== null) {
+                            $response->parent->detach();
                             self::$server->send($fd, $head);
                             if (!$keepAlive) {
                                 self::$server->close($fd);
                             }
+                        } else {
+                            // Prerequisites missing (no usable fd / no server
+                            // instance, e.g. a unit-test double): fall back to
+                            // the native end() — engine-default CT/CL reattach
+                            // there, but the client is never left hanging.
+                            $response->parent->end();
                         }
                     } else {
                         $body = $serverResponse->getBody();


### PR DESCRIPTION
Fixes the two partial residuals left from the closed parity batch — both re-verified **still reproducing on a fresh clone at HEAD `4322076`** before fixing (mixed mode, PHP 8.3.6, openswoole 26.2.0).

## #290 residual — 204/304 still carried `Content-Type: text/html` + `Content-Length: 0`
The body-drop fix holds (0-byte body ✓), but the strip only filters the **PSR-side** headers: OpenSwoole's native `end()` then re-injects its engine defaults at the C level, where no `header()` call can reach them — a `null` value restores the default and `''`/`false` emits a malformed bare `Content-Type:` (probed all three on openswoole 26.2.0). RFC 7230 §3.3.2 / RFC 9110 §6.4.1: a 204 MUST NOT carry `Content-Length`, and neither status should carry a `Content-Type` for content that cannot exist.

**Fix:** at the emit chokepoint, when `statusForbidsBody()` holds, serialize the head ourselves (status line + already-set headers + cookies + `Date`) and send it raw on the detached connection — the engine defaults never get a chance to attach. Keep-alive follows the request's semantics: HTTP/1.1 reuses the connection (`Connection: keep-alive`), HTTP/1.0 and `Connection: close` get `close` plus a server-side close.

## #306 residual — integer ports + missing SERVER_ADDR
The `REQUEST_URI`/`QUERY_STRING`/`CONTENT_*`/`PATH_INFO` half landed earlier; the originally-reported typed-ports half was still live:
- **`SERVER_PORT`/`REMOTE_PORT` pass through as OpenSwoole's PHP ints.** CGI/1.1 meta-variables are strings (RFC 3875 §4.1) — mod_php publishes `'443'` — so the common strict `$_SERVER['SERVER_PORT'] === '443'` comparison silently fails. Both now cast to the mod_php string form in `synthesizeRequestServerVars()`. (`REQUEST_TIME(_FLOAT)` stay numeric — mod_php publishes those numerically.)
- **`SERVER_ADDR` absent entirely** (OpenSwoole's `$request->server` has no equivalent key) → `Undefined array key` in vhost/multi-homed app code. Now synthesized from the bound listen address; a wildcard (`0.0.0.0`/`::`) or hostname bind resolves to the host's primary address once per worker, loopback as last-resort fallback so the key is never absent.

## Gates
| Check | Result |
|---|---|
| 204 + 304 wire | **zero** `Content-Type`/`Content-Length`, 0-byte body; `Date`/`Connection` intact, `ETag` preserved on 304 |
| All four lifecycle modes | mixed / coroutine / legacy-cgi / coroutine-legacy — identical clean wire + string ports + `SERVER_ADDR` in each |
| Keep-alive | single-connection reuse 204→200 verified (curl connection re-use); HTTP/1.0 → `Connection: close`; explicit `Connection: close` honored + closed |
| Burst | 40-req alternating 204/JSON-200, 0 deaths, 0 hangs |
| `$_SERVER` | `SERVER_PORT`/`REMOTE_PORT` now `string`; `SERVER_ADDR` populated (`127.0.0.1` bind → `127.0.0.1`) |
| Unit suite | 3960 OK |
| PHPStan | L10 at baseline (only the 2 pre-existing closure-arity reports in the session managers) |

Closes the #290 reopen-evidence residual; closes the #306 reopen-evidence residual.