### PR TITLE
docs: refresh agent reference snapshot for v0.4.12

### DIFF
--- a/examples/agents/zealphp_reference.txt
+++ b/examples/agents/zealphp_reference.txt
@@ -4821,7 +4821,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.11 .
+docker build -t zealphp:0.4.12 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -4833,7 +4833,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.11 .
+    -t zealphp:0.4.12 .
 ```
 
 ### Run (single container)
@@ -4845,7 +4845,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.11
+    zealphp:0.4.12
 ```
 
 ### Production compose
@@ -4856,7 +4856,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.11
+    image: registry.example.com/zealphp-app:0.4.12
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
Regenerated `examples/agents/zealphp_reference.txt` via `make docs-rebuild` after the v0.4.12 release — picks up the `docs/deployment.md` version-string bump (0.4.11 → 0.4.12). Snapshot-only; no `src/` changes.