### PR TITLE
fix(#443): fork CGI child iterates a returned Generator/Closure into the response

### DIFF
--- a/src/fork_master.php
+++ b/src/fork_master.php
@@ -412,6 +412,24 @@ while ($__fm_running) {
             try {
                 /** @psalm-suppress UnresolvableInclude */
                 $__fm_result = include $__fm_file;   // ← TRUE GLOBAL SCOPE
+                // #443 — a returned Closure/Generator is the documented SSR-stream
+                // idiom; pool/proc (cgi_worker.php) invoke + iterate it into the
+                // response body. The fork child must too, else the streamed output
+                // is silently lost (empty 200, Content-Length: 0 — the Generator is
+                // never iterated). Resolve it while the output buffer is still
+                // active so the chunks (and any echo inside the generator) are
+                // captured into $__fm_body below, in wire order.
+                if ($__fm_result instanceof \Closure) {
+                    // Param injection across the fork pipe is unsupported (the
+                    // documented CGI limitation) — invoke with no args, as cgi_worker.
+                    $__fm_result = $__fm_result();
+                }
+                if ($__fm_result instanceof \Generator) {
+                    foreach ($__fm_result as $__fm_chunk) {
+                        echo \is_scalar($__fm_chunk) ? (string) $__fm_chunk : '';
+                    }
+                    $__fm_result = null;   // streamed output captured into the body
+                }
             } catch (\Throwable $e) {
                 $__fm_resp = ['status' => 500, 'body' => 'fork_master: ' . $e->getMessage(), 'headers' => [], 'cookies' => [], 'rawcookies' => []];
                 while (ob_get_level() > 0) { ob_end_clean(); }


### PR DESCRIPTION
Closes #443.

`legacy-cgi` `cgiMode('fork')` served an empty `200` (`Content-Length: 0`) for any `.php` that returns a Generator — the documented universal-contract SSR idiom `return (function(){ yield …; })();`. `fork_build_response()` classifies a "real" return as only `int|array|string`, so a Generator fell through to `null` and was never iterated; the streamed output was silently lost. `pool` and `proc` (`cgi_worker.php`) handle it — they invoke a returned Closure and iterate a returned Generator into the response body.

The fork child now does the same: it resolves a returned Closure/Generator **while the output buffer is still active**, so the chunks (and any `echo` inside the generator) are captured into the response body in wire order. Closure / Generator / scalar / array / echo returns now all round-trip under `fork`, matching pool/proc and the in-process modes.

Param injection into a returned Closure across the fork pipe remains unsupported (the documented CGI limitation — reflection doesn't survive the process boundary), matching `cgi_worker.php`.

> `fork_master.php` is a forked-subprocess entry point (not exercised by the unit harness, and phpstan-excluded), so there's no dedicated unit test — the fix is verified by inspection against the already-working `cgi_worker.php` Closure/Generator path it mirrors.
