### PR TITLE
fix: ScopedMiddleware reads lower-case request_uri — closes the //-prefix guard bypass (#232 regression)

### DIFF
--- a/src/Middleware/ScopedMiddleware.php
+++ b/src/Middleware/ScopedMiddleware.php
@@ -66,8 +66,15 @@ final class ScopedMiddleware implements MiddlewareInterface
         // `/admin` guard while still routing to `/admin/secret` (auth/IP/php-block
         // bypass). REQUEST_URI preserves the raw target. Fall back to the PSR path
         // for pure-PSR contexts (tests) where REQUEST_URI isn't populated on $g.
+        // LazyServerRequest::getServerParams() returns OpenSwoole's native
+        // server array verbatim, whose keys are LOWER-case (`request_uri`),
+        // while the hydrated/$_SERVER path uses the CGI UPPER-case
+        // (`REQUEST_URI`). Accept either casing — reading only the upper form
+        // left this null on the live request path, silently falling back to
+        // the authority-dropping PSR path the fix above exists to avoid (the
+        // `//admin/secret` bypass would then reach the guard as `/secret`).
         $serverParams = $request->getServerParams();
-        $reqUri = $serverParams['REQUEST_URI'] ?? null;
+        $reqUri = $serverParams['REQUEST_URI'] ?? $serverParams['request_uri'] ?? null;
         $target = (is_string($reqUri) && $reqUri !== '')
             ? $reqUri
             : $request->getUri()->getPath();


### PR DESCRIPTION
Fixes a **HIGH** auth/guard-bypass regression of #232, live-reproduced on a fresh clone at HEAD `4322076`. Filed as #406.

## The bypass
`ScopedMiddleware::location($guard, '/admin')` is **skipped** for `//admin/secret` (handler runs, **200**) while `/admin/secret` is correctly guarded (**403**) — whenever a slash-collapsing rewrite (`MergeSlashesMiddleware`, Apache's default `MergeSlashes On`) lets the router still dispatch `/admin/secret`.

| Request | Before | After |
|---|---|---|
| `/admin/secret` | 403 | 403 |
| `//admin/secret` (+ MergeSlashes) | **200 (bypass)** | **403** |
| `/./admin/secret` | 403 | 403 |

## Root cause
The #232 fix matches on the raw `REQUEST_URI` (not the PSR `Uri` path) precisely so a leading `//` — which the PSR `Uri` parses as the *authority*, dropping `//admin/secret` to `/secret` — can't skip a `/admin` scope. But the lookup read `getServerParams()['REQUEST_URI']` (**upper**-case), while `LazyServerRequest::getServerParams()` (`src/HTTP/LazyServerRequest.php:99-114`) returns OpenSwoole's native `$request->server` verbatim, whose keys are **lower**-case (`request_uri`). The upper-case key was always absent on the live request path, so the guard always fell back to `$request->getUri()->getPath()` — the exact authority-dropping path #232 set out to avoid.

```php
// src/Middleware/ScopedMiddleware.php:69-70 (before)
$serverParams = $request->getServerParams();
$reqUri = $serverParams['REQUEST_URI'] ?? null;   // always null on the live path
```

## Fix
One line — accept either key casing:

```php
$reqUri = $serverParams['REQUEST_URI'] ?? $serverParams['request_uri'] ?? null;
```

(The PSR fallback stays for pure-PSR/unit-test contexts where neither key is populated.)

## Gates
- Live: `//admin/secret` → **403** (was 200), `/admin/secret` → 403, `/./admin/secret` → 403, with `MergeSlashesMiddleware` registered.
- `ScopedMiddlewareTest` — **24 tests green**.
- Lint clean.

Closes #406 (the #232 regression).