### PR TITLE
feat: echo/print interleave with yield in streamed generators

### DIFF
--- a/route/streaming.php
+++ b/route/streaming.php
@@ -146,3 +146,32 @@ $app->route('/stream/events', function($response) {
         $emit(json_encode(['message' => 'stream complete']), 'done');
     });
 });
+
+// ---------------------------------------------------------------------------
+// 4. echo / print interleaved with yield
+//    Inside a generator body, echo and print follow the universal return
+//    contract just like yield — streamed to the client in source order, not
+//    leaked to the server's stdout. This endpoint emits exactly "ABCDE".
+// ---------------------------------------------------------------------------
+$app->route('/stream/echo-yield', function() {
+    return (function() {
+        echo 'A';        // buffered, flushed before the next yield
+        yield 'B';
+        print 'C';       // print behaves like echo
+        yield 'D';
+        echo 'E';        // trailing output after the final yield
+    })();
+});
+
+// ---------------------------------------------------------------------------
+// 5. echo BEFORE returning a generator
+//    A handler that echoes and then returns a generator: the pre-generator
+//    output is prepended to the stream (source order preserved). Emits "PREGEN".
+// ---------------------------------------------------------------------------
+$app->route('/stream/pre-echo', function() {
+    echo 'PRE';
+    return (function() {
+        yield 'G';
+        yield 'EN';
+    })();
+});

--- a/src/App.php
+++ b/src/App.php
@@ -1505,20 +1505,51 @@ class App
         }
         // @phpstan-ignore-next-line — zealphp_response set by CoSessionManager before any route dispatches
         $g->zealphp_response->flush();
-        foreach ($object as $chunk) {
-            // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
-            if (!$g->openswoole_response->isWritable()) break;
-            // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
-            $g->openswoole_response->write((string)$chunk);
-            // #354 — yield to the scheduler ONLY when inside a coroutine.
-            // In mixed mode (enable_coroutine=false) the handler runs outside
-            // any coroutine, so Coroutine::sleep(0) throws "API must be called
-            // in the coroutine" → uncaught → worker exits status=255 with a
-            // truncated, unterminated chunked stream. write() already flushes
-            // each chunk; the yield is only a concurrency nicety, and there are
-            // no peer coroutines to yield to when enable_coroutine is off.
-            if (\OpenSwoole\Coroutine::getCid() > 0) {
-                \OpenSwoole\Coroutine::sleep(0);
+        // Capture echo/print emitted INSIDE the generator body (between yields)
+        // so it follows the universal return contract — streamed to the client
+        // in wire order — instead of leaking to the server's stdout. A handler
+        // that interleaves `echo "a"; yield "b"; echo "c"; yield "d";` writes
+        // a, b, c, d in source order. `print` is `echo` with a return value, so
+        // capturing the output buffer covers it too.
+        $obLevel = \ob_get_level();
+        \ob_start();
+        try {
+            foreach ($object as $chunk) {
+                // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                if (!$g->openswoole_response->isWritable()) break;
+                // Flush any echo/print buffered BEFORE this yield first, so output
+                // emitted earlier in the generator body precedes the yielded chunk.
+                $buffered = \ob_get_contents();
+                if ($buffered !== false && $buffered !== '') {
+                    \ob_clean();
+                    // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                    $g->openswoole_response->write($buffered);
+                }
+                // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                $g->openswoole_response->write((string)$chunk);
+                // #354 — yield to the scheduler ONLY when inside a coroutine.
+                // In mixed mode (enable_coroutine=false) the handler runs outside
+                // any coroutine, so Coroutine::sleep(0) throws "API must be called
+                // in the coroutine" → uncaught → worker exits status=255 with a
+                // truncated, unterminated chunked stream. write() already flushes
+                // each chunk; the yield is only a concurrency nicety, and there are
+                // no peer coroutines to yield to when enable_coroutine is off.
+                if (\OpenSwoole\Coroutine::getCid() > 0) {
+                    \OpenSwoole\Coroutine::sleep(0);
+                }
+            }
+        } finally {
+            // Always tear down our buffer level. Flush any trailing echo/print
+            // (output after the final yield, or a generator that only echoes and
+            // never yields) before the stream ends; on an exception this still
+            // closes the level and the throw propagates to the dispatch handler.
+            if (\ob_get_level() > $obLevel) {
+                $trailing = \ob_get_clean();
+                // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                if ($trailing !== false && $trailing !== '' && $g->openswoole_response->isWritable()) {
+                    // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
+                    $g->openswoole_response->write($trailing);
+                }
             }
         }
         // @phpstan-ignore-next-line — openswoole_response set by CoSessionManager before any route dispatches
@@ -7170,7 +7201,7 @@ class App
      * is "echo first, then stream". Returns a new Generator that yields the
      * buffered chunk before delegating to the original.
      */
-    private static function prependToStreamable(string $prefix, \Generator $gen): \Generator
+    public static function prependToStreamable(string $prefix, \Generator $gen): \Generator
     {
         yield $prefix;
         yield from $gen;

--- a/src/ResponseMiddleware.php
+++ b/src/ResponseMiddleware.php
@@ -350,9 +350,17 @@ class ResponseMiddleware implements MiddlewareInterface
             ob_start();
             $object = call_user_func_array($handler, $invokeArgs);
 
-            // Fast paths — discard output buffer without string copy
             if ($object instanceof \Generator) {
-                ob_end_clean();
+                // A handler may echo/print BEFORE returning a generator
+                // (`echo "header"; return (function(){ yield ...; })();`). Capture
+                // that output and prepend it so it streams in source order instead
+                // of being lost — matching the universal return contract. For a
+                // plain generator function (no pre-return echo) the buffer is
+                // empty, so this is a cheap ob_get_clean() returning ''.
+                $pre = ob_get_clean();
+                if ($pre !== false && $pre !== '') {
+                    $object = App::prependToStreamable($pre, $object);
+                }
                 return App::emitGeneratorStream($object, $method);
             }
 

--- a/tests/Integration/StreamingTest.php
+++ b/tests/Integration/StreamingTest.php
@@ -23,6 +23,31 @@ class StreamingTest extends TestCase
         $this->assertStringContainsString('Posts', $r['body']);
     }
 
+    /**
+     * echo / print inside a generator body follow the universal return contract:
+     * streamed to the client in source order (interleaved with the yields), not
+     * leaked to the server's stdout. /stream/echo-yield emits exactly "ABCDE"
+     * from: echo 'A'; yield 'B'; print 'C'; yield 'D'; echo 'E';
+     */
+    public function testEchoAndPrintInterleaveWithYieldInSourceOrder(): void
+    {
+        $r = $this->get('/stream/echo-yield');
+        $this->assertStatus(200, $r);
+        $this->assertSame('ABCDE', $r['body']);
+    }
+
+    /**
+     * A handler that echoes BEFORE returning a generator: the pre-generator
+     * output is prepended to the stream rather than discarded. /stream/pre-echo
+     * emits "PRE" then the generator's "G" + "EN" → "PREGEN".
+     */
+    public function testEchoBeforeReturnedGeneratorIsPrepended(): void
+    {
+        $r = $this->get('/stream/pre-echo');
+        $this->assertStatus(200, $r);
+        $this->assertSame('PREGEN', $r['body']);
+    }
+
     public function testStreamCallbackReturns200(): void
     {
         $r = $this->get('/stream/words');


### PR DESCRIPTION
## What

Inside a generator handler, `echo`/`print` now follow the universal return contract — **streamed to the client in source order, interleaved with the yields** — instead of leaking to the server's stdout.

```php
$app->route('/stream/echo-yield', fn() => (function () {
    echo 'A'; yield 'B'; print 'C'; yield 'D'; echo 'E';
})());          // => wire body: ABCDE
```

## How
- `App::emitGeneratorStream()` wraps generator iteration in an output buffer; flushes any buffered `echo`/`print` **before** each yielded chunk (preserving order), with a trailing flush after the final yield and a `try/finally` so the buffer level is always torn down. `print` is captured the same way (it writes the output buffer like `echo`).
- `ResponseMiddleware` now captures+prepends a handler's **pre-generator** echo (`echo "x"; return $gen;`) instead of discarding it; `App::prependToStreamable()` is made public for that.

## Tests
- Demo routes `/stream/echo-yield` (→ `ABCDE`) and `/stream/pre-echo` (→ `PREGEN`).
- Integration tests assert exact wire order (`tests/Integration/StreamingTest.php`).
- StreamingTest 8/8, Routing+HttpFeatures 42/42, full unit suite 4033 green, PHPStan L10 clean.

## Note
Output is flushed at yield boundaries (buffered between yields), which is exactly the wire order you want for interleaved echo/yield; a trailing bare `echo` with no following yield is flushed at stream end.