### PR TITLE
fix: Guru legacy-mode issue batch (#453, #454, #457, #458)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1745,12 +1745,23 @@ class App
      * routing calls to the given ZealPHP replacement. Uses `zealphp_override()`
      * when ext-zealphp is loaded (preferred), falling back to `uopz_set_return()`.
      *
+     * #457 — ext-zealphp denylists a small set of builtins it refuses to
+     * trampoline (`session_set_save_handler`); calling `zealphp_override()` on
+     * one emits an E_WARNING every boot and installs nothing. For those, skip
+     * the ext path and use uopz (which CAN override them — restoring the #295
+     * custom-save-handler routing); if uopz is absent the override is simply
+     * skipped, with no warning.
+     *
      * @param callable-string $callable Fully-qualified ZealPHP replacement function name.
      */
     private static function overrideBuiltin(string $name, string $callable): void
     {
         $cb = \Closure::fromCallable($callable);
-        if (\extension_loaded('zealphp') && \function_exists('zealphp_override')) {
+        // ext-zealphp's zealphp_override() denylists session_set_save_handler:
+        // calling it warns + installs nothing (#457). Skip the ext path for it
+        // and use uopz (which CAN override it — keeps the #295 save-handler routing).
+        $extRefuses = ($name === 'session_set_save_handler');
+        if (\extension_loaded('zealphp') && \function_exists('zealphp_override') && !$extRefuses) {
             (\zealphp_override(...))($name, $cb);
         } elseif (\function_exists('uopz_set_return')) {
             \uopz_set_return($name, $cb, true);
@@ -1887,6 +1898,29 @@ class App
             self::$hook_exit = $value;
         }
         return self::$hook_exit;
+    }
+
+    /**
+     * Boot-time advisory for `App::hookExit(true)` set without a coroutine
+     * scheduler (#454). The ext-zealphp exit() interception is scheduler-bound:
+     * with `enableCoroutine` off (mixed / in-process-sync modes) a userland
+     * exit()/die() still throws OpenSwoole\ExitException (extends \Exception) —
+     * which a legacy `try { … exit; } catch (\Exception)` router swallows — NOT
+     * ZealPHP\HaltException. Forcing the hook on there is silently inert, so
+     * surface it at boot rather than let the developer believe exit() is
+     * protected. Returns the advisory string, or null when N/A; the `null`
+     * (auto) default follows the scheduler and never warns. Testable seam.
+     */
+    public static function exitHookAdvisory(?bool $forced, bool $hasScheduler): ?string
+    {
+        if ($forced === true && !$hasScheduler) {
+            return '[advisory] App::hookExit(true) has no effect without the coroutine '
+                . 'scheduler (this mode runs with enableCoroutine=false): exit()/die() will '
+                . 'still throw OpenSwoole\\ExitException (not ZealPHP\\HaltException), which a '
+                . "legacy `catch (\\Exception)` swallows. Use App::mode('coroutine-legacy') "
+                . '(or enableCoroutine(true)) if you need exit()-hook protection.';
+        }
+        return null;
     }
 
     // -----------------------------------------------------------------------
@@ -6756,6 +6790,37 @@ class App
     // -----------------------------------------------------------------------
 
     /**
+     * Run a user file (template / public page) in an ISOLATED scope and return
+     * its value (#458). The file is included HERE, not in executeFile(), so a
+     * page that reuses a common variable name — `$g`, `$result`, `$output`,
+     * `$args`, … — only shadows this helper's throwaway locals and never
+     * corrupts executeFile()'s framework state used after the include (which
+     * previously fatalled "Attempt to assign property _ob_floor on array" → 500
+     * when a page did `$g = …`). Locals are `$__zeal_`-prefixed (and EXTR_SKIP
+     * keeps them safe during extract) to stay clear of app/template names.
+     *
+     * @param array<string,mixed> $__zeal_args   Template/route args, bound by name.
+     * @param object              $__zeal_g       Request RequestContext (bound as $g).
+     * @param bool                $__zeal_global  Run at true global scope (Stage 8).
+     */
+    private static function runUserFile(string $__zeal_abs, array $__zeal_args, object $__zeal_g, bool $__zeal_global): mixed
+    {
+        // $__zeal_global already implies the function exists (the caller ANDs in
+        // function_exists), but re-check so PHPStan narrows it (the ext function
+        // is unstubbed) and as a safe fallback to the plain include.
+        if ($__zeal_global && \function_exists('zealphp_require_global')) {
+            // Stage 8: TRUE global scope — bare file-scope vars (WordPress
+            // $menu/$submenu/$_wp_submenu_nopriv) become real $GLOBALS; the file
+            // does NOT see $g / route params (this mode is for legacy apps that
+            // read request state via superglobals).
+            return \zealphp_require_global($__zeal_abs);
+        }
+        $__zeal_args['g'] = $__zeal_g;
+        extract($__zeal_args, EXTR_SKIP);
+        return include $__zeal_abs;
+    }
+
+    /**
      * Run a PHP file with the framework's universal return contract.
      *
      * Captures buffered output, then maps the included file's result:
@@ -6861,18 +6926,19 @@ class App
         $result = null;
         try {
             try {
-                $args['g'] = $g;
-                extract($args, EXTR_SKIP);
-                if (self::globalScopeIncludeEffective() && \function_exists('zealphp_require_global')) {
-                    // Stage 8: run the file at TRUE global scope so bare file-scope
-                    // vars (WordPress $menu/$submenu/$_wp_submenu_nopriv) become real
-                    // $GLOBALS. The included file does NOT see the extracted $g /
-                    // route params (they stay in this frame) — by contract this mode
-                    // is for legacy apps that read request state via superglobals.
-                    $result = \zealphp_require_global($absPath);
-                } else {
-                    $result = include $absPath;
-                }
+                // #458 — run the user file in an ISOLATED helper scope. A plain
+                // `include` HERE shares executeFile()'s frame, so an ordinary app
+                // variable (`$g = getGrade(...)`, an array — or $result/$output/…)
+                // clobbers framework state the post-include logic depends on →
+                // "Attempt to assign property _ob_floor on array" 500. runUserFile()
+                // binds the args + $g and includes in its OWN frame, so any name the
+                // page reuses only shadows throwaway locals, never executeFile()'s.
+                $result = self::runUserFile(
+                    $absPath,
+                    $args,
+                    $g,
+                    self::globalScopeIncludeEffective() && \function_exists('zealphp_require_global')
+                );
             } finally {
                 if ($didChdir && $prevCwd !== false) {
                     @\chdir($prevCwd);
@@ -8833,6 +8899,12 @@ class App
         ) {
             \class_exists(\ZealPHP\HaltException::class);   // force autoload, pre-fork
             (\zealphp_exit_hook(...))(true);
+        }
+        // #454 — forcing App::hookExit(true) without a coroutine scheduler is
+        // silently inert (the ext interception is scheduler-bound). Surface it.
+        $exitAdvisory = self::exitHookAdvisory(self::$hook_exit, $enableCoroutine);
+        if ($exitAdvisory !== null) {
+            elog($exitAdvisory, 'warn');
         }
 
         if ($hookFlags !== 0) {

--- a/src/utils.php
+++ b/src/utils.php
@@ -1599,25 +1599,45 @@ function apache_request_headers(): array
 {
     $g = RequestContext::instance();
     $out = [];
-    $raw = [];
     if (isset($g->zealphp_request)) {
+        // In-process (coroutine / mixed / in-process include): read the live
+        // OpenSwoole request header map — exact and multi-value aware.
         $raw = $g->zealphp_request->parent->header ?? [];
-    }
-    if (!is_array($raw)) {
+        if (!is_array($raw)) {
+            return $out;
+        }
+        foreach ($raw as $name => $value) {
+            $canonical = str_replace(' ', '-', ucwords(str_replace('-', ' ', strtolower((string)$name))));
+            if (is_array($value)) {
+                $strValues = [];
+                foreach ($value as $v) {
+                    if (is_scalar($v)) {
+                        $strValues[] = (string)$v;
+                    }
+                }
+                $out[$canonical] = implode(', ', $strValues);
+            } else {
+                $out[$canonical] = is_scalar($value) ? (string)$value : '';
+            }
+        }
         return $out;
     }
-    foreach ($raw as $name => $value) {
-        $canonical = str_replace(' ', '-', ucwords(str_replace('-', ' ', strtolower((string)$name))));
-        if (is_array($value)) {
-            $strValues = [];
-            foreach ($value as $v) {
-                if (is_scalar($v)) {
-                    $strValues[] = (string)$v;
-                }
-            }
-            $out[$canonical] = implode(', ', $strValues);
-        } else {
-            $out[$canonical] = is_scalar($value) ? (string)$value : '';
+    // #453 — no live OpenSwoole request object: this is a legacy-cgi CGI
+    // subprocess (pool/proc). Reconstruct the header map from $_SERVER HTTP_*
+    // meta-vars (+ CONTENT_TYPE / CONTENT_LENGTH), RFC 3875 §4.1.18 / Apache
+    // mod_php parity. Pre-fix this returned [] on the pool backend even though
+    // the headers ARE present in $_SERVER, silently breaking getallheaders()-
+    // based auth / CORS / signature code in unmodified apps.
+    foreach ($_SERVER as $name => $value) {
+        if (!is_string($name) || !is_scalar($value)) {
+            continue;
+        }
+        if (strncmp($name, 'HTTP_', 5) === 0) {
+            $canonical = str_replace(' ', '-', ucwords(str_replace('_', ' ', strtolower(substr($name, 5)))));
+            $out[$canonical] = (string)$value;
+        } elseif ($name === 'CONTENT_TYPE' || $name === 'CONTENT_LENGTH') {
+            $canonical = str_replace(' ', '-', ucwords(str_replace('_', ' ', strtolower($name))));
+            $out[$canonical] = (string)$value;
         }
     }
     return $out;

--- a/tests/Unit/AppStaticHelpersTest.php
+++ b/tests/Unit/AppStaticHelpersTest.php
@@ -143,6 +143,22 @@ class AppStaticHelpersTest extends TestCase
         $this->assertSame(250, App::resolveMaxRequest('250'));
     }
 
+    public function testExitHookAdvisoryOnlyWhenForcedWithoutScheduler(): void
+    {
+        // #454 — hookExit(true) is silently inert without the coroutine scheduler
+        // (the ext exit() interception is scheduler-bound). The advisory fires
+        // ONLY for forced-true + no-scheduler; it stays silent for the auto
+        // (null) default, explicit-off, and forced-true WITH a scheduler.
+        $this->assertNull(App::exitHookAdvisory(null, false));    // auto default → no warn
+        $this->assertNull(App::exitHookAdvisory(null, true));
+        $this->assertNull(App::exitHookAdvisory(false, false));   // explicitly off → no warn
+        $this->assertNull(App::exitHookAdvisory(true, true));      // forced + scheduler → works
+        $adv = App::exitHookAdvisory(true, false);                 // forced + NO scheduler → advise
+        $this->assertIsString($adv);
+        $this->assertStringContainsString('hookExit(true)', $adv);
+        $this->assertStringContainsString('enableCoroutine=false', $adv);
+    }
+
     // ─────────────────────────────────────────────────────────────
     // reasonPhrase() + REASON_PHRASES
     // ─────────────────────────────────────────────────────────────

--- a/tests/Unit/FileExecutionFamilyTest.php
+++ b/tests/Unit/FileExecutionFamilyTest.php
@@ -182,4 +182,15 @@ class FileExecutionFamilyTest extends TestCase
         // 'W[CB||CA]'. A no-selector nested render must not inherit.
         $this->assertSame('W[CB|CRI|CA]', App::render('parent_frag', ['fragment' => 'want'], self::DIR));
     }
+
+    // ── #458: page-scope isolation (app vars don't clobber framework) ──
+
+    public function testPageReassigningGDoesNotClobberFrameworkContext(): void
+    {
+        // #458 — a page assigning an ordinary $g (an array) must NOT corrupt
+        // executeFile()'s RequestContext local (pre-fix: "Attempt to assign
+        // property _ob_floor on array" → 500). The include runs in an isolated
+        // runUserFile() scope, so the page's $g only shadows a throwaway local.
+        $this->assertSame('clobber-ok', App::render('clobbers_g', [], self::DIR));
+    }
 }

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -385,4 +385,32 @@ class UtilsTest extends TestCase
     {
         $this->assertIsBool(set_time_limit(30));
     }
+
+    public function testApacheRequestHeadersFallsBackToServerWhenNoRequestObject(): void
+    {
+        // #453 — a legacy-cgi CGI subprocess has no live OpenSwoole request
+        // object; getallheaders()/apache_request_headers() must reconstruct the
+        // header map from $_SERVER HTTP_* (+ CONTENT_TYPE) — it returned [] on
+        // the pool backend despite the headers being present in $_SERVER.
+        $g = RequestContext::instance();
+        $hadReq = isset($g->zealphp_request);
+        $savedReq = $hadReq ? $g->zealphp_request : null;
+        $savedServer = $_SERVER;
+        try {
+            unset($g->zealphp_request);                 // simulate the subprocess
+            $_SERVER['HTTP_X_PROBE'] = 'hello123';
+            $_SERVER['HTTP_HOST']    = 'example.test';
+            $_SERVER['CONTENT_TYPE'] = 'application/json';
+            $headers = \ZealPHP\apache_request_headers();
+            $this->assertSame('hello123', $headers['X-Probe'] ?? null);
+            $this->assertSame('example.test', $headers['Host'] ?? null);
+            $this->assertSame('application/json', $headers['Content-Type'] ?? null);
+            $this->assertSame($headers, \ZealPHP\getallheaders(), 'getallheaders() must agree');
+        } finally {
+            $_SERVER = $savedServer;
+            if ($hadReq) {
+                $g->zealphp_request = $savedReq;
+            }
+        }
+    }
 }

--- a/tests/fixtures/render/clobbers_g.php
+++ b/tests/fixtures/render/clobbers_g.php
@@ -1,0 +1,8 @@
+<?php
+// #458 fixture — a page that assigns an ordinary variable named $g (a very
+// common name, and ironically ZealPHP's own idiom for the request context).
+// Pre-fix this clobbered executeFile()'s RequestContext local and fatalled at
+// `$g->_ob_floor = …` ("Attempt to assign property _ob_floor on array" → 500).
+// With the isolated runUserFile() scope it must render cleanly.
+$g = ['x' => 1];
+echo 'clobber-ok';


### PR DESCRIPTION
Closes the four remaining open issues from @Guruprasanth-M's legacy-mode sweep. Tested where unit-testable; full Unit suite (4031 tests) green; PHPStan level 10 clean.

### #458 — coroutine-legacy: an app `$g` clobbers the framework RequestContext → 500 (MEDIUM-HIGH)
`executeFile()` ran the page via a plain `include` *in its own scope*, so a page assigning an ordinary `$g` (a very common name — ironically ZealPHP's own idiom) overwrote the framework's RequestContext local; the post-include `$g->_ob_floor = …` then fatalled "Attempt to assign property _ob_floor on array" → 500. The include now runs in an isolated `runUserFile()` helper with `$__zeal_`-prefixed locals, so any name the page reuses (`$g`, `$result`, `$output`, …) only shadows throwaway locals — protecting **all** exposed framework state, not just `$g`.

### #453 — getallheaders() returns [] in legacy-cgi (pool) (HIGH)
The pool CGI subprocess has no live OpenSwoole request object, so `apache_request_headers()` returned `[]` even though the headers were present as `$_SERVER['HTTP_*']` — silently breaking auth / CORS / signature code on the **default** backend (proc worked). It now reconstructs the canonical map from `$_SERVER` HTTP_* (+ CONTENT_TYPE/CONTENT_LENGTH, RFC 3875 §4.1.18 / Apache mod_php) when no request object exists; the in-process path is unchanged.

### #454 — hookExit(true) silently inert in mixed mode (MEDIUM)
The ext `exit()` interception is coroutine-scheduler-bound, so `App::hookExit(true)` in a non-coroutine mode installs the hook but it never fires — `exit()` still throws `OpenSwoole\ExitException` (swallowed by legacy `catch (\Exception)`). Added a boot advisory (`App::exitHookAdvisory()`, a testable seam) so the mismatch is surfaced instead of silent. (True mixed-mode exit interception is an ext-level change; this makes the limitation visible.)

### #457 — `session_set_save_handler` boot warning (LOW)
ext-zealphp denylists `session_set_save_handler`; `zealphp_override()` on it emitted an `E_WARNING` every boot and installed nothing. `overrideBuiltin()` now skips the ext path for it and uses uopz (which can override it — restoring the #295 custom-save-handler routing).

Closes #453, closes #454, closes #457, closes #458.

> #457's behavioral change is only observable with ext-zealphp loaded (the unit env has none), so it has no dedicated unit test — verified by inspection; the warning disappears in the ext-loaded runtime.
