### PR TITLE
fix(#490,#489,#491): satisfiable Tiered advisory + document the error_log override and onWorkerStart signature

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,6 +132,23 @@ systemd unit (`Environment="..."`), Docker `-e` flags, or shell.
 | `ZEALPHP_LOG_ASYNC` | bool | `1` | Use coroutine channels for log writes |
 | `ZEALPHP_BENCH_MODE` | bool | `0` | Disables all logging for benchmarks |
 
+#### Container-friendly logging (stdout / stderr)
+
+By default every stream is a **file** under `ZEALPHP_LOG_DIR` (`/tmp/zealphp`). In a container that is the wrong destination: nothing tails `/tmp`, so logs vanish with the container and `docker logs` stays empty. Note this also swallows `error_log()` output, which ZealPHP redirects into `debug.log` rather than stderr — see [the `error_log()` override note](runtime-architecture.md#️-error_log-is-overridden--it-writes-to-debuglog-not-stderr).
+
+The log-file resolver accepts PHP stream wrappers, so the 12-factor setup is just three env vars:
+
+```yaml
+environment:
+  ZEALPHP_ACCESS_LOG_FILE: "php://stdout"
+  ZEALPHP_DEBUG_LOG_FILE:  "php://stderr"
+  ZEALPHP_ZLOG_FILE:       "php://stderr"
+```
+
+With that set, `/tmp/zealphp/` holds only the PID file, and `docker logs` carries boot messages, route registration, access lines, `elog()` output **and** `error_log()` output — ready for `docker logs`, `kubectl logs`, or any log shipper reading the container's streams. Verified on v0.4.13.
+
+If you would rather keep files (for `logrotate`, or to keep access logs off the error stream), leave these unset and mount `ZEALPHP_LOG_DIR` on a volume instead.
+
 ### Compression
 
 | Variable | Type | Default | Purpose |
@@ -432,7 +449,10 @@ use ZealPHP\Counter;
 
 $reqs = new Counter(0, 'http_requests_total');
 
-App::onWorkerStart(function ($workerId) use ($reqs) {
+// Hooks are called as $fn($server, $workerId) — take BOTH parameters. Writing
+// `function ($workerId)` binds the SERVER to $workerId, so the `=== 0` guard
+// below silently never matches and the ticker never starts (#491).
+App::onWorkerStart(function ($server, $workerId) use ($reqs) {
     if ($workerId !== 0) return;        // worker 0 only
     App::tick(15_000, function () use ($reqs) {
         $lines = [

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,6 +34,8 @@ This is the canonical reference for every `ZEALPHP_*` environment variable read 
 
 > `ZEALPHP_LOG_DIR` has a per-user fallback chain — when unset, the resolver tries `/tmp/zealphp`, then per-user XDG/temp dirs, then `./tmp/zealphp` and `./logs/zealphp`. See [`docs/cli.md`](cli.md) and [`docs/hot-reload.md`](hot-reload.md) for the log/PID directory behaviour.
 
+> **Every `*_LOG_FILE` variable accepts a PHP stream wrapper**, so `php://stdout` / `php://stderr` turn the file sinks into container streams — the 12-factor setup, see [Container-friendly logging](deployment.md#container-friendly-logging-stdout--stderr). This also matters because **`error_log()` is overridden** to write into the debug log rather than stderr ([note](runtime-architecture.md#️-error_log-is-overridden--it-writes-to-debuglog-not-stderr)); without the redirect above, `error_log()` output never reaches `docker logs`.
+
 | Variable | Default | Scope | Description |
 |----------|---------|-------|-------------|
 | `ZEALPHP_LOG_DIR` | unset → first writable candidate (`/tmp/zealphp`, then per-user XDG/temp, then `./tmp/zealphp`, `./logs/zealphp`) | user | Explicit override for the directory ZealPHP writes logs and per-port PID files into (read in `zealphp_log_dir_candidates()` in `src/utils.php` and the PID-dir/logs resolution in `App.php`). |

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -235,6 +235,25 @@ When superglobals are disabled, `CoSessionManager` applies the same behaviour wh
 - `jTraceEx($exception)` builds Java-style stack traces for easier debugging.
 - When `App::$display_errors` is false, clients receive generic `500 Internal Server Error` responses even if the server logs the detailed exception.
 
+### ⚠️ `error_log()` is overridden — it writes to `debug.log`, not stderr
+
+ZealPHP replaces the `error_log` builtin at boot (`App::overrideBuiltin('error_log', …)`), so it does **not** follow PHP's `error_log` ini directive (which under the CLI SAPI means stderr). Every `error_log($msg)` call lands in the debug log — `/tmp/zealphp/debug.log` by default — tagged `[error_log]`.
+
+This matters most in containers, where nothing tails `/tmp`: the output is effectively lost, and because the failure mode is **silence**, it reads as *"my code path never ran"* rather than *"my log went somewhere else"*.
+
+| call | container stdout/stderr (`docker logs`) | `debug.log` |
+|---|---|---|
+| `error_log($m)` | ✗ | ✓ (tagged `[error_log]`) |
+| `ZealPHP\elog($m)` | ✗ | ✓ |
+| `fwrite(STDERR, $m)` | ✓ | ✗ |
+| `fwrite(STDOUT, $m)` | ✓ | ✗ |
+
+**Rules of thumb**
+
+- Want it on the container's stream regardless of configuration? Use `fwrite(STDERR, …)` — the worker's stderr is *not* detached, it is the same pipe as PID 1's.
+- Want it in the framework's structured log? Use `elog()` — that is the intended API, and it carries levels.
+- Want `error_log()` (and everything else) on stdout/stderr? Point the log files at PHP stream wrappers — see [Container-friendly logging](deployment.md#container-friendly-logging-stdout--stderr).
+
 ## Choosing Between Execution Modes
 
 ### One-call presets — `App::mode()`

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -323,3 +323,31 @@ App::onWorkerStart(function($server, $workerId) {
 When the server stops (SIGTERM, `php app.php stop`, or `Ctrl+C`), ZealPHP's `shutdown` handler sends a WebSocket CLOSE frame with code **1001 Going Away** to every connected client before the process exits. Browser-side `ws.onclose` handlers receive `event.code === 1001`, which is the standard signal to back off and reconnect rather than treat the disconnect as an error.
 
 `App::onWorkerStart()` is also where you'd warm up shared state, start producer coroutines, or pre-populate `Store` tables — anything that should run once per worker before the first connection arrives.
+
+### `App::onWorkerStart()` callback signature
+
+The hook is always invoked with **two** arguments, in this order:
+
+```php
+App::onWorkerStart(function ($server, int $workerId) { /* … */ });
+//                            ^^^^^^^  ^^^^^^^^^^
+//                            OpenSwoole server   0-based worker id
+```
+
+Take both parameters even if you only need the id. PHP silently drops extra arguments passed to a userland closure, so a one-parameter `function ($workerId)` binds the **server object** to `$workerId` — no warning, no exception. That breaks the most common use of the hook, running something exactly once per server rather than once per worker:
+
+```php
+App::onWorkerStart(function ($workerId) {      // ✗ WRONG — $workerId is the Server
+    if ($workerId === 0) {                     //   never true
+        startSingletonTicker();                //   silently never runs
+    }
+});
+
+App::onWorkerStart(function ($server, $workerId) {   // ✓ correct
+    if ($workerId === 0) {
+        startSingletonTicker();
+    }
+});
+```
+
+Task workers fire this hook too, with ids continuing past the HTTP worker range — so `$workerId === 0` selects exactly one process in the whole server.

--- a/examples/agents/zealphp_reference.txt
+++ b/examples/agents/zealphp_reference.txt
@@ -2031,6 +2031,34 @@ When the server stops (SIGTERM, `php app.php stop`, or `Ctrl+C`), ZealPHP's `shu
 
 `App::onWorkerStart()` is also where you'd warm up shared state, start producer coroutines, or pre-populate `Store` tables — anything that should run once per worker before the first connection arrives.
 
+### `App::onWorkerStart()` callback signature
+
+The hook is always invoked with **two** arguments, in this order:
+
+```php
+App::onWorkerStart(function ($server, int $workerId) { /* … */ });
+//                            ^^^^^^^  ^^^^^^^^^^
+//                            OpenSwoole server   0-based worker id
+```
+
+Take both parameters even if you only need the id. PHP silently drops extra arguments passed to a userland closure, so a one-parameter `function ($workerId)` binds the **server object** to `$workerId` — no warning, no exception. That breaks the most common use of the hook, running something exactly once per server rather than once per worker:
+
+```php
+App::onWorkerStart(function ($workerId) {      // ✗ WRONG — $workerId is the Server
+    if ($workerId === 0) {                     //   never true
+        startSingletonTicker();                //   silently never runs
+    }
+});
+
+App::onWorkerStart(function ($server, $workerId) {   // ✓ correct
+    if ($workerId === 0) {
+        startSingletonTicker();
+    }
+});
+```
+
+Task workers fire this hook too, with ids continuing past the HTTP worker range — so `$workerId === 0` selects exactly one process in the whole server.
+
 ## Middleware and Authentication
 
 Middleware is the preferred way to enforce cross-cutting policies in ZealPHP. The framework embraces PSR-15 (`Psr\Http\Server\MiddlewareInterface`) and runs every request through a configurable stack before handing it to the routing engine. This guide shows how to register middleware, build authentication flows, and combine them with the file-based routing model.
@@ -3657,6 +3685,25 @@ When superglobals are disabled, `CoSessionManager` applies the same behaviour wh
 - `jTraceEx($exception)` builds Java-style stack traces for easier debugging.
 - When `App::$display_errors` is false, clients receive generic `500 Internal Server Error` responses even if the server logs the detailed exception.
 
+### ⚠️ `error_log()` is overridden — it writes to `debug.log`, not stderr
+
+ZealPHP replaces the `error_log` builtin at boot (`App::overrideBuiltin('error_log', …)`), so it does **not** follow PHP's `error_log` ini directive (which under the CLI SAPI means stderr). Every `error_log($msg)` call lands in the debug log — `/tmp/zealphp/debug.log` by default — tagged `[error_log]`.
+
+This matters most in containers, where nothing tails `/tmp`: the output is effectively lost, and because the failure mode is **silence**, it reads as *"my code path never ran"* rather than *"my log went somewhere else"*.
+
+| call | container stdout/stderr (`docker logs`) | `debug.log` |
+|---|---|---|
+| `error_log($m)` | ✗ | ✓ (tagged `[error_log]`) |
+| `ZealPHP\elog($m)` | ✗ | ✓ |
+| `fwrite(STDERR, $m)` | ✓ | ✗ |
+| `fwrite(STDOUT, $m)` | ✓ | ✗ |
+
+**Rules of thumb**
+
+- Want it on the container's stream regardless of configuration? Use `fwrite(STDERR, …)` — the worker's stderr is *not* detached, it is the same pipe as PID 1's.
+- Want it in the framework's structured log? Use `elog()` — that is the intended API, and it carries levels.
+- Want `error_log()` (and everything else) on stdout/stderr? Point the log files at PHP stream wrappers — see [Container-friendly logging](deployment.md#container-friendly-logging-stdout--stderr).
+
 ## Runtime Architecture — Choosing Between Execution Modes
 
 ### One-call presets — `App::mode()`
@@ -4370,6 +4417,8 @@ This is the canonical reference for every `ZEALPHP_*` environment variable read 
 
 > `ZEALPHP_LOG_DIR` has a per-user fallback chain — when unset, the resolver tries `/tmp/zealphp`, then per-user XDG/temp dirs, then `./tmp/zealphp` and `./logs/zealphp`. See [`docs/cli.md`](cli.md) and [`docs/hot-reload.md`](hot-reload.md) for the log/PID directory behaviour.
 
+> **Every `*_LOG_FILE` variable accepts a PHP stream wrapper**, so `php://stdout` / `php://stderr` turn the file sinks into container streams — the 12-factor setup, see [Container-friendly logging](deployment.md#container-friendly-logging-stdout--stderr). This also matters because **`error_log()` is overridden** to write into the debug log rather than stderr ([note](runtime-architecture.md#️-error_log-is-overridden--it-writes-to-debuglog-not-stderr)); without the redirect above, `error_log()` output never reaches `docker logs`.
+
 | Variable | Default | Scope | Description |
 |----------|---------|-------|-------------|
 | `ZEALPHP_LOG_DIR` | unset → first writable candidate (`/tmp/zealphp`, then per-user XDG/temp, then `./tmp/zealphp`, `./logs/zealphp`) | user | Explicit override for the directory ZealPHP writes logs and per-port PID files into (read in `zealphp_log_dir_candidates()` in `src/utils.php` and the PID-dir/logs resolution in `App.php`). |
@@ -4402,6 +4451,7 @@ This is the canonical reference for every `ZEALPHP_*` environment variable read 
 | `ZEALPHP_HTTP_COMPRESSION` | `!$compressionMiddleware` (true when `CompressionMiddleware` is NOT registered, false when it is) | user | In `app.php`, sets the OpenSwoole `http_compression` server setting (`env_flag`) — toggles OpenSwoole's built-in gzip/deflate response compression. |
 | `ZEALPHP_OPCACHE_ADVISORY` | unset (advisory enabled; only literal `'0'` suppresses) | user | Read in `App::opcacheLegacyBootCheck()` via `getenv()==='0'`; when `'0'`, suppresses the boot-time advisory about opcache + coroutine-legacy re-declaring `require_once`'d classes. |
 | `ZEALPHP_FN_STATICS_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineStaticsIsolation()` — when `'1'`, disables per-coroutine isolation of function-local `static $x` (S5a) for raw throughput. |
+| `ZEALPHP_SHARED_STATICS` | unset (off; only literal `'1'` enables) | user | Read by `App::sharedStatics()` when no explicit setter call was made. When `'1'` in coroutine-legacy, the WHOLE statics machinery is off (S5a isolation, S5b class-static parking, begin/end per-request static resets) — statics become worker-global like vanilla long-running PHP, while superglobals/$GLOBALS/constants/session/ini stay per-request isolated. Contract: statics must be request-agnostic (memoisation/config only). See the `App::$shared_statics` docblock. |
 | `ZEALPHP_CWD_ISOLATION_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineCwdIsolation()` — when `'1'`, disables per-coroutine working-directory isolation (S9a, #323), so a request's `chdir()` leaks process-wide again. |
 | `ZEALPHP_LOCALE_ISOLATION_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineLocaleIsolation()` — when `'1'`, disables per-coroutine `setlocale()` isolation (S9b). |
 | `ZEALPHP_UMASK_ISOLATION_DISABLE` | unset (isolation stays ENABLED in coroutine-legacy; only literal `'1'` disables) | user | Read in `App::mode()` via `(string)getenv()!=='1'` to set `coroutineUmaskIsolation()` — when `'1'`, disables per-coroutine `umask()` isolation (S9c). |
@@ -4734,6 +4784,23 @@ systemd unit (`Environment="..."`), Docker `-e` flags, or shell.
 | `ZEALPHP_LOG_ASYNC` | bool | `1` | Use coroutine channels for log writes |
 | `ZEALPHP_BENCH_MODE` | bool | `0` | Disables all logging for benchmarks |
 
+#### Container-friendly logging (stdout / stderr)
+
+By default every stream is a **file** under `ZEALPHP_LOG_DIR` (`/tmp/zealphp`). In a container that is the wrong destination: nothing tails `/tmp`, so logs vanish with the container and `docker logs` stays empty. Note this also swallows `error_log()` output, which ZealPHP redirects into `debug.log` rather than stderr — see [the `error_log()` override note](runtime-architecture.md#️-error_log-is-overridden--it-writes-to-debuglog-not-stderr).
+
+The log-file resolver accepts PHP stream wrappers, so the 12-factor setup is just three env vars:
+
+```yaml
+environment:
+  ZEALPHP_ACCESS_LOG_FILE: "php://stdout"
+  ZEALPHP_DEBUG_LOG_FILE:  "php://stderr"
+  ZEALPHP_ZLOG_FILE:       "php://stderr"
+```
+
+With that set, `/tmp/zealphp/` holds only the PID file, and `docker logs` carries boot messages, route registration, access lines, `elog()` output **and** `error_log()` output — ready for `docker logs`, `kubectl logs`, or any log shipper reading the container's streams. Verified on v0.4.13.
+
+If you would rather keep files (for `logrotate`, or to keep access logs off the error stream), leave these unset and mount `ZEALPHP_LOG_DIR` on a volume instead.
+
 ### Compression
 
 | Variable | Type | Default | Purpose |
@@ -4821,7 +4888,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.12 .
+docker build -t zealphp:0.4.13 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -4833,7 +4900,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.12 .
+    -t zealphp:0.4.13 .
 ```
 
 ### Run (single container)
@@ -4845,7 +4912,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.12
+    zealphp:0.4.13
 ```
 
 ### Production compose
@@ -4856,7 +4923,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.12
+    image: registry.example.com/zealphp-app:0.4.13
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"
@@ -5034,7 +5101,10 @@ use ZealPHP\Counter;
 
 $reqs = new Counter(0, 'http_requests_total');
 
-App::onWorkerStart(function ($workerId) use ($reqs) {
+// Hooks are called as $fn($server, $workerId) — take BOTH parameters. Writing
+// `function ($workerId)` binds the SERVER to $workerId, so the `=== 0` guard
+// below silently never matches and the ticker never starts (#491).
+App::onWorkerStart(function ($server, $workerId) use ($reqs) {
     if ($workerId !== 0) return;        // worker 0 only
     App::tick(15_000, function () use ($reqs) {
         $lines = [

--- a/src/Store.php
+++ b/src/Store.php
@@ -78,6 +78,14 @@ class Store
     private static array $backendConfig = ['kind' => 'table'];
 
     /**
+     * #490 — whether the deferred Tiered-advisory worker-start hook is already
+     * registered. Scheduling must be idempotent: `defaultBackend()` can be
+     * called more than once (re-configuration, test setup) and each call would
+     * otherwise append another hook and duplicate the boot warning.
+     */
+    private static bool $tieredAdvisoryScheduled = false;
+
+    /**
      * Get or set the process-wide default backend.
      *
      * Prefers `StoreBackendKind` (type-safe enum) but accepts the bare
@@ -201,24 +209,90 @@ class Store
 
         $backend = new TieredBackend(new TableBackend(), $l2, l1Ttl: $l1Ttl, invalidationSecret: $secret);
 
-        // Surface the silent cross-node coherence gap at build time. The
-        // default Tiered backend ships with invalidation OFF (it needs a
-        // coroutine + a secret decision the framework can't make for the
-        // operator), so a key updated on node A serves stale from node B's L1
-        // for up to $l1Ttl. We do NOT auto-enable it (that changes Redis
-        // subscription behaviour) — we make the gap LOUD instead. The
-        // testable decision lives in tieredAdvisory(); emit it via elog so it
-        // reaches the same boot-log channel as the other Store advisories.
-        $advisory = self::tieredAdvisory($backend);
-        if ($advisory !== null) {
-            if (function_exists('ZealPHP\\elog')) {
-                \ZealPHP\elog($advisory, 'warn');
-            } else {
-                error_log($advisory);
-            }
-        }
+        // Surface the silent cross-node coherence gap. The default Tiered
+        // backend ships with invalidation OFF (it needs a coroutine + a secret
+        // decision the framework can't make for the operator), so a key updated
+        // on node A serves stale from node B's L1 for up to $l1Ttl. We do NOT
+        // auto-enable it (that changes Redis subscription behaviour) — we make
+        // the gap LOUD instead. The testable decision lives in
+        // tieredAdvisory(); scheduling decides WHEN it is evaluated (#490).
+        self::scheduleTieredAdvisory();
 
         return $backend;
+    }
+
+    /**
+     * Schedule the Tiered advisory for evaluation at a moment when the operator
+     * could actually have satisfied it (#490).
+     *
+     * The advisory asks for `enableInvalidation()`, which MUST run inside a
+     * coroutine — i.e. from an `App::onWorkerStart()` hook. That is necessarily
+     * LATER than this build moment: `Store::defaultBackend()` is called at
+     * `app.php` file scope, before `App::init()`/`run()`, when no scheduler
+     * exists. Evaluating the decision here therefore made it STRUCTURALLY
+     * UNSATISFIABLE — an app doing exactly what the message asks still logged
+     * "invalidation is OFF" on every boot, forever. Worse, because that branch
+     * always won at build time, the SECOND advisory (invalidation ON but
+     * UNAUTHENTICATED — a real evict-forgery/DoS signal) was unreachable.
+     *
+     * So defer it: register a worker-start hook that arms a 1 ms timer. The
+     * timer fires once the worker-start callback returns to the event loop —
+     * i.e. after EVERY worker-start hook has run — so the decision observes the
+     * final state regardless of whether the operator registered their
+     * `enableInvalidation()` hook before or after this backend was built (hooks
+     * run in registration order, and this backend is usually built first).
+     * Gated to worker 0 so a 32-worker server logs the advisory once, not 32
+     * times; task workers (higher ids) are skipped by the same gate.
+     *
+     * The hook fires against the CURRENT process-wide default backend, not the
+     * instance built here, so a backend swapped after this call is advised
+     * accurately. Scheduling is idempotent — repeated `defaultBackend()` calls
+     * (tests, re-configuration) must not pile up hooks or duplicate warnings.
+     *
+     * If no server ever runs (plain CLI script, unit test) the hook simply
+     * never fires and nothing is logged; `Store::tieredBootChecks()` remains
+     * the synchronous seam for callers that want the decision on demand.
+     */
+    private static function scheduleTieredAdvisory(): void
+    {
+        if (self::$tieredAdvisoryScheduled) {
+            return;
+        }
+        self::$tieredAdvisoryScheduled = true;
+
+        App::onWorkerStart(static function ($server, int $workerId): void {
+            if ($workerId !== 0) {
+                return;   // one advisory per server, not one per worker
+            }
+            // 1 ms (not 0 — OpenSwoole\Timer requires >= 1) lands on the next
+            // loop iteration, i.e. after the whole hook chain has completed.
+            App::after(1, static function (): void {
+                self::emitTieredAdvisory();
+            });
+        });
+    }
+
+    /**
+     * Emit the Tiered advisory (if any) for the CURRENT default backend, on the
+     * boot-log channel the other Store/App advisories use. Split from the
+     * decision (`tieredAdvisory()`, pure) and the timing
+     * (`scheduleTieredAdvisory()`) so each is testable on its own.
+     */
+    private static function emitTieredAdvisory(): void
+    {
+        $backend = self::$backend;
+        if (!$backend instanceof TieredBackend) {
+            return;   // swapped to a non-Tiered backend before the timer fired
+        }
+        $advisory = self::tieredAdvisory($backend);
+        if ($advisory === null) {
+            return;
+        }
+        if (function_exists('ZealPHP\\elog')) {
+            \ZealPHP\elog($advisory, 'warn');
+        } else {
+            error_log($advisory);
+        }
     }
 
     /**
@@ -229,12 +303,13 @@ class Store
      * cross-node L1 coherence is OFF, how to turn it on, and the
      * enable-relative-to-make boot-order requirement. When invalidation IS
      * enabled but no HMAC secret is set, the message instead warns that any
-     * Redis writer can forge an evict (the C2 trust-mode gap). Returns null
-     * when invalidation is enabled with a secret — nothing to warn about.
+     * Redis writer can forge an evict (the C2 trust-mode gap) — a branch that
+     * was unreachable from the boot path until #490 moved the evaluation past
+     * worker start. Returns null when invalidation is enabled with a secret.
      *
      * Pure (no side effects) so a unit test can assert the decision; the
-     * build path emits it via `elog`. Mirrors the shape of
-     * `App::redisBootChecks()` / `App::opcacheLegacyBootCheck()`.
+     * boot path emits it via `elog` (see `scheduleTieredAdvisory()`). Mirrors
+     * the shape of `App::redisBootChecks()` / `App::opcacheLegacyBootCheck()`.
      */
     public static function tieredAdvisory(StoreBackend $backend): ?string
     {
@@ -244,8 +319,9 @@ class Store
         if (!$backend->isInvalidationEnabled()) {
             return 'Store(Tiered): cross-node L1 invalidation is OFF — a key updated on one node serves '
                 . 'STALE from another node\'s L1 cache for up to l1_ttl (' . $backend->l1Ttl() . 's). '
-                . 'Call $backend->enableInvalidation() inside a coroutine at boot to evict peer L1 entries '
-                . 'sub-millisecond, and set an invalidation_secret (or ZEALPHP_TIERED_INVALIDATION_SECRET) '
+                . 'Call $backend->enableInvalidation() from an App::onWorkerStart() hook to evict peer L1 '
+                . 'entries sub-millisecond — it spawns a subscriber coroutine, so it CANNOT be called at '
+                . 'app.php file scope (no scheduler yet) — and set an invalidation_secret (or ZEALPHP_TIERED_INVALIDATION_SECRET) '
                 . 'so peers can authenticate evicts. BOOT-ORDER: call enableInvalidation() during boot for '
                 . 'every table you make() (tables made() before OR after enable() auto-subscribe; do not '
                 . 'interleave make()/stop()/enable() at runtime).';

--- a/tests/Unit/Store/TieredAdvisoryDeferralTest.php
+++ b/tests/Unit/Store/TieredAdvisoryDeferralTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZealPHP\Tests\Unit\Store;
+
+use OpenSwoole\Coroutine;
+use PHPUnit\Framework\TestCase;
+use ZealPHP\App;
+use ZealPHP\Store;
+use ZealPHP\Store\RedisBackend;
+use ZealPHP\Store\RedisConnectionPool;
+use ZealPHP\Store\TableBackend;
+use ZealPHP\Store\TieredBackend;
+
+/**
+ * #490 — the Tiered advisory must be evaluated at a moment the operator could
+ * actually have satisfied.
+ *
+ * It used to be emitted from `defaultBackend()` at BUILD time, but the thing it
+ * asks for (`enableInvalidation()`) needs a coroutine and is therefore only
+ * legal from an `App::onWorkerStart()` hook — necessarily later. The warning
+ * was thus unsatisfiable (it fired forever even for correct apps), and because
+ * its branch always won, the second advisory (invalidation ON but
+ * UNAUTHENTICATED — an evict-forgery/DoS signal) was unreachable from the boot
+ * path.
+ *
+ * These tests pin the TIMING contract (the decision itself is covered by
+ * TieredAdvisoryTest).
+ */
+final class TieredAdvisoryDeferralTest extends TestCase
+{
+    /** @var list<callable> */
+    private array $prevHooks = [];
+    private mixed $prevBackend = null;
+    private bool $prevScheduled = false;
+
+    protected function setUp(): void
+    {
+        // Snapshot every piece of process-wide state these tests touch.
+        $this->prevHooks     = self::hooks();
+        $this->prevBackend   = self::storeProp('backend')->getValue();
+        $this->prevScheduled = (bool) self::storeProp('tieredAdvisoryScheduled')->getValue();
+    }
+
+    protected function tearDown(): void
+    {
+        self::appHooksProp()->setValue(null, $this->prevHooks);
+        self::storeProp('backend')->setValue(null, $this->prevBackend);
+        self::storeProp('tieredAdvisoryScheduled')->setValue(null, $this->prevScheduled);
+    }
+
+    // ── the fix: defer, don't emit at build time ────────────────────────
+
+    public function testBuildingTieredRegistersAWorkerStartHookInsteadOfEmittingNow(): void
+    {
+        self::resetScheduled();
+        $before = count(self::hooks());
+
+        $this->buildTieredDefault();
+
+        $this->assertCount(
+            $before + 1,
+            self::hooks(),
+            '#490: the advisory must be deferred to a worker-start hook, not decided at build time'
+        );
+    }
+
+    public function testSchedulingIsIdempotentAcrossRepeatedBuilds(): void
+    {
+        self::resetScheduled();
+        $before = count(self::hooks());
+
+        $this->buildTieredDefault();
+        $this->buildTieredDefault();
+        $this->buildTieredDefault();
+
+        $this->assertCount(
+            $before + 1,
+            self::hooks(),
+            'repeated defaultBackend() calls must not pile up hooks / duplicate the warning'
+        );
+    }
+
+    // ── the hook itself ────────────────────────────────────────────────
+
+    public function testHookIsNoOpOnNonZeroWorkerIds(): void
+    {
+        $hook = $this->freshlyRegisteredHook();
+
+        // Workers 1..N and task workers (higher ids) must stay silent so a
+        // 32-worker server logs the advisory once, not 32 times. No timer is
+        // armed on these ids, so this is safe to call outside an event loop.
+        $hook(null, 1);
+        $hook(null, 7);
+        $hook(null, 31);
+
+        $this->addToAssertionCount(1);   // reaching here = no timer, no throw
+    }
+
+    public function testWorkerZeroDefersToATimerThatActuallyFires(): void
+    {
+        $hook = $this->freshlyRegisteredHook();
+
+        // Neutral default backend so the timer's emit is a no-op — this test is
+        // about the DEFERRAL firing, not about logging (elog's async sink would
+        // otherwise leave a channel consumer coroutine parked past the test).
+        self::storeProp('backend')->setValue(null, new TableBackend());
+
+        Coroutine::run(static function () use ($hook): void {
+            $hook(null, 0);
+            Coroutine::usleep(20000);   // 20 ms: let the 1 ms timer fire AND complete
+        });
+
+        $this->addToAssertionCount(1);   // deferred callback ran, loop drained
+    }
+
+    // ── emit reads the CURRENT default backend ─────────────────────────
+
+    public function testEmitIsNoOpWhenDefaultBackendIsNotTiered(): void
+    {
+        self::storeProp('backend')->setValue(null, new TableBackend());
+
+        self::invokeEmit();
+
+        $this->addToAssertionCount(1);   // no advisory, no throw
+    }
+
+    /**
+     * The #490 unmasking: once the decision happens AFTER worker start,
+     * `enableInvalidation()` has had its chance to run — so a backend that is
+     * enabled-but-unauthenticated now reaches the security advisory instead of
+     * being masked by the permanently-winning "invalidation is OFF" branch.
+     */
+    public function testEnabledWithoutSecretReachesTheSecurityAdvisory(): void
+    {
+        Coroutine::run(function (): void {
+            $backend = $this->tiered();   // no secret
+            $backend->enableInvalidation();
+
+            self::storeProp('backend')->setValue(null, $backend);
+
+            // This is the state the boot path now observes at emit time (it
+            // reads the CURRENT default backend), and it selects the security
+            // branch — which the old build-time evaluation could never reach.
+            // The emit itself is exercised by the timer test above; calling it
+            // here would park elog's async-log consumer past the test.
+            $advisory = Store::tieredAdvisory($backend);
+            $this->assertIsString($advisory);
+            $this->assertStringContainsString(
+                'UNAUTHENTICATED',
+                $advisory,
+                '#490: the security branch must be reachable once the decision is deferred'
+            );
+
+            $backend->stopInvalidation();
+        });
+    }
+
+    // ── guidance text ──────────────────────────────────────────────────
+
+    public function testAdvisoryNamesTheOnlyLegalPlacement(): void
+    {
+        $advisory = Store::tieredAdvisory($this->tiered());
+        $this->assertIsString($advisory);
+        // Telling the operator "at boot" is what made the old message a trap:
+        // app.php file scope IS boot, and it cannot work there.
+        $this->assertStringContainsString('App::onWorkerStart()', $advisory);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private function tiered(?string $secret = null): TieredBackend
+    {
+        // Pool is lazy — never dials unless an op runs.
+        $l2 = new RedisBackend(new RedisConnectionPool('redis://127.0.0.1:6379', 1), 'zptest');
+        return new TieredBackend(new TableBackend(), $l2, l1Ttl: 5, invalidationSecret: $secret);
+    }
+
+    /** Build a Tiered default backend through the real facade path. */
+    private function buildTieredDefault(): void
+    {
+        Store::defaultBackend(Store::BACKEND_TIERED, [
+            'url'    => 'redis://127.0.0.1:6379',
+            'prefix' => 'zptest',
+            'l1_ttl' => 5,
+        ]);
+    }
+
+    /** @return callable the hook the tiered build path just registered */
+    private function freshlyRegisteredHook(): callable
+    {
+        self::resetScheduled();
+        $this->buildTieredDefault();
+        $hooks = self::hooks();
+        $hook = end($hooks);
+        $this->assertIsCallable($hook);
+        return $hook;
+    }
+
+    private static function resetScheduled(): void
+    {
+        self::storeProp('tieredAdvisoryScheduled')->setValue(null, false);
+    }
+
+    private static function invokeEmit(): void
+    {
+        $m = new \ReflectionMethod(Store::class, 'emitTieredAdvisory');
+        $m->setAccessible(true);
+        $m->invoke(null);
+    }
+
+    private static function storeProp(string $name): \ReflectionProperty
+    {
+        $p = new \ReflectionProperty(Store::class, $name);
+        $p->setAccessible(true);
+        return $p;
+    }
+
+    private static function appHooksProp(): \ReflectionProperty
+    {
+        $p = new \ReflectionProperty(App::class, 'workerStartHooks');
+        $p->setAccessible(true);
+        return $p;
+    }
+
+    /** @return list<callable> */
+    private static function hooks(): array
+    {
+        /** @var list<callable> $hooks */
+        $hooks = self::appHooksProp()->getValue();
+        return $hooks;
+    }
+}


### PR DESCRIPTION
Three observability/DX traps found while debugging a containerised deployment. Independent, small, shared theme: **the framework was silently withholding information the operator needed.**

---

### #490 — the Tiered advisory was structurally unsatisfiable *(code)*

The advisory was decided in `Store::defaultBackend()` at **build time**, but what it asks for — `enableInvalidation()` — spawns a subscriber coroutine and is only legal from an `App::onWorkerStart()` hook, i.e. necessarily *later*. So an app doing exactly what the message asked still logged `cross-node L1 invalidation is OFF` on every boot, forever.

The more serious half: because that branch always won at build time, the **second advisory was unreachable** — *invalidation ON but UNAUTHENTICATED*, i.e. any client with Redis write access can forge an L1-evict and DoS the cluster's caches. A real security signal, dead behind an unsatisfiable branch.

**Fix:** `scheduleTieredAdvisory()` registers a worker-start hook that arms a 1 ms timer, so the decision runs *after the whole hook chain* — it sees the final state no matter what order the operator registered their hook in. Worker-0 gated (one advisory per server, not per worker). Evaluated against the *current* default backend, and idempotent so repeated `defaultBackend()` calls can't pile up hooks. The message now names `App::onWorkerStart()` instead of saying "at boot" — `app.php` file scope *is* boot, and it cannot work there, which is exactly what made the old text a trap. `tieredAdvisory()` stays pure; only the timing moved.

### #489 — `error_log()` is redirected to `debug.log`, documented nowhere *(docs)*

It's overridden at boot, so it ignores PHP's `error_log` ini (stderr under CLI). `grep -c error_log llms.txt` → **0**. In a container nothing tails `/tmp`, so the output is simply lost — and the failure mode is *silence*, so it reads as "this code path never ran" rather than "my log went elsewhere".

Documented in `runtime-architecture.md` with the four-way probe table (`error_log`/`elog` vs `fwrite` STDERR/STDOUT), plus a **Container-friendly logging** recipe in `deployment.md`: every `*_LOG_FILE` accepts a stream wrapper, so `php://stdout` + `php://stderr` put boot, access, `elog()` **and** `error_log()` output on the container's streams. Verified against `log_write()`'s `'://'` handling in `src/utils.php`.

### #491 — `onWorkerStart()` documented with two signatures *(docs)*

Hook is invoked `$hook($server, $workerId)`, but `deployment.md` showed a one-arg `function ($workerId)`. PHP silently drops extra args to a userland closure, so `$workerId` bound the **Server object** and the `!== 0` guard never matched — the metrics ticker *in that very example* silently never started. Fixed the example and added an explicit callback-signature section to `websocket.md` showing wrong vs right and why it fails silently. `llms.txt` regenerated.

---

### Validation
- `tests/Unit/Store/TieredAdvisoryDeferralTest.php` — **7 cases** pinning the timing contract: hook registered instead of build-time emit, idempotent scheduling, worker-0 gate, the deferred timer *actually firing*, emit reading the current backend, and the security branch reachable once deferred
- PHPStan **level 10 clean**; unit **4,060** green; integration **311** green

> Note: one integration run showed a transient failure in `LearnApiTest::test_chat_consecutive_requests_work` (chat SSE, "request 3" empty). It does **not** reproduce — passes in isolation and on a re-run of the full suite with identical numbers to master, and master is unaffected by these changes. Flaky SSE timing under load, worth watching separately.