### PR TITLE
chore: release v0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.4.12] - 2026-06-25
+
+### Added
+- **`echo`/`print` now interleaves correctly with `yield` in streamed generators** — a streamed generator (route handler or streaming template) that both `echo`es and `yield`s now flushes the two in wire order instead of buffering the `echo` output until after the generator drains. The output-buffer level captured at generator entry is restored around each `yield`, so a handler can freely mix `echo "<chunk>"` and `yield "<chunk>"` and the bytes land in source order.
+
+### Fixed
+- **Async-log consumer coroutine leak under coroutine-legacy — FIXED** (consumed via [ext-zealphp 0.3.59](https://github.com/sibidharan/ext-zealphp/releases/tag/v0.3.59); [ext#55](https://github.com/sibidharan/ext-zealphp/issues/55)) — the async-logging consumer coroutine could leak under coroutine-legacy; the consumer lifecycle is now bounded.
+- **Fork-CGI child now streams a returned `Generator`/`Closure`** ([#443](https://github.com/sibidharan/zealphp/issues/443)) — a `cgiMode('fork')` child that returns a `Generator` or `Closure` from the included file now iterates it into the response (universal return-contract parity with the in-process and `proc` paths) instead of dropping it.
+- **coroutine-legacy page-scope isolation + exit-hook advisory + session-handler override** ([#458](https://github.com/sibidharan/zealphp/issues/458), [#454](https://github.com/sibidharan/zealphp/issues/454), [#457](https://github.com/sibidharan/zealphp/issues/457)).
+- **`getallheaders()` / `apache_request_headers()` in the CGI subprocess** ([#453](https://github.com/sibidharan/zealphp/issues/453)) — both now reconstruct the request header set from `$_SERVER`'s `HTTP_*` entries inside the CGI subprocess, so legacy apps that call them see the real inbound headers.
+- **htmx separate-template + nested-fragment render fixes** ([#444](https://github.com/sibidharan/zealphp/issues/444), [#446](https://github.com/sibidharan/zealphp/issues/446)).
+- **`ZEALPHP_MAX_REQUEST=0` now disables worker recycle** ([#449](https://github.com/sibidharan/zealphp/issues/449)) — the max-request resolver used a falsy `?:` check, so `0` (the documented "never recycle" value) fell through to the default. It is now a presence check, so `0` means unbounded.
+- **Upload shims accept `null` like native PHP** ([#455](https://github.com/sibidharan/zealphp/issues/455)) — optional file-upload helpers no longer 500 on a missing/`null` upload.
+- **`StringUtils::get_string_between()` returns `''` when the end delimiter is absent** ([#448](https://github.com/sibidharan/zealphp/issues/448)).
+- **`App::render()` template resolution confined to the template dir** ([#442](https://github.com/sibidharan/zealphp/issues/442)) — path-traversal hardening on the template name.
+- **`SERVER_NAME` is host-only** ([#459](https://github.com/sibidharan/zealphp/issues/459)) — the port is stripped from the `Host` header when populating `$_SERVER['SERVER_NAME']`.
+
+### Changed
+- **Docker base image bumped to PHP 8.5** (`8.4-cli-bookworm` → `8.5-cli-bookworm`).
+- CI/dev dependency bumps: `actions/checkout` 6.0.3→7.0.0, `codecov/codecov-action` 6.0.1→7.0.0, the actions-minor-and-patch group, `predis/predis` 2.4.1→3.5.1, `phpstan/phpstan`, `infection/infection`.
+
+### Documentation
+- **PSR interoperability table in `STANDARDS.md`; over-claimed PSR-11 dropped** ([#451](https://github.com/sibidharan/zealphp/issues/451)).
+- **Four user-facing isolation/exit `ZEALPHP_*` knobs documented** ([#450](https://github.com/sibidharan/zealphp/issues/450)).
+- **API page: the verb-named-file gotcha** — `$get` in `api/php/get.php` is a *filename match* (serves every HTTP method), not per-method dispatch; documented with the `${basename(__FILE__, '.php')}` canonical form.
+- Return-contract note scoped to the `executeFile()` entry points plus Copilot-review follow-ups ([#445](https://github.com/sibidharan/zealphp/issues/445)); Learn-section link added to the docs index; agent reference refreshed.
+
 ## [0.4.11] - 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project zealphp/project:^0.4.11 my-project
+composer create-project zealphp/project:^0.4.12 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -469,16 +469,16 @@ The fine-grained setters (`App::superglobals()`, `App::isolation()`, `App::enabl
 2. Run `composer validate`, `./vendor/bin/phpunit`, and `./vendor/bin/phpstan analyse --no-progress` (level 10, zero errors).
 3. Open a release PR, wait for required checks to go green, and merge (rebase):
    ```bash
-   git checkout -b release/v0.4.11
-   git commit -am "chore: release v0.4.11"
-   git push origin1 release/v0.4.11
-   gh pr create --base master --head release/v0.4.11 --title "chore: release v0.4.11"
+   git checkout -b release/v0.4.12
+   git commit -am "chore: release v0.4.12"
+   git push origin1 release/v0.4.12
+   gh pr create --base master --head release/v0.4.12 --title "chore: release v0.4.12"
    ```
 4. After merge, tag the merged commit and push to both remotes (tags aren't protected):
    ```bash
    git checkout master && git pull origin1 master --ff-only
-   git tag -a v0.4.11 -m "Release v0.4.11"
-   git push origin v0.4.11 && git push origin1 v0.4.11
+   git tag -a v0.4.12 -m "Release v0.4.12"
+   git push origin v0.4.12 && git push origin1 v0.4.12
    ```
 5. Bump `zealphp/project` (the scaffold) to the same version and refresh its `llms.txt`. Packagist auto-syncs via webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -219,7 +219,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.11 .
+docker build -t zealphp:0.4.12 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -231,7 +231,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.11 .
+    -t zealphp:0.4.12 .
 ```
 
 ### Run (single container)
@@ -243,7 +243,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.11
+    zealphp:0.4.12
 ```
 
 ### Production compose
@@ -254,7 +254,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.11
+    image: registry.example.com/zealphp-app:0.4.12
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/api.php
+++ b/template/pages/api.php
@@ -85,6 +85,10 @@ PHP]); ?>
 <strong>Don't mix both conventions in one file.</strong> If <code>api/list.php</code> defines both <code>$list</code> (filename match) <em>and</em> <code>$get</code>/<code>$post</code>, the filename match wins and method handlers are unreachable. The framework logs a warning to <code>debug.log</code> when this happens.
 </div>
 
+<div class="callout warning">
+<strong>Watch the verb-named file gotcha.</strong> <code>$get</code>/<code>$post</code>/… aren't globally "reserved" — but if the <em>filename itself</em> is an HTTP verb (e.g. <code>api/php/get.php</code>), then <code>$get</code> is a <strong>filename match</strong> (it equals <code>${basename(__FILE__, '.php')}</code> and serves every method), <em>not</em> per-method dispatch. Filename match always wins, so a verb-named file can never do per-method routing. To dispatch by method, put the handlers in a non-verb-named file (<code>api/users.php</code> → <code>$get</code>/<code>$post</code>). The framework logs a <code>debug.log</code> warning when <code>$get</code> in <code>get.php</code> collapses to a filename match.
+</div>
+
 <h2>Return value conventions</h2>
 <p>API handlers ride the <a href="/responses#return-contract">universal return contract</a> — same shapes as route handlers, public files, <code>App::render()</code>, and <code>App::include()</code>. <code>int</code> = status, <code>array</code> = JSON, <code>string</code> = HTML, <code>Generator</code> = stream, <code>ResponseInterface</code> = PSR-7 used directly.</p>
 
@@ -111,9 +115,13 @@ PHP]); ?>
     'label' => 'Magic parameters: $request, $response, $app, $server (auto-injected by name)',
     'code'  => <<<'PHP'
 <?php
+// File: api/user/show.php  →  /api/user/show
+// Canonical convention: the closure variable name matches the filename
+// (basename without .php). One handler serves EVERY HTTP method — branch
+// on the verb with $this->get_request_method() if you need to.
 use ZealPHP\RequestContext;
 
-$get = function($request, $response) {
+${basename(__FILE__, '.php')} = function($request, $response) {
     // ZealAPI's dispatcher injects these by parameter name (reflection-cached):
     //   $request  → ZealPHP\HTTP\Request  (wrapped OpenSwoole request; alias: $req)
     //   $response → ZealPHP\HTTP\Response (wrapped OpenSwoole response; alias: $res)
@@ -277,8 +285,11 @@ $sapi_name = function() {
 };
 PHP],
   ['api-get',  'GET /api/php/get — dump GET params',          '/api/php/get?demo=zealapi&works=true', <<<'PHP'
-// api/php/get.php
-$get = function() {
+// api/php/get.php → /api/php/get
+// NOTE: $get here is a FILENAME MATCH (the file is named get.php), NOT
+// per-method dispatch. ${basename(__FILE__, '.php')} resolves to $get and
+// serves every HTTP method. See the gotcha under "Per-method dispatch".
+${basename(__FILE__, '.php')} = function() {
     $g = G::instance();
     return ['query_params' => $g->get, 'async' => php_sapi_name() === 'cli'];
 };

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.4.11
+    image: zealphp:0.4.12
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -178,7 +178,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  zealphp/project:^0.4.11 \
+  zealphp/project:^0.4.12 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, state isolated coroutines, shared memory, task workers &mdash;
        first&#8209;class. Powered by Openswoole. Isolated by <em>ext-zealphp.</em></p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.4.11 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.4.12 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -306,7 +306,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project zealphp/project:^0.4.11 my-app</span><button class="qs-copy" data-copy="composer create-project zealphp/project:^0.4.11 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project zealphp/project:^0.4.12 my-app</span><button class="qs-copy" data-copy="composer create-project zealphp/project:^0.4.12 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>


### PR DESCRIPTION
Release **v0.4.12** — fix wave + echo/yield interleave + ext#55 async-log fix.

### Added
- `echo`/`print` interleaves with `yield` in streamed generators (wire-order flush).

### Fixed
- ext#55 async-log consumer coroutine leak under coroutine-legacy (consumed via [ext-zealphp 0.3.59](https://github.com/sibidharan/ext-zealphp/releases/tag/v0.3.59)).
- #443 fork-CGI child streams a returned Generator/Closure.
- #458/#454/#457 coroutine-legacy page-scope isolation + exit-hook advisory + session-handler override.
- #453 getallheaders()/apache_request_headers() in the CGI subprocess.
- #444/#446 htmx separate-template + nested-fragment render fixes.
- #449 ZEALPHP_MAX_REQUEST=0 disables worker recycle (presence check).
- #455 upload shims accept null. #448 get_string_between empty on missing end delim.
- #442 App::render() template resolution confined to template dir. #459 SERVER_NAME host-only.

### Changed
- Docker base image PHP 8.4 → 8.5; CI/dev dependency bumps.

### Documentation
- PSR interoperability table (#451); 4 isolation/exit ZEALPHP_* env knobs (#450); API verb-named-file gotcha; return-contract scoping (#445).

All 24 commits since v0.4.11 already passed CI on merge; this PR bumps version refs + CHANGELOG + one doc callout (no instrumented `src/` changes).