### PR TITLE
chore: release v0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.15] - 2026-07-27
 
 ### Added
 - **`RedisSessionHandler` can authenticate to Redis/Valkey** ([#494](https://github.com/sibidharan/zealphp/issues/494)) — the handler accepted only `(host, port, prefix, ttl)`, so it could talk to an **unauthenticated** server only, and because every member was `private` it could not be subclassed to add `AUTH` either. Any deployment using it was forced to run its session store with no `requirepass`: enabling one made every session read/write fail with `NOAUTH Authentication required`, logging out every user. The constructor now takes an optional trailing `$auth` — a password string, or `[user, pass]` for a Redis 6+ ACL user — which `connect()` sends via `AUTH` on each new connection. Trailing and defaulted to `null`, so existing 4-argument call sites are untouched; and the credential is sent **only when configured**, because Redis errors on an `AUTH` sent to a server without `requirepass` (an unconditional call would break every existing passwordless deployment). The decision lives in a pure, protected `authCredential()` seam that normalises `null` / `''` / `[]` / all-blank arrays to "send nothing", so it is unit-testable without ext-redis or a live server. Note `App::sessionHandler('redis')` still builds the handler with **defaults** (localhost, no password) — pass a configured instance to authenticate; documented on `App::$session_handler`.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker compose up app
 
 ```bash
 # New project
-composer create-project zealphp/project:^0.4.14 my-project
+composer create-project zealphp/project:^0.4.15 my-project
 cd my-project
 php app.php
 # → https://php.zeal.ninja
@@ -469,16 +469,16 @@ The fine-grained setters (`App::superglobals()`, `App::isolation()`, `App::enabl
 2. Run `composer validate`, `./vendor/bin/phpunit`, and `./vendor/bin/phpstan analyse --no-progress` (level 10, zero errors).
 3. Open a release PR, wait for required checks to go green, and merge (rebase):
    ```bash
-   git checkout -b release/v0.4.14
-   git commit -am "chore: release v0.4.14"
-   git push origin1 release/v0.4.14
-   gh pr create --base master --head release/v0.4.14 --title "chore: release v0.4.14"
+   git checkout -b release/v0.4.15
+   git commit -am "chore: release v0.4.15"
+   git push origin1 release/v0.4.15
+   gh pr create --base master --head release/v0.4.15 --title "chore: release v0.4.15"
    ```
 4. After merge, tag the merged commit and push to both remotes (tags aren't protected):
    ```bash
    git checkout master && git pull origin1 master --ff-only
-   git tag -a v0.4.14 -m "Release v0.4.14"
-   git push origin v0.4.14 && git push origin1 v0.4.14
+   git tag -a v0.4.15 -m "Release v0.4.15"
+   git push origin v0.4.15 && git push origin1 v0.4.15
    ```
 5. Bump `zealphp/project` (the scaffold) to the same version and refresh its `llms.txt`. Packagist auto-syncs via webhook for both packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -236,7 +236,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.14 .
+docker build -t zealphp:0.4.15 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -248,7 +248,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.14 .
+    -t zealphp:0.4.15 .
 ```
 
 ### Run (single container)
@@ -260,7 +260,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.14
+    zealphp:0.4.15
 ```
 
 ### Production compose
@@ -271,7 +271,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.14
+    image: registry.example.com/zealphp-app:0.4.15
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/examples/agents/zealphp_reference.txt
+++ b/examples/agents/zealphp_reference.txt
@@ -4888,7 +4888,7 @@ needed.
 ### Build
 
 ```bash
-docker build -t zealphp:0.4.14 .
+docker build -t zealphp:0.4.15 .
 ```
 
 The shipped `Dockerfile` is PHP 8.4-cli on `bookworm` with OpenSwoole and
@@ -4900,7 +4900,7 @@ versions with the build args:
 docker build \
     --build-arg OPENSWOOLE_VERSION=22.1.2 \
     --build-arg ZEALPHP_EXT_VERSION=v0.3.33 \
-    -t zealphp:0.4.14 .
+    -t zealphp:0.4.15 .
 ```
 
 ### Run (single container)
@@ -4912,7 +4912,7 @@ docker run -d \
     -e ZEALPHP_TASK_WORKERS=0 \
     --restart unless-stopped \
     --name zealphp \
-    zealphp:0.4.14
+    zealphp:0.4.15
 ```
 
 ### Production compose
@@ -4923,7 +4923,7 @@ production, bake your app into the image and avoid volume mounts:
 ```yaml
 services:
   app:
-    image: registry.example.com/zealphp-app:0.4.14
+    image: registry.example.com/zealphp-app:0.4.15
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/deployment.php
+++ b/template/pages/deployment.php
@@ -140,7 +140,7 @@ App::render('/components/_code', [
     'code'  => <<<'YAML'
 services:
   app:
-    image: zealphp:0.4.14
+    image: zealphp:0.4.15
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/template/pages/getting-started.php
+++ b/template/pages/getting-started.php
@@ -178,7 +178,7 @@ BASH
           'lang' => 'bash',
           'code' => <<<'BASH'
 composer create-project \
-  zealphp/project:^0.4.14 \
+  zealphp/project:^0.4.15 \
   my-app
 cd my-app && php app.php
 BASH

--- a/template/pages/home.php
+++ b/template/pages/home.php
@@ -18,7 +18,7 @@ $siteUrl = site_url();
        WebSocket, SSE, streaming, state isolated coroutines, shared memory, task workers &mdash;
        first&#8209;class. Powered by Openswoole. Isolated by <em>ext-zealphp.</em></p>
     <p class="home-hero-sub">Bring your existing PHP code. New features go async without a separate Node or Go service.</p>
-    <p class="home-hero-stamp">Alpha &middot; v0.4.14 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
+    <p class="home-hero-stamp">Alpha &middot; v0.4.15 &middot; built on <a href="https://openswoole.com/" target="_blank" rel="noopener">OpenSwoole</a></p>
     <div class="cta">
       <a href="/getting-started" class="btn btn-primary">
         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>
@@ -306,7 +306,7 @@ Store::defaultBackend(Store::BACKEND_TIERED);</code></pre>
 
     <div class="qs-panel active" data-panel="starter">
       <div class="qs-block">
-        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project zealphp/project:^0.4.14 my-app</span><button class="qs-copy" data-copy="composer create-project zealphp/project:^0.4.14 my-app">copy</button></div>
+        <div class="qs-line"><span class="qs-num">1</span><span class="qs-cmd"><span class="qs-prompt">$</span> composer create-project zealphp/project:^0.4.15 my-app</span><button class="qs-copy" data-copy="composer create-project zealphp/project:^0.4.15 my-app">copy</button></div>
         <div class="qs-line"><span class="qs-num">2</span><span class="qs-cmd"><span class="qs-prompt">$</span> cd my-app && php app.php</span><button class="qs-copy" data-copy="cd my-app && php app.php">copy</button></div>
         <div class="qs-line"><span class="qs-arrow">→</span><span class="qs-out">Server running at <code class="qs-out-code">http://localhost:8080</code></span></div>
       </div>


### PR DESCRIPTION
Release v0.4.15 — ships the #494 session-store authentication fix.

### Added
- **`RedisSessionHandler` can authenticate** (#494) — new optional trailing `$auth`: a `requirepass` password, or `[user, pass]` for a Redis 6+ ACL user. Trailing + defaulted, so existing 4-argument call sites are untouched, and `AUTH` is sent **only when configured** (Redis errors on an `AUTH` to a passwordless server, so an unconditional call would break existing deployments). Until now any deployment using this handler was forced to run its session store with **no `requirepass`** — enabling one logged out every user with `NOAUTH Authentication required`.

### Changed
- **Connection surface `private` → `protected`** (#494) — `$host`/`$port`/`$prefix`/`$ttl`/`$auth`/`$fallback` + `connect()`/`conn()`, so TLS options, custom timeouts or a non-zero DB `select()` can be added by subclassing instead of reimplementing `SessionHandlerInterface` and duplicating the coroutine-concurrency 3-way merge. Merge internals stay private.

### Verification
Beyond unit tests, the fix was proven end-to-end against two real password-protected servers — same 6-check script, **6/6 on both**:

| | Valkey 8.1.9 | Redis 6.0.16 |
|---|---|---|
| no-password handler **rejected** by requirepass server | ✅ | ✅ |
| password handler write + read round-trip | ✅ | ✅ |
| prefix / key format preserved | ✅ | ✅ |
| `[user, pass]` against a scoped **ACL user** | ✅ | ✅ |
| `null` auth still works on a **passwordless** server | ✅ | ✅ |
| `destroy()` under auth | ✅ | ✅ |

ext-zealphp pin unchanged (**v0.3.60**) — no extension reinstall needed. Version strings bumped across README / home / getting-started / deployment; `llms.txt` regenerated. PHPStan level 10 clean, unit 4,070 green.