### PR TITLE
chore: release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-06-14
+
+### Fixed
+- **WordPress `$wp_object_cache` lost-global under coroutine-legacy concurrency — FIXED** (consumed via [ext-zealphp 0.3.57](https://github.com/sibidharan/ext-zealphp/releases/tag/v0.3.57); closes the residual called out in 0.4.10's notes) — WordPress's `wp_start_object_cache()` has `static $first_init = true;` and on the *second* run takes the "already initialised" branch (`wp_cache_switch_to_blog()`) instead of `wp_cache_init()`. That function-local static is process-global, so under coroutine concurrency a peer coroutine could read another in-flight request's `false` **before** that request's request-end reset ran — skipping `wp_cache_init()` and leaving its own `$wp_object_cache` null → `Call to a member function switch_to_blog() on null` (~30% of requests at c8 + opcache). ext 0.3.57 adds a request-**begin** function-static refresh (`zealphp_reset_request_statics_begin()`) and makes the request-**end** reset rewrite to the template **in place** (stable table address, no destroy-window); `CoSessionManager` + `SessionManager` call the begin-refresh just before dispatch under the existing `perRequestStateResetsActive()` gate. Result (coroutine-legacy + patched opcache): WordPress homepage **c8×200 = 200/200**, **c16×480 = 480/480**, worker RSS flat (~0.06 KB/req, no leak), 0 crashes/segv — down from ~30% 500s. ext phpt 68/68 (incl. the new 064 begin-refresh pin). With the `$wpdb`-null Phase R fix (0.4.10 / ext 0.3.56), unmodified WordPress now serves clean under coroutine-legacy concurrency.
+
 ## [0.4.10] - 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project zealphp/project:^0.4.10 my-project
+composer create-project zealphp/project:^0.4.11 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -469,16 +469,16 @@ The fine-grained setters (`App::superglobals()`, `App::isolation()`, `App::enabl
 2. Run `composer validate`, `./vendor/bin/phpunit`, and `./vendor/bin/phpstan analyse --no-progress` (level 10, zero errors).
 3. Open a release PR, wait for required checks to go green, and merge (rebase):
    ```bash
-   git checkout -b release/v0.4.10
-   git commit -am "chore: release v0.4.10"
-   git push origin1 release/v0.4.10
-   gh pr create --base master --head release/v0.4.10 --title "chore: release v0.4.10"
+   git checkout -b release/v0.4.11
+   git commit -am "chore: release v0.4.11"
+   git push origin1 release/v0.4.11
+   gh pr create --base master --head release/v0.4.11 --title "chore: release v0.4.11"
    ```
 4. After merge, tag the merged commit and push to both remotes (tags aren't protected):
    ```bash
    git checkout master && git pull origin1 master --ff-only
-   git tag -a v0.4.10 -m "Release v0.4.10"
-   git push origin v0.4.10 && git push origin1 v0.4.10
+   git tag -a v0.4.11 -m "Release v0.4.11"
+   git push origin v0.4.11 && git push origin1 v0.4.11
    ```
 5. Bump `zealphp/project` (the scaffold) to the same version and refresh its `llms.txt`. Packagist auto-syncs via webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.10 .
+docker build -t zealphp:0.4.11 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -231,7 +231,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.10 .
+    -t zealphp:0.4.11 .
 ```
 
 ### Run (single container)
@@ -243,7 +243,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.10
+    zealphp:0.4.11
 ```
 
 ### Production compose
@@ -254,7 +254,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.10
+    image: registry.example.com/zealphp-app:0.4.11
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/examples/agents/zealphp_reference.txt
+++ b/examples/agents/zealphp_reference.txt
@@ -2881,8 +2881,12 @@ distinct issues were root-caused (see
 - **`Undefined constant AUTOLOAD_FILE` / `ROOT_PATH`** — only appears if you
   enable `defineIsolation(true)` (the S10 constants stage) *without*
   `includeIsolation(true)` (S7 Include-once). Clearing request-scoped constants
-  is only sound when the `require_once`'d files that define them re-execute. `App::mode(App::MODE_COROUTINE_LEGACY)` enables both together,
-  so don't hand-roll that half-combo (the framework now warns at boot if you do).
+  is only sound when the `require_once`'d files that define them re-execute.
+  `App::mode(App::MODE_COROUTINE_LEGACY)` enables `includeIsolation` but **NOT**
+  `defineIsolation` (S10 is a standalone opt-in — request-scoped constants are
+  *not* isolated per coroutine by default; that's the ext#16 structural limit).
+  So if you opt into `defineIsolation(true)`, do it on top of coroutine-legacy
+  (which already provides `includeIsolation`) — never `defineIsolation` alone.
 - **Bootstrap hang (000)** — phpMyAdmin's deeply-recursive Symfony DI container
   build hits a coroutine yield/resume scheduling race under HOOK_ALL (a
   Heisenbug: extra I/O makes it pass). Open; `cgiMode('pool')` is the supported
@@ -2943,6 +2947,8 @@ How 50 popular PHP apps run on ZealPHP across **all four runtime modes**, with *
 **2026-06-12 re-validation level:** every graded app below was re-run on 0.3.49 with the standard **84-request 6-way burst** (`burst6.php <port> 6 14`) plus a homepage check. Apps where the burst lifted to 0 worker deaths AND that previously failed *solely* on worker-crash were taken one level deeper (content sanity + scripted login/write where the harness allowed); the per-app detail notes the exact level reached ("full protocol" vs "burst+content" vs "burst-only"). The **ext#52 fix eliminated worker deaths** across most of the C/D set (kanboard, kirby, dokuwiki, phpmyadmin, yii2, laminas, elfinder, codeigniter4, tinyfilemanager, symfony, drupal all 0 deaths now), but **content-level checks revealed several apps whose 0-death bursts serve hollow/broken bodies** — those stay D/C honestly (CodeIgniter4 0-byte bodies, DokuWiki content "str() on null", TinyFileManager login still lost). An **object-global-null regression cluster** surfaced on 0.3.49 (WordPress `wp_set_wpdb_vars` null, MyBB `read() on null` — 500 on every request) — root-caused the same day and **FIXED in ext-zealphp v0.3.50**: the S2 request-frame walkers trusted `ex->symbol_table` without gating on `ZEND_CALL_HAS_SYMBOL_TABLE`, so a plain function frame’s stale field could match and the parked `$wpdb` bucket was re-pointed into `require_wp_db()`’s dying frame (NOT the ext#44/#49 frontier as first suspected). On v0.3.50 both render again — see the per-app rows.
 
 **Status: 31/50 re-validated in `coroutine-legacy`** (B: 7 · C: 15 · D: 9); 19 pending. **2026-06-12 late corrections (ext v0.3.51 + framework OB fix):** CodeIgniter 4 D→**B** (0-byte bodies were a framework flush bug, fixed), DokuWiki D→**C** (content restored by the ext#50 class_alias fix), TinyFileManager D→**C** (login proven working — the sweep probe missed the CSRF token and didn't follow redirects). **Net grade changes 2026-06-12:** Kanboard D→B, Yii 2 C→B (both driven by ext#52 + session #379); 5 previously-_pending_ rows newly graded (TYPO3 C, Craft CMS C, Roundcube C, Concrete CMS D, Flarum D). The two 0.3.49 regressions (WordPress, MyBB — object-global null) are **resolved on v0.3.50**. Leantime now **F** (boot-fail: its prebuilt vendor directory without composer.json blocks the psr/http-message v1 fix, leading to cascading PHP 8.4 fatal errors).
+
+> **Note on `USE_ZEND_ALLOC=0` in the per-app burst notes below.** It is a **diagnostic toggle, not a recommended production setting.** Root-caused 2026-06-13 (`docs/architecture/2026-06-13-use-zend-alloc-reframe.md`): for the WordPress-class apps it does not fix an allocator bug — it disables Zend MM, which disables `memory_limit` enforcement, so a worker carrying a per-request memory accumulation never hits the OOM fatal that triggers the coroutine-legacy worker-exit teardown corruption. The production-correct knob for an accumulating legacy app under a long-lived worker is **`max_request` worker recycle** (`run(['max_request' => 50])`, FPM `pm.max_requests` parity), or `cgi-pool`/`legacy-cgi`. The burst notes that mention it are kept as accurate observations of what was seen, not as guidance.
 
 ---
 
@@ -4807,7 +4813,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.9 .
+docker build -t zealphp:0.4.10 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -4819,7 +4825,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.9 .
+    -t zealphp:0.4.10 .
 ```
 
 ### Run (single container)
@@ -4831,7 +4837,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.9
+    zealphp:0.4.10
 ```
 
 ### Production compose
@@ -4842,7 +4848,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.9
+    image: registry.example.com/zealphp-app:0.4.10
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/src/App.php
+++ b/src/App.php
@@ -4093,6 +4093,41 @@ class App
     }
 
     /**
+     * Request-BEGIN function-static refresh (coroutine-legacy, #28).
+     *
+     * The concurrency companion to the request-END `zealphp_reset_request_statics()`.
+     * The end-reset makes function-local `static $x` fresh-per-request SEQUENTIALLY,
+     * but under coroutine concurrency a peer can read a process-global static that
+     * another in-flight request mutated BEFORE that request's end-reset runs. The
+     * canonical break is WordPress's `wp_start_object_cache()`: its `static $first_init`
+     * is set false on the first run, so a concurrent peer reading that false skips
+     * `wp_cache_init()` and leaves its own `$wp_object_cache` null → "Call to a member
+     * function switch_to_blog() on null". Refreshing every registered static to its
+     * template at request begin makes THIS request coroutine's first read see the
+     * template; the per-yield static snapshot (S5a) then multiplexes per coroutine.
+     *
+     * Gated identically to the end-resets (`perRequestStateResetsActive()`), and a
+     * no-op when the ext primitive is absent (older ext, or `legacy-cgi`/sync modes).
+     * Returns whether the refresh ran, so the call sites — `CoSessionManager` /
+     * `SessionManager` just before dispatch — stay one-liners and the behaviour is
+     * unit-testable without a live request. The ext primitive's refreshed-count
+     * return value is discarded (mirrors the sibling `zealphp_reset_request_*`
+     * calls), so no return-type plumbing crosses the ext boundary.
+     *
+     * @return bool True when the refresh ran (resets active + ext primitive present).
+     */
+    public static function runRequestStaticsBeginRefresh(): bool
+    {
+        if (!self::perRequestStateResetsActive()
+            || !\function_exists('zealphp_reset_request_statics_begin')
+        ) {
+            return false;
+        }
+        (\zealphp_reset_request_statics_begin(...))();
+        return true;
+    }
+
+    /**
      * Stage 8 global-scope request include (coroutine-legacy). A no-arg call
      * returns the current setting; a one-arg call sets it. See the
      * `$global_scope_include` docblock for the contract. Set BEFORE `App::run()`.

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -280,6 +280,25 @@ class CoSessionManager
             $g->zealphp_request = $request;
             $g->zealphp_response = $response;
 
+            // #28: per-request function-static REFRESH at request BEGIN — the
+            // concurrency companion to the request-END zealphp_reset_request_statics()
+            // below. The end-reset gives fresh-per-request statics SEQUENTIALLY, but
+            // under coroutine concurrency a peer can read a process-global static
+            // (e.g. WordPress wp_start_object_cache()'s `static $first_init`) that
+            // another in-flight request set false, BEFORE that request's end-reset
+            // runs — so it skips wp_cache_init() and $wp_object_cache stays null
+            // ("Call to a member function switch_to_blog() on null"). Refreshing
+            // registered statics to their template at the start of THIS request
+            // coroutine makes its first read see the template; S5a's per-yield save
+            // then captures it into this coroutine's snapshot and restore re-asserts
+            // it across peer interleaving. Same gate as the end-resets; no-op without
+            // the ext function.
+            if (\ZealPHP\App::perRequestStateResetsActive()
+                && \function_exists('zealphp_reset_request_statics_begin')
+            ) {
+                (\zealphp_reset_request_statics_begin(...))();
+            }
+
             call_user_func($this->middleware, $request, $response);
         } finally {
             \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338

--- a/src/Session/CoSessionManager.php
+++ b/src/Session/CoSessionManager.php
@@ -282,22 +282,11 @@ class CoSessionManager
 
             // #28: per-request function-static REFRESH at request BEGIN — the
             // concurrency companion to the request-END zealphp_reset_request_statics()
-            // below. The end-reset gives fresh-per-request statics SEQUENTIALLY, but
-            // under coroutine concurrency a peer can read a process-global static
-            // (e.g. WordPress wp_start_object_cache()'s `static $first_init`) that
-            // another in-flight request set false, BEFORE that request's end-reset
-            // runs — so it skips wp_cache_init() and $wp_object_cache stays null
-            // ("Call to a member function switch_to_blog() on null"). Refreshing
-            // registered statics to their template at the start of THIS request
-            // coroutine makes its first read see the template; S5a's per-yield save
-            // then captures it into this coroutine's snapshot and restore re-asserts
-            // it across peer interleaving. Same gate as the end-resets; no-op without
-            // the ext function.
-            if (\ZealPHP\App::perRequestStateResetsActive()
-                && \function_exists('zealphp_reset_request_statics_begin')
-            ) {
-                (\zealphp_reset_request_statics_begin(...))();
-            }
+            // below (closes WordPress's wp_start_object_cache() `static $first_init`
+            // cross-coroutine leak → $wp_object_cache null). See
+            // App::runRequestStaticsBeginRefresh() for the full rationale; gated and
+            // no-op'd there.
+            \ZealPHP\App::runRequestStaticsBeginRefresh();
 
             call_user_func($this->middleware, $request, $response);
         } finally {

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -358,21 +358,12 @@ class SessionManager
             $g->zealphp_request = $request;
             $g->zealphp_response = $response;
             // #28: per-request function-static REFRESH at request BEGIN — the
-            // concurrency companion to the request-END zealphp_reset_request_statics().
-            // The end-reset gives fresh-per-request statics SEQUENTIALLY, but under
-            // coroutine concurrency a peer can read a process-global static (e.g.
-            // WordPress wp_start_object_cache()'s `static $first_init`) that another
-            // in-flight request set false, BEFORE that request's end-reset runs — so
-            // it skips wp_cache_init() and $wp_object_cache stays null
-            // ("switch_to_blog() on null"). Refreshing registered statics to their
-            // template at the start of THIS request makes its first read see the
-            // template; S5a's per-yield save then captures it per-coroutine. Same gate
-            // as the end-resets; no-op without the ext function.
-            if (\ZealPHP\App::perRequestStateResetsActive()
-                && \function_exists('zealphp_reset_request_statics_begin')
-            ) {
-                (\zealphp_reset_request_statics_begin(...))();
-            }
+            // concurrency companion to the request-END zealphp_reset_request_statics()
+            // (closes WordPress's wp_start_object_cache() `static $first_init`
+            // cross-coroutine leak → $wp_object_cache null). See
+            // App::runRequestStaticsBeginRefresh() for the full rationale; gated and
+            // no-op'd there.
+            \ZealPHP\App::runRequestStaticsBeginRefresh();
             call_user_func($this->middleware, $request, $response);
         } finally {
             \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338

--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -357,6 +357,22 @@ class SessionManager
             $response = new \ZealPHP\HTTP\Response($response);
             $g->zealphp_request = $request;
             $g->zealphp_response = $response;
+            // #28: per-request function-static REFRESH at request BEGIN — the
+            // concurrency companion to the request-END zealphp_reset_request_statics().
+            // The end-reset gives fresh-per-request statics SEQUENTIALLY, but under
+            // coroutine concurrency a peer can read a process-global static (e.g.
+            // WordPress wp_start_object_cache()'s `static $first_init`) that another
+            // in-flight request set false, BEFORE that request's end-reset runs — so
+            // it skips wp_cache_init() and $wp_object_cache stays null
+            // ("switch_to_blog() on null"). Refreshing registered statics to their
+            // template at the start of THIS request makes its first read see the
+            // template; S5a's per-yield save then captures it per-coroutine. Same gate
+            // as the end-resets; no-op without the ext function.
+            if (\ZealPHP\App::perRequestStateResetsActive()
+                && \function_exists('zealphp_reset_request_statics_begin')
+            ) {
+                (\zealphp_reset_request_statics_begin(...))();
+            }
             call_user_func($this->middleware, $request, $response);
         } finally {
             \ZealPHP\App::fatalGuardRelease($zpFatalGuardId); // #338

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.4.10
+    image: zealphp:0.4.11
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -178,7 +178,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  zealphp/project:^0.4.10 \
+  zealphp/project:^0.4.11 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, state isolated coroutines, shared memory, task workers &mdash;
        first&#8209;class. Powered by Openswoole. Isolated by <em>ext-zealphp.</em></p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.4.10 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.4.11 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -306,7 +306,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project zealphp/project:^0.4.10 my-app</span><button class="qs-copy" data-copy="composer create-project zealphp/project:^0.4.10 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project zealphp/project:^0.4.11 my-app</span><button class="qs-copy" data-copy="composer create-project zealphp/project:^0.4.11 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>

--- a/tests/Unit/AppRequestStaticsBeginRefreshTest.php
+++ b/tests/Unit/AppRequestStaticsBeginRefreshTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+
+/**
+ * App::runRequestStaticsBeginRefresh() — the request-BEGIN function-static
+ * refresh (#28), the concurrency companion to the request-END
+ * zealphp_reset_request_statics(). It is gated identically to the other
+ * per-request resets (perRequestStateResetsActive()) and is a no-op when the
+ * ext primitive is absent, so it stays safe to call unconditionally from the
+ * session managers just before dispatch.
+ *
+ * The session managers' __invoke() needs a live OpenSwoole request/response
+ * pair (Integration territory), so the call sites themselves aren't unit
+ * reachable — this pins the extracted helper directly: the gate short-circuits
+ * to 0 when resets are inactive, and the ext primitive is invoked (and its
+ * count returned) when they are active and the function is available.
+ */
+final class AppRequestStaticsBeginRefreshTest extends TestCase
+{
+    private bool $origSr = false;
+    private bool $origFi = false;
+    private bool $origIi = false;
+
+    protected function setUp(): void
+    {
+        $this->origSr = App::$silent_redeclare;
+        $this->origFi = App::$function_isolation;
+        $this->origIi = App::$include_isolation;
+    }
+
+    protected function tearDown(): void
+    {
+        App::$silent_redeclare  = $this->origSr;
+        App::$function_isolation = $this->origFi;
+        App::$include_isolation  = $this->origIi;
+    }
+
+    public function testReturnsFalseWhenResetsInactive(): void
+    {
+        // silent_redeclare off → perRequestStateResetsActive() is false → the
+        // ext primitive is never consulted, even if it exists.
+        App::$silent_redeclare   = false;
+        App::$function_isolation = true;
+        App::$include_isolation  = true;
+
+        $this->assertFalse(App::perRequestStateResetsActive());
+        $this->assertFalse(App::runRequestStaticsBeginRefresh());
+    }
+
+    public function testReturnsFalseWhenSilentRedeclareWithoutIsolation(): void
+    {
+        // #227 gate: silent_redeclare alone (no isolation) must NOT run resets.
+        App::$silent_redeclare   = true;
+        App::$function_isolation = false;
+        App::$include_isolation  = false;
+
+        $this->assertFalse(App::perRequestStateResetsActive());
+        $this->assertFalse(App::runRequestStaticsBeginRefresh());
+    }
+
+    public function testInvokesExtPrimitiveWhenActive(): void
+    {
+        // Resets active (the coroutine-legacy shape). When the ext provides the
+        // primitive (ext-zealphp 0.3.57+, as on CI) the refresh runs and returns
+        // true (refreshing an empty registry is a safe no-op); when the ext is
+        // older/absent the helper short-circuits to false via the function_exists
+        // guard. Either way the gate evaluates true and the helper body executes.
+        App::$silent_redeclare   = true;
+        App::$function_isolation = true;
+        App::$include_isolation  = false;
+
+        $this->assertTrue(App::perRequestStateResetsActive());
+
+        $ran = App::runRequestStaticsBeginRefresh();
+        $this->assertSame(
+            \function_exists('zealphp_reset_request_statics_begin'),
+            $ran,
+            'refresh runs iff the ext primitive is available'
+        );
+    }
+}


### PR DESCRIPTION
## v0.4.11 — WordPress `$wp_object_cache` lost-global fixed (ext-zealphp 0.3.57)

Closes the residual called out in v0.4.10's notes. With the `$wpdb`-null Phase R fix (v0.4.10 / ext 0.3.56) **and** this, unmodified WordPress now serves clean under coroutine-legacy concurrency.

### Root cause
`wp_start_object_cache()` has `static $first_init = true;`; on the second run it takes the "already initialised" branch (`wp_cache_switch_to_blog()`) instead of `wp_cache_init()`. That function-local static is process-global, so under coroutine concurrency a peer reads another in-flight request's `false` **before** that request's request-end reset runs — skipping `wp_cache_init()` and leaving its own `$wp_object_cache` null → `switch_to_blog() on null` (~30% at c8 + opcache).

### Fix (consumed via ext-zealphp 0.3.57)
- ext: request-**begin** function-static refresh (`zealphp_reset_request_statics_begin()`) re-instantiates a destroyed/nulled static from its template, and the request-**end** reset now rewrites to the template **in place** (stable address, no destroy-window).
- framework: `CoSessionManager` + `SessionManager` call the begin-refresh just before dispatch, under the existing `perRequestStateResetsActive()` gate (no-op without the ext function).

### Validation (coroutine-legacy + patched opcache)
- WordPress homepage **c8×200 = 200/200**, **c16×480 = 480/480**, worker RSS flat (~0.06 KB/req, no leak), 0 crashes / 0 segv — down from ~30% 500s.
- ext phpt **68/68** (incl. new 064 begin-refresh pin); framework phpunit Unit 4018 OK.

Pairs with ext-zealphp **v0.3.57** (tagged + pushed).