### PR TITLE
fix(#485): unbounded api/ endpoint nesting — fold deep tail dirs into $module in processApi()

### DIFF
--- a/api/nested/deep/probe.php
+++ b/api/nested/deep/probe.php
@@ -1,0 +1,5 @@
+<?php
+// #485 integration fixture — 2 directory levels: /api/nested/deep/probe
+$probe = function () {
+    return ['ok' => true, 'levels' => 2];
+};

--- a/api/nested/deep/very/probe2.php
+++ b/api/nested/deep/very/probe2.php
@@ -1,0 +1,5 @@
+<?php
+// #485 integration fixture — 3 directory levels: /api/nested/deep/very/probe2
+$probe2 = function () {
+    return ['ok' => true, 'levels' => 3];
+};

--- a/api/nested/ping.php
+++ b/api/nested/ping.php
@@ -1,0 +1,5 @@
+<?php
+// #485 integration fixture — 1 directory level (control): /api/nested/ping
+$ping = function () {
+    return ['ok' => true, 'levels' => 1];
+};

--- a/src/App.php
+++ b/src/App.php
@@ -9713,10 +9713,13 @@ class App
         # dir) keep the implicit routes AND the #347 404 for an unmatched method.
         #
         # The two-segment route is registered FIRST so that /api/users/list
-        # matches with module=users, request=list (a single segment passing
-        # the security regex), instead of being captured by the one-segment
-        # catch-all as request="users/list" — which contains a slash and
-        # would fail validation with a misleading "invalid_request" error.
+        # matches with module=users, request=list, instead of being captured
+        # by the one-segment catch-all as request="users/list". For URLs
+        # nested DEEPER than one directory level the catch-all still puts the
+        # whole tail in {rquest} (module="a", rquest="b/c/d") — processApi()
+        # folds the tail's directory components back into $module before
+        # validation (#485), so endpoint files may nest arbitrarily deep
+        # under api/, exactly like filesystem routing under mod_php.
         if (is_dir(self::$cwd . '/api')) {
             $this->nsPathRoute('api', "{module}/{rquest}", [
                 'methods' => ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']

--- a/src/ZealAPI.php
+++ b/src/ZealAPI.php
@@ -131,13 +131,43 @@ class ZealAPI extends REST
      * injects named parameters, applies any in-file `$middleware`, and returns the
      * result through the universal return contract.
      *
-     * @param string      $module  URL sub-path (e.g. `'device'` for `/api/device/list`)
-     * @param string|null $request Basename without `.php` (e.g. `'list'`)
+     * @param string      $module  URL sub-path (e.g. `'device'` for `/api/device/list`).
+     *                             May be arbitrarily nested (`'a/b/c'`) — slashes become
+     *                             directory components under `api/`.
+     * @param string|null $request Handler basename without `.php` (e.g. `'list'`). A
+     *                             slashed tail (what the implicit route's catch-all
+     *                             captures for nested URLs, e.g. `'notes/download'`) is
+     *                             accepted: its directory components are folded into
+     *                             `$module` before validation (#485).
      * @return mixed
      */
     public function processApi($module, $request=null)
     {
         $g = RequestContext::instance();
+
+        // #485: the implicit /api routes compile their LAST {param} as a
+        // slash-matching catch-all, so a nested URL arrives with the whole
+        // path tail in $request — /api/programs/notes/download dispatches as
+        // $module="programs", $request="notes/download" — while file
+        // resolution needs the directories in $module (slashes are legal
+        // there and become path components under api/) and the slash-free
+        // script basename in $request. Fold the tail's directories into
+        // $module so endpoint nesting depth is unbounded, exactly like
+        // filesystem routing under mod_php/FPM. Malformed tails (an empty
+        // segment from a leading, trailing, or doubled slash) are left
+        // untouched so the strict $request validation below keeps rejecting
+        // them with 400 invalid_request, exactly as before. Traversal stays
+        // impossible downstream: the $module regex admits no dots and the
+        // realpath() containment gate is unchanged.
+        if (\is_string($request) && ($slash = \strrpos($request, '/')) !== false) {
+            $dirs = \substr($request, 0, $slash);
+            $base = \substr($request, $slash + 1);
+            if ($dirs !== '' && $base !== '' && !\str_contains('/' . $dirs . '/', '//')) {
+                $module  = ($module ? $module . '/' : '') . $dirs;
+                $request = $base;
+            }
+        }
+
         $module = $module ? '/'.$module : '';
         $func = basename($request ?? '');
 

--- a/tests/Integration/ZealApiNestedRoutingTest.php
+++ b/tests/Integration/ZealApiNestedRoutingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Integration;
+
+use ZealPHP\Tests\TestCase;
+
+/**
+ * #485 — file-based api/ endpoints nested more than one directory deep must be
+ * reachable at ANY depth (filesystem-is-the-router parity with mod_php/FPM),
+ * and the deep-dispatch fold must NOT weaken the validation/traversal posture:
+ * dots are impossible in both components (charset regexes run on the decoded
+ * path), empty segments still 400, and the realpath() jail still gates every
+ * on-disk resolution. Fixtures: api/nested/ping.php, api/nested/deep/probe.php,
+ * api/nested/deep/very/probe2.php.
+ */
+final class ZealApiNestedRoutingTest extends TestCase
+{
+    // ── functional: unbounded nesting depth ─────────────────────────────
+
+    public function testOneLevelControlStillWorks(): void
+    {
+        $res = $this->get('/api/nested/ping');
+        $this->assertStatus(200, $res);
+        $json = $this->assertJsonResponse($res);
+        $this->assertTrue($json['ok']);
+        $this->assertSame(1, $json['levels']);
+    }
+
+    public function testTwoDirectoryLevelsReachable(): void
+    {
+        $res = $this->get('/api/nested/deep/probe');
+        $this->assertStatus(200, $res);
+        $json = $this->assertJsonResponse($res);
+        $this->assertTrue($json['ok']);
+        $this->assertSame(2, $json['levels']);
+    }
+
+    public function testThreeDirectoryLevelsReachable(): void
+    {
+        $res = $this->get('/api/nested/deep/very/probe2');
+        $this->assertStatus(200, $res);
+        $json = $this->assertJsonResponse($res);
+        $this->assertTrue($json['ok']);
+        $this->assertSame(3, $json['levels']);
+    }
+
+    public function testDeepMissingFileIs404NotFound(): void
+    {
+        // Deep path passes validation now, so the absent file must hit the
+        // realpath 404 gate — not a 400 and never a 500.
+        $res = $this->get('/api/nested/deep/very/definitely-absent');
+        $this->assertStatus(404, $res);
+        $json = $this->assertJsonResponse($res);
+        $this->assertSame('method_not_found', $json['error']);
+    }
+
+    // ── adversarial: the fold must not open traversal or malformed paths ─
+
+    public function testDotDotTraversalIsRejected(): void
+    {
+        // '.' is outside both charset regexes — traversal can't even reach
+        // file resolution. Accept either component's 400 (or a router-level
+        // 404), but never 200/500.
+        $res = $this->get('/api/nested/../../composer/installed');
+        $this->assertContains($res['status'], [400, 404]);
+        $this->assertNotSame(500, $res['status']);
+    }
+
+    public function testEncodedDotDotTraversalIsRejected(): void
+    {
+        // %2e%2e decodes to '..' before routing — same rejection.
+        $res = $this->get('/api/nested/%2e%2e/%2e%2e/composer/installed');
+        $this->assertContains($res['status'], [400, 404]);
+    }
+
+    public function testPhpSuffixedDeepPathIsRejected(): void
+    {
+        // Dots are impossible in $request too — no direct .php probing.
+        $res = $this->get('/api/nested/deep/probe.php');
+        $this->assertContains($res['status'], [400, 403, 404]);
+    }
+
+    public function testDoubledSlashSegmentStillRejected(): void
+    {
+        // Empty segment ⇒ the fold refuses; strict validation 400s as before
+        // (a proxy/normalizer collapsing to the clean path making it 200 is
+        // also acceptable — what must never happen is a 500 or a different
+        // file being served).
+        $res = $this->get('/api/nested//ping');
+        $this->assertContains($res['status'], [200, 400, 404]);
+        $this->assertNotSame(500, $res['status']);
+        if ($res['status'] === 400) {
+            $json = $this->assertJsonResponse($res);
+            $this->assertSame('invalid_request', $json['error']);
+        }
+    }
+
+    public function testTrailingSlashStillRejected(): void
+    {
+        $res = $this->get('/api/nested/deep/probe/');
+        // Never a 500, and never a "wrong handler" 200 body: if a trailing-
+        // slash normalizer upstream redirects/serves the clean path, the body
+        // must be the probe's own.
+        $this->assertNotSame(500, $res['status']);
+        if ($res['status'] === 200) {
+            $json = $this->assertJsonResponse($res);
+            $this->assertSame(2, $json['levels']);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #485.

## The bug
Any `api/` endpoint nested **two or more directories deep** was unreachable at any depth (400 `invalid_request`) in **all lifecycle modes**: the implicit `/api/{module}/{rquest}` route compiles its last `{param}` as a slash-matching catch-all, so `/api/a/b/c/d` dispatched as `module="a"`, `rquest="b/c/d"` — but `processApi()` validates `$request` as slash-free, while file resolution needs the tail's directories in `$module` (where slashes are legal path components). The two halves could never agree beyond one directory level.

## The fix
In `processApi()` itself (so it covers the implicit routes **and** direct callers): before validation, split a slashed `$request` tail on its **last** slash and fold the directory part into `$module` — `module="a/b/c"`, `request="d"` — making nesting depth unbounded, exactly like filesystem routing under mod_php/FPM. Malformed tails (empty segment from a leading/trailing/doubled slash, detected with one wrapped `'//'` containment check) never fold, so strict validation keeps 400ing them exactly as before.

## Security posture — unchanged, now adversarially pinned
The fold runs **before** the same two gates that always protected single-level dispatch:
- the charset regexes admit **no dots** in either component, and they run on the *decoded* path — `../` and `%2e%2e` can never reach file resolution;
- the `realpath()` containment jail still gates every on-disk lookup (also defeats symlink escapes).

## Tests
`tests/Integration/ZealApiNestedRoutingTest.php` — 9 cases: 1/2/3-level dispatch (fixtures under `api/nested/`), deep-missing → 404 via the realpath gate, `../` traversal, encoded `%2e%2e` traversal, `.php`-suffixed probe, doubled-slash and trailing-slash rejection.

Full integration (311) + unit (4,046) suites green; PHPStan level 10 clean. Verified live: `/api/nested/deep/probe` → `{"ok":true,"levels":2}`, `/api/nested/deep/very/probe2` → `{"ok":true,"levels":3}`, `%2e%2e` probe → 400.