### PR TITLE
fix(#444,#446): htmx separate-template + nested-fragment render fixes

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -6794,6 +6794,12 @@ class App
                 'matched' => false,
                 'result'  => null,
             ];
+        } else {
+            // #446 — a nested render with NO selector must not inherit the
+            // parent's active fragment selector; clear it so the child runs its
+            // own App::fragment() regions inline. The parent's state is saved
+            // above and restored on exit, so this only scopes the child.
+            $g->memo['_fragment'] = null;
         }
 
         // Mode 4: $_SESSION reference is established in zeal_session_start()
@@ -7241,14 +7247,25 @@ class App
             return self::render($fullPageTemplate ?? $template, $args);
         }
 
-        // Explicit fragment wins.
+        // Explicit fragment wins (either form).
         if ($fragmentName !== null) {
             return self::render($template, $args + ['fragment' => $fragmentName]);
         }
 
-        // Derive the fragment from the request: HX-Target (strip a leading
-        // '#'), else HX-Trigger-Name. If neither is present, render the bare
-        // partial with no fragment key.
+        // #444 — separate-template form: a non-null $fullPageTemplate signals
+        // that $template is a BARE PARTIAL (the htmx swap content itself, with no
+        // App::fragment() region), not a fragment-bearing page. A real htmx swap
+        // carries HX-Target, so deriving a fragment here would ask the partial
+        // for a region it doesn't have → executeFile's post-flight 404. The
+        // partial IS the response — render it directly. Fragment derivation only
+        // applies to the single-template form (a page that holds the regions).
+        if ($fullPageTemplate !== null) {
+            return self::render($template, $args);
+        }
+
+        // Single-template form: derive the fragment from the request — HX-Target
+        // (strip a leading '#'), else HX-Trigger-Name. If neither is present,
+        // render the template with no fragment key (its bare partial output).
         $target = $req->htmxTarget();
         $derived = $target !== null ? ltrim($target, '#') : $req->htmxTriggerName();
         if ($derived !== null && $derived !== '') {

--- a/tests/Unit/FileExecutionFamilyTest.php
+++ b/tests/Unit/FileExecutionFamilyTest.php
@@ -169,4 +169,17 @@ class FileExecutionFamilyTest extends TestCase
         $this->expectException(\ZealPHP\TemplateUnavailableException::class);
         App::render('/../render-sibling/leak', [], self::DIR);
     }
+
+    // ── #446: nested-render fragment-selector isolation ───────────
+
+    public function testNestedRenderDoesNotInheritParentFragmentSelector(): void
+    {
+        // Standalone child: its own 'cr' fragment runs inline.
+        $this->assertSame('CB|CRI|CA', App::render('child_frag', [], self::DIR));
+        // #446 — nested inside the parent's matched 'want' fragment, the child's
+        // 'cr' region must STILL run inline. Pre-fix the child inherited the
+        // parent's 'want' selector ('cr' != 'want') and was silently dropped →
+        // 'W[CB||CA]'. A no-selector nested render must not inherit.
+        $this->assertSame('W[CB|CRI|CA]', App::render('parent_frag', ['fragment' => 'want'], self::DIR));
+    }
 }

--- a/tests/Unit/RenderHtmxTest.php
+++ b/tests/Unit/RenderHtmxTest.php
@@ -205,4 +205,22 @@ PHP);
         $result = App::renderHtmx('status-page', [], 'gone');
         $this->assertSame(410, $result);
     }
+
+    // ──────────────────────────────────────────────────────────────
+    // #444 — separate-template form: bare partial + fullPageTemplate.
+    // ──────────────────────────────────────────────────────────────
+
+    public function testHtmxSeparateTemplateFormRendersBarePartialNotDerivedFragment(): void
+    {
+        // #444 — $template is a BARE PARTIAL (no fragment region) paired with a
+        // fullPageTemplate. A real htmx swap carries HX-Target/HX-Trigger-Name,
+        // but the partial IS the response; deriving a fragment from those headers
+        // asks the partial for a region it lacks → executeFile post-flight 404.
+        // The partial must be rendered directly (return its body, not 404).
+        $this->request(['hx-request' => 'true', 'hx-target' => '#results']);
+        $this->assertSame('[BARE-PARTIAL]', App::renderHtmx('partial', [], null, 'full'));
+
+        $this->request(['hx-request' => 'true', 'hx-trigger-name' => 'results']);
+        $this->assertSame('[BARE-PARTIAL]', App::renderHtmx('partial', [], null, 'full'));
+    }
 }

--- a/tests/fixtures/render/child_frag.php
+++ b/tests/fixtures/render/child_frag.php
@@ -1,0 +1,7 @@
+<?php
+// #446 fixture — a child component with its own App::fragment() region.
+// Rendered standalone OR nested inside a parent's fragment closure, its 'cr'
+// region must run inline either way (the child passes no fragment selector).
+echo 'CB|';
+\ZealPHP\App::fragment('cr', function () { echo 'CRI'; });
+echo '|CA';

--- a/tests/fixtures/render/parent_frag.php
+++ b/tests/fixtures/render/parent_frag.php
@@ -1,0 +1,9 @@
+<?php
+// #446 fixture — a parent page whose 'want' fragment closure does a NESTED
+// render of child_frag (passing NO fragment arg). The nested child must run its
+// own 'cr' region inline, not inherit the parent's active 'want' selector.
+echo 'HEAD|';
+\ZealPHP\App::fragment('want', function () {
+    echo 'W[' . \ZealPHP\App::renderToString('child_frag', [], 'tests/fixtures/render') . ']';
+});
+echo '|TAIL';


### PR DESCRIPTION
Two related htmx/fragment render fixes from @Guruprasanth-M's bug sweep (one commit — both touch `App.php`). 33 affected unit tests pass; PHPStan level 10 clean.

### #444 — `renderHtmx()` separate-template form 404s on every real htmx swap (MEDIUM)

The documented `App::renderHtmx('partial', $args, fullPageTemplate: 'page')` form (bare partial for htmx, separate full-page shell for direct nav) derived a fragment from `HX-Target`/`HX-Trigger-Name` and asked the bare partial — which has no `App::fragment()` region — for it → `executeFile` post-flight **404**. Since htmx sets `HX-Target` on essentially every targeted swap, the feature 404'd in its documented form.

Fix: gate fragment derivation on the single-template form (`$fullPageTemplate === null`); the separate-template form renders the partial directly. Explicit `$fragmentName` still wins in either form.

### #446 — nested render inherits the parent's fragment selector (MEDIUM)

Docs promise a nested `App::render()` from inside a fragment closure does **not** inherit the parent's fragment selector. In fact a no-selector nested render left the parent's `{wanted:…}` state live, so the child's own `App::fragment()` regions were matched against the parent's name and silently **dropped** (or wrongly extracted on a name collision).

Fix: `executeFile()` now clears the fragment slot for a no-selector child (parent state saved + restored on exit), so the child runs its regions inline — matching the documented non-inheritance contract.

Closes #444, closes #446.
