### PR TITLE
fix(ext#55): async-log consumer coroutine leak under coroutine-legacy

### DIFF
--- a/src/utils.php
+++ b/src/utils.php
@@ -398,12 +398,34 @@ function log_file_for(string $kind): ?string
  * The consumer goroutine falls back to `php://stderr` when the file cannot be
  * opened (avoids silent log loss). Results are memoised per path.
  */
+/**
+ * Per-worker registry for the async-log sinks and their consumer-spawn guard.
+ *
+ * Held on a BOOT CLASS static — defined here in src/utils.php (a composer
+ * `files` autoload entry, loaded at worker boot) ON PURPOSE. Under
+ * `coroutine-legacy` mode, function-local `static` variables are isolated
+ * per-coroutine (Stage 5a) AND reset to their template at the end of every
+ * request (Stage 11). `log_sink_for()` previously memoised `$sinks`/`$started`
+ * as function statics, so the consumer-spawn guard was empty on EVERY request →
+ * a fresh `Channel` + detached consumer `go()` was spawned per request, blocked
+ * forever on `pop()`, accumulating until OpenSwoole's `max_coroutine` cap was
+ * hit (issue #55). A boot-class static is exempt from the per-request reset, so
+ * the memoisation correctly survives for the worker's lifetime.
+ */
+final class LogSinkRegistry
+{
+    /** @var array<string, \OpenSwoole\Coroutine\Channel> */
+    public static array $sinks = [];
+    /** @var array<string, bool> */
+    public static array $started = [];
+}
+
 function log_sink_for(string $path): ?\OpenSwoole\Coroutine\Channel
 {
     /** @var array<string, \OpenSwoole\Coroutine\Channel> $sinks */
-    static $sinks = [];
+    $sinks = &LogSinkRegistry::$sinks;
     /** @var array<string, bool> $started */
-    static $started = [];
+    $started = &LogSinkRegistry::$started;
 
     if (isset($sinks[$path])) {
         return $sinks[$path];

--- a/tests/Unit/UtilsLoggingTest.php
+++ b/tests/Unit/UtilsLoggingTest.php
@@ -9,7 +9,9 @@ use ZealPHP\Tests\TestCase;
 
 use function ZealPHP\resolve_log_dir;
 use function ZealPHP\log_file_for;
+use function ZealPHP\log_sink_for;
 use function ZealPHP\log_write;
+use ZealPHP\LogSinkRegistry;
 use function ZealPHP\debug_logging_enabled;
 use function ZealPHP\access_logging_enabled;
 use function ZealPHP\async_logging_enabled;
@@ -471,5 +473,43 @@ class UtilsLoggingTest extends TestCase
         $this->assertFalse(\ZealPHP\apache_getenv('NOPE', true));
         \ZealPHP\apache_setenv('WALKVAR', 'wval', true);
         $this->assertSame('wval', \ZealPHP\apache_getenv('WALKVAR', true));
+    }
+
+    // ── async-log sink registry (#55 regression) ─────────────────
+    //
+    // log_sink_for() memoizes the async Channel sink + consumer-spawn guard on
+    // the BOOT-CLASS static LogSinkRegistry, NOT function-local statics. Under
+    // coroutine-legacy, function statics reset every request (Stage 11), which
+    // emptied the guard and spawned a fresh Channel + detached consumer go() per
+    // request — accumulating to OpenSwoole's max_coroutine cap (#55). A boot
+    // class static survives the per-request reset. The full no-leak behaviour is
+    // integration-verified (needs a live coroutine scheduler); here we pin the
+    // structural contract that the memoisation lives on the class static.
+
+    public function testLogSinkRegistryIsBootClassWithStaticArrayState(): void
+    {
+        $rc = new \ReflectionClass(LogSinkRegistry::class);
+        $this->assertTrue($rc->isFinal(), 'LogSinkRegistry should be final');
+        foreach (['sinks', 'started'] as $name) {
+            $prop = $rc->getProperty($name);
+            $this->assertTrue($prop->isStatic(), "$name must be static (boot-class state)");
+            $this->assertTrue($prop->isPublic(), "$name must be public");
+        }
+    }
+
+    public function testLogSinkForMemoizesViaRegistryClassStatic(): void
+    {
+        // A pre-seeded registry entry short-circuits log_sink_for() at the top
+        // (before any coroutine/async gate), proving the function reads the
+        // boot-class static — so the guard survives per-request resets and the
+        // consumer go() is spawned at most once per path per worker.
+        $path = sys_get_temp_dir() . '/zealphp-test-sink-' . uniqid() . '.log';
+        $channel = new \OpenSwoole\Coroutine\Channel(1);
+        LogSinkRegistry::$sinks[$path] = $channel;
+        try {
+            $this->assertSame($channel, log_sink_for($path));
+        } finally {
+            unset(LogSinkRegistry::$sinks[$path]);
+        }
     }
 }


### PR DESCRIPTION
## Root cause (ext-zealphp#55 reframed)

`log_sink_for()` memoised the async `Channel` sink + consumer-spawn guard in **function-local statics**. Under `coroutine-legacy` those isolate per-coroutine (Stage 5a) and reset to their template every request (Stage 11), so the once-guard (`$started`) was empty on **every** request → a fresh `Channel(8192)` + a detached consumer `go()` spawned per request, each blocked forever on `pop()`, accumulating to OpenSwoole's `max_coroutine` cap.

This is the actual root cause of the ~10k live coroutines reported as a *snapshot leak* in **ext-zealphp#55** — the per-coroutine snapshot tables faithfully track those live coroutines, so the extension is **not** at fault and no ext change is needed.

## Fix
Move the registry to a **boot-class static** (`LogSinkRegistry`, in the `files`-autoloaded `src/utils.php`), which is exempt from the per-request reset. The consumer now spawns at most once per path per worker.

**Validated** on a coroutine-legacy app: 100k requests → `coroutine_num=2` (was 10000); access log intact.

## Also
- `chore(phpstan)`: `ignoreErrors` entry for `zealphp_process_state_clean()` (ext arginfo under-declares its optional int param; `stubFiles` doesn't override loaded-ext reflection). Matches the existing `OpenSwoole\Timer::clear` pattern.

## Tests
- New unit tests pin the boot-class-static memoisation contract (`tests/Unit/UtilsLoggingTest.php`).
- Full unit suite green (4033); PHPStan L10 clean.